### PR TITLE
Increase size of output list to 250.

### DIFF
--- a/core/CCP4Data.py
+++ b/core/CCP4Data.py
@@ -2790,9 +2790,6 @@ class CList(CCollection):
             self.__dict__['_value'].append(obj)
         else:
             self.__dict__['_value'].insert(index, obj)
-        print(obj)
-        print(type(obj))
-        print(obj.dataChanged)
         obj.dataChanged.connect(self.dataChanged.emit)
         self.itemAdded.emit(index)
         self.updateData()
@@ -3133,7 +3130,7 @@ class COutputFileList(CList):
 
     PYTHONTYPE = list
     CONTENTS = {}
-    QUALIFIERS = {'default' : NotImplemented, 'listMinLength' : 0, 'listMaxLength' : 10,
+    QUALIFIERS = {'default' : NotImplemented, 'listMinLength' : 0, 'listMaxLength' : 250,
         'listCompare' : NotImplemented, 'nameRoot' : NotImplemented}
     QUALIFIERS_ORDER = ['listMinLength', 'listMaxLength', 'listCompare', 'nameRoot']
     QUALIFIERS_DEFINITION = {'default' : {'type' :list},

--- a/wrappers/coot_rebuild/script/coot_rebuild.py
+++ b/wrappers/coot_rebuild/script/coot_rebuild.py
@@ -295,8 +295,9 @@ file_to_preferences('template_key_bindings.py')
                 os.rename(outputPDB, newPath)
                 xyzoutList[iFile].annotation = "Coot output file number"+str(iFile)
                 xyzoutList[iFile].subType = 1
-            #Here truncate the xyzoutList back to the numberof files that werew actually found
+            #Here truncate the xyzoutList back to the numberof files that were actually found
             xyzoutList = xyzoutList[0:len(outList)]
+            self.container.outputData.XYZOUT.set(xyzoutList)
 
             #Ligand builder places output cifs in the coot-cif directory as prorg-out.cif
             #'prodrgify this residue' places output cifs in the coot-cif directory as prodrg-???.cif
@@ -315,8 +316,9 @@ file_to_preferences('template_key_bindings.py')
                 elif 'prodrg' in fname: annotation='Coot/Prodrg created geometry for ligand'
                 else: annotation='Coot/Prodrg created geometry for ligand'
                 dictoutList[iFile].annotation = annotation
-            #Here truncate the dictoutList back to the numberof files that werew actually found
+            #Here truncate the dictoutList back to the numberof files that were actually found
             dictoutList = dictoutList[0:len(cifOutList)]
+            self.container.outputData.DICTOUT.set(dictoutList)
 
             # Create a trivial xml output file
             from lxml import etree


### PR DESCRIPTION
Increase `COutputFileList` size to 250 to allow for far more saving of files in a Coot session.