### PR TITLE
Update CCP4DbApi.py : fixing missing "Dummy"entry relevant to arp-war…

### DIFF
--- a/dbapi/CCP4DbApi.py
+++ b/dbapi/CCP4DbApi.py
@@ -83,7 +83,7 @@ JOB_EVALUATION_TEXT = ['Unknown','Best','Good','Rejected']
 USER_AGENT_TEXT = ['Unknown','CCP4i2','CCP4mg','Coot']
 FILETYPES_TEXT = ['Unknown', 'application/CCP4-seq', 'chemical/x-pdb', 'MultiPDB', 'application/CCP4-mtz', 'application/CCP4-unmerged-mtz',
                   'application/CCP4-unmerged-experimental', 'application/CCP4-map', 'application/refmac-dictionary', 'application/refmac-TLS',
-                  'application/CCP4-mtz-freerflag', 'application/CCP4-mtz-observed', 'application/CCP4-mtz-phases', 'application/CCP4-mtz-map', '',
+                  'application/CCP4-mtz-freerflag', 'application/CCP4-mtz-observed', 'application/CCP4-mtz-phases', 'application/CCP4-mtz-map', 'Dummy',
                   'application/CCP4-seqalign', 'application/CCP4-mtz-mini', 'application/coot-script', 'application/refmac-external-restraints',
                   'application/CCP4-scene', 'application/CCP4-shelx-FA', 'application/phaser-sol', 'chemical/x-mdl-molfile',
                   'application/iMosflm-xml', 'application/CCP4-image', 'application/CCP4-generic-reflections', 'application/HHPred-alignments',


### PR DESCRIPTION
…p in FILETYPES_TEXT

CCP4DbApi contains multiple tables relating to file typing, which include some near redundancy.  The table FILETYPES_TEXT lists the pseudo mime types of files, although same information is in the list of tuples that is FILETYPELIST.  To make them consistent, I have added the relevant type name ("Dummy") into FILETYPES_TEXT.  Will only show up in wrappers that use the "Dummy" file type, typically auto build, and *should* only help in those cases