### PR TITLE
Allow for CCP4 python3.11 in CCP4 10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix Coot map coluring with multiple models
 - Fix for AceDRG atom name matching
 - Added checks before xmlnode append
+- Searching Python 3.11 paths for CCP4 10
 - PDB-REDO text change
 
 ## [2.4.0] - 2025-07-15

--- a/bin/ccp4
+++ b/bin/ccp4
@@ -19,14 +19,20 @@ export CCP4I2 CCP4I2_TOP PYTHONSTARTUP
 # LIBTBX_BUILD is used in cctbx to find libtbx_env file (pickle)
 if test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/cctbx; then
   LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/cctbx
+elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages/ccp4i2; then
+  LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages/ccp4i2
 elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages/ccp4i2; then
   LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages/ccp4i2
 elif test -d $CCP4/lib/python3.7/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/python3.7/cctbx
+elif test -d $CCP4/lib/python3.11/cctbx; then
+  LIBTBX_BUILD=$CCP4/lib/python3.11/cctbx
 elif test -d $CCP4/lib/python3.9/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/python3.9/cctbx
 elif test -d $CCP4/lib/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/cctbx
+elif test -d $CCP4/lib/python3.11/site-packages/cctbx; then
+  LIBTBX_BUILD=$CCP4/lib/python3.11/site-packages/cctbx
 elif test -d $CCP4/lib/python3.9/site-packages/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/python3.9/site-packages/cctbx
 else

--- a/bin/ccp4i2
+++ b/bin/ccp4i2
@@ -6,6 +6,8 @@ if test -d $CCP4/share/ccp4i2; then
   CCP4I2=$CCP4/share/ccp4i2
 elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages/ccp4i2; then
   CCP4I2=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages/ccp4i2
+elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages/ccp4i2; then
+  CCP4I2=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages/ccp4i2
 elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages/ccp4i2; then
   CCP4I2=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages/ccp4i2
 elif test -d $CCP4/lib/python3.7/site-packages/ccp4i2; then
@@ -28,16 +30,24 @@ export CCP4 CCP4I2 PYTHONSTARTUP
 # LIBTBX_BUILD is used in cctbx to find libtbx_env file (pickle)
 if test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/cctbx; then
   LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/cctbx
+elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/cctbx; then
+  LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/cctbx
 elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/cctbx; then
   LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/cctbx
+elif test -d $CCP4/Frameworks/Python.framework/Versions/3.11/share/cctbx; then
+  LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/3.11/share/cctbx
 elif test -d $CCP4/Frameworks/Python.framework/Versions/3.9/share/cctbx; then
   LIBTBX_BUILD=$CCP4/Frameworks/Python.framework/Versions/3.9/share/cctbx
 elif test -d $CCP4/lib/python3.7/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/python3.7/cctbx
+elif test -d $CCP4/lib/python3.11/cctbx; then
+  LIBTBX_BUILD=$CCP4/lib/python3.11/cctbx
 elif test -d $CCP4/lib/python3.9/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/python3.9/cctbx
 elif test -d $CCP4/lib/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/cctbx
+elif test -d $CCP4/lib/python3.11/site-packages/cctbx; then
+  LIBTBX_BUILD=$CCP4/lib/python3.11/site-packages/cctbx
 elif test -d $CCP4/lib/python3.9/site-packages/cctbx; then
   LIBTBX_BUILD=$CCP4/lib/python3.9/site-packages/cctbx
 else

--- a/bin/i2run-inst
+++ b/bin/i2run-inst
@@ -4,10 +4,14 @@ if test -d $CCP4/share/ccp4i2; then
     CCP4I2=$CCP4/share/ccp4i2
 elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages/ccp4i2; then
       CCP4I2=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages/ccp4i2
+elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages/ccp4i2; then
+      CCP4I2=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.11/site-packages/ccp4i2
 elif test -d $CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages/ccp4i2; then
       CCP4I2=$CCP4/Frameworks/Python.framework/Versions/Current/lib/python3.9/site-packages/ccp4i2
 elif test -d $CCP4/lib/python3.7/site-packages/ccp4i2; then
       CCP4I2=$CCP4/lib/python3.7/site-packages/ccp4i2
+elif test -d $CCP4/lib/python3.11/site-packages/ccp4i2; then
+      CCP4I2=$CCP4/lib/python3.11/site-packages/ccp4i2
 elif test -d $CCP4/lib/python3.9/site-packages/ccp4i2; then
       CCP4I2=$CCP4/lib/python3.9/site-packages/ccp4i2
 elif test -d $CCP4/lib/site-packages/ccp4i2; then


### PR DESCRIPTION
This adds python3.11 to list of searched python paths in CCP4 directory. This allows ccp4i2 to work in CCP4-9 and CCP4-10.