### PR TITLE
Smaller logtext in report

### DIFF
--- a/docs/report_files/0.1.0/mosflmApp.js
+++ b/docs/report_files/0.1.0/mosflmApp.js
@@ -30,6 +30,27 @@ if (!Function.prototype.bind) {
 if (typeof Float64Array === 'undefined') Float64Array = Float32Array;
 
 //Some lingering globals for the report
+
+function fetchAndDecode(url) {
+  return fetch(url.innerHTML).then(response => {
+    if(!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    } else {
+      if(response.headers.get("content-type") === "text/plain") {
+        return response.text();
+      } else {
+        return url.innerHTML+" is not plain text. Ignoring."
+      }
+    }
+  })
+  .catch(e => {
+    console.log(`There has been a problem with your fetch operation for resource "${url}": ` + e.message);
+  })
+  .finally(() => {
+    //console.log(`fetch attempt for "${url}" finished.`);
+  })
+}
+
 function toggleview(obj) {
     src = obj
     while ( (' ' + obj.className +' ').indexOf(' hidesection ') == -1){
@@ -38,14 +59,21 @@ function toggleview(obj) {
         else                                return;
     }
     if ( (' ' + obj.className +' ').indexOf(' displayed ') > -1 ) {
-        $(obj).slideUp(300,function(){obj.className = obj.className.replace( 'displayed' , 'hidden' );})
-        //src.childNodes[0].nodeValue = src.childNodes[0].nodeValue.replace( "Hide", "Show" );
+        $(obj).slideUp(50,function(){
+            obj.className = obj.className.replace( 'displayed' , 'hidden' );
+        })
         src.childNodes[0].nodeValue = src.childNodes[0].nodeValue.replace( "\u25BC", "\u25B6" );
-        
     } else if ( (' ' + obj.className +' ').indexOf(' hidden ') > -1 )  {
-        $(obj).slideDown(300,function(){obj.className = obj.className.replace( 'hidden' , 'displayed' );})
-        //obj.className = obj.className.replace( /(?:^|\s)hidden(?!\S)/g , 'displayed' )
-        //src.childNodes[0].nodeValue = src.childNodes[0].nodeValue.replace( "Show", "Hide");
+        $(obj).slideDown(50,function(){
+            var matches = obj.querySelectorAll(":scope .urlfetchtag");
+            if(matches.length===1) {
+                fetchAndDecode(matches[0]).then(res => {
+                  matches[0].innerHTML = res
+                  matches[0].classList.remove("urlfetchtag")
+                })
+            }
+            obj.className = obj.className.replace( 'hidden' , 'displayed' );
+        })
         src.childNodes[0].nodeValue = src.childNodes[0].nodeValue.replace( "\u25B6", "\u25BC" );
     }
 }

--- a/report/CCP4ReportParser.py
+++ b/report/CCP4ReportParser.py
@@ -982,6 +982,9 @@ class Container(ReportClass):
   def addCopyToClipboard(self,xrtnode=None,xmlnode=None,jobInfo=None,text="",label="",**kw):
       return self.addObjectOfClass(CopyToClipboard, text=text,label=label, **kw)
 
+  def addCopyUrlToClipboard(self,xrtnode=None,xmlnode=None,jobInfo=None,text="",label="",**kw):
+      return self.addObjectOfClass(CopyUrlToClipboard, text=text,label=label, **kw)
+
   def addResults(self,xrtnode=None,xmlnode=None,jobInfo=None,**kw):
       return self.addObjectOfClass(Results, xrtnode, xmlnode, jobInfo, **kw)
 
@@ -3754,6 +3757,8 @@ class JobLogFiles(ReportClass):
     jobId = self.jobInfo["jobid"]
     jobDirectory = PROJECTSMANAGER().makeFileName(jobId=jobId,mode='ROOT')
 
+    """
+#TODO = Need a whole bunch of fetches.
     allText = ""
     for root, subFolders, files in os.walk(jobDirectory):
         for fn in files:
@@ -3769,21 +3774,17 @@ class JobLogFiles(ReportClass):
                         print("Could not read file",fn)
 
     download = logFold.addCopyToClipboard(text=allText,label="Copy all to clipboard")
+    """
 
     for root, subFolders, files in os.walk(jobDirectory):
         for fn in files:
             if (fn.endswith(".log") or fn.endswith(".txt")) and os.path.exists(os.path.join(root,fn)):
                 fileName = os.path.join(root,fn)
                 if os.path.exists(fileName):
-                    fileFold = Fold(label=fileName,brief=os.path.basename(fileName))
+                    fileFold = Fold(label=os.path.relpath(fileName,jobDirectory),brief=os.path.basename(fileName))
                     logFold.append(fileFold)
-                    t = ""
-                    try:
-                        f = open(fileName)
-                        t = f.read()
-                    except:
-                        print("Could not read file",fn)
-                    download = fileFold.addCopyToClipboard(text=t,label="Copy "+os.path.basename(fileName)+" to clipboard")
+                    t = os.path.relpath(fileName,jobDirectory)
+                    download = fileFold.addCopyUrlToClipboard(text=t,label="Copy "+os.path.basename(fileName)+" to clipboard",projectId=self.jobInfo['projectid'],jobnumber=self.jobInfo['jobnumber'])
                     logPre = fileFold.addPre()
                     logPre.text = t
 
@@ -3925,6 +3926,32 @@ class CopyToClipboard:
 
     return obj
 
+class CopyUrlToClipboard:
+  def __init__(self,text="",label="Copy to clipboard (by url...)",**kw):
+    self.text=text
+    self.label=label
+    self.projectId=kw.get("projectId")
+    self.jobnumber=kw.get("jobnumber")
+
+  def as_etree(self):
+    import json
+
+    obj = etree.Element('button')
+
+    obj.set('style','line-height: 14pt; box-sizing: border-box;')
+    obj.text = self.label
+    obj.set('title',"CopyUrlToClipboard")
+
+    n = 4096
+    split_text = [escapeI2Quotify(self.text[i:i+n]) for i in range(0, len(self.text), n)]
+
+    url = htmlBase().rstrip("/report_files/"+CURRENT_CSS_VERSION)+"/database/?getProjectJobFile?projectId="+self.projectId+"?jobNumber="+self.jobnumber+"?fileName="+self.text
+
+    escaped = escapeI2Quotify('fetch("'+url+'").then(response => {if(response.ok) response.text().then(text => {navigator.clipboard.writeText(text)})})')
+
+    obj.set('onclick',"eval("+escaped+")")
+
+    return obj
 
 class Download:
   

--- a/report/CCP4ReportParser.py
+++ b/report/CCP4ReportParser.py
@@ -934,6 +934,9 @@ class Container(ReportClass):
   def addPre(self,xrtnode=None,xmlnode=None,jobInfo=None,**kw):
       return self.addObjectOfClass(Pre, xrtnode, xmlnode, jobInfo, **kw)
 
+  def addFetchPre(self,xrtnode=None,xmlnode=None,jobInfo=None,**kw):
+      return self.addObjectOfClass(FetchPre, xrtnode, xmlnode, jobInfo, **kw)
+
   def addGraph(self,xrtnode=None,xmlnode=None,jobInfo=None,**kw):
       return self.addObjectOfClass(Graph, xrtnode, xmlnode, jobInfo, **kw)
 
@@ -1732,7 +1735,6 @@ class DrillDown(ReportClass):
       
     return retSubJobs
 
-
 def foldTitleLine(label, initiallyOpen, brief = None):
   root = etree.Element('root')
   anchor = etree.Element('a')
@@ -1901,6 +1903,21 @@ class Text(ReportClass):
 
 class Pre(Text):
     tag='pre'
+
+class FetchPre(Text):
+    tag='pre'
+    def data_as_xml(self, fileName=None):
+        dataXml = Text.data_as_xml(self, fileName)
+        if(hasattr(dataXml,"findall")):
+            pres = dataXml.findall("pre")
+            if len(pres)>0:
+                thePre = pres[0]
+                theClass = thePre.get("class")
+                if not theClass:
+                    thePre.set("class","urlfetchtag")
+                else:
+                    thePre.set("class",theClass+" urlfetchtag")
+        return dataXml
 
 # Status class
 class Status(Container):
@@ -3785,8 +3802,9 @@ class JobLogFiles(ReportClass):
                     logFold.append(fileFold)
                     t = os.path.relpath(fileName,jobDirectory)
                     download = fileFold.addCopyUrlToClipboard(text=t,label="Copy "+os.path.basename(fileName)+" to clipboard",projectId=self.jobInfo['projectid'],jobnumber=self.jobInfo['jobnumber'])
-                    logPre = fileFold.addPre()
-                    logPre.text = t
+                    logPre = fileFold.addFetchPre()
+                    url = htmlBase().rstrip("/report_files/"+CURRENT_CSS_VERSION)+"/database/?getProjectJobFile?projectId="+self.jobInfo['projectid']+"?jobNumber="+self.jobInfo['jobnumber']+"?fileName="+t
+                    logPre.text = url
 
     return logFold.as_etree()
 

--- a/report/CCP4ReportParser.py
+++ b/report/CCP4ReportParser.py
@@ -3927,7 +3927,7 @@ class CopyToClipboard:
     return obj
 
 class CopyUrlToClipboard:
-  def __init__(self,text="",label="Copy to clipboard (by url...)",**kw):
+  def __init__(self,text="",label="Copy to clipboard",**kw):
     self.text=text
     self.label=label
     self.projectId=kw.get("projectId")


### PR DESCRIPTION
Reduce size of report files by not embedding all the log files, but instead the urls of the log files in classed tags. The log text is pulled on the fly the first time and inserted into the report in the browser.