### PR TITLE
Bug fix to CCP4ReportParser.py

### DIFF
--- a/report/CCP4ReportParser.py
+++ b/report/CCP4ReportParser.py
@@ -2318,7 +2318,7 @@ class Table(BaseTable):
   def as_data_etree(self):
     root = super().as_data_etree()
     root.set('transpose', 'True' if self.transpose else 'False')
-    for child in self.data_as_etree().findall('//table'):
+    for child in self.data_as_etree().findall('.//table'):
       root.append(child)
     return root
 


### PR DESCRIPTION
CCP4ReportParser.py in main branch included bug at line 2321 where `findall` was called on an ET.Element with an absolute instead of a relative path.  This commit replaces `//table` with `.//table` as it should be.  This codepath is not called routinely, but this fix is needed to keep/make the code suitable for migration