### PR TITLE
Servalcat: weight setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # CCP4i2 Changelog
 
-## [2.6.2] - 2026-05-14
+## [2.6.2] - 2026-05-27
 
 - Added a Lorestr test
 - Updated Servalcat 7beq electron test R-work threshold
 - Updated ModelCraft task title
 - Allow DUI2 to continue from previous jobs regardless of status
+- Updated interface for the Servalcat refinement weight setting
 
 ## [2.6.1] - 2026-04-09
 

--- a/core/version.params.xml
+++ b/core/version.params.xml
@@ -5,7 +5,7 @@
     <function>PARAMS</function>
     <pluginName>ccp4i2</pluginName>
     <userId></userId>
-    <creationTime>14/May/2026</creationTime>
+    <creationTime>27/May/2026</creationTime>
     <ccp4iVersion>2.6.2</ccp4iVersion>
     <pluginVersion></pluginVersion>
   </ccp4i2_header>

--- a/pipelines/servalcat_pipe/script/servalcat_pipe.def.xml
+++ b/pipelines/servalcat_pipe/script/servalcat_pipe.def.xml
@@ -346,7 +346,7 @@
                  <allowUndefined>True</allowUndefined>
                  <charWidth>4</charWidth>
                  <min>0.0</min>
-                 <toolTip>Controls the influence of external restraints during refinement (default: 1.0).</toolTip>
+                 <toolTip>Starting weight controlling the relative contribution of experiment data and restraint (geometry) terms.</toolTip>
               </qualifiers>
            </content>
            <content id="SGMN">

--- a/pipelines/servalcat_pipe/script/servalcat_pipe.py
+++ b/pipelines/servalcat_pipe/script/servalcat_pipe.py
@@ -202,9 +202,9 @@ class servalcat_pipe(CPluginScript):
         if status == CPluginScript.FAILED:
             self.reportStatus(status)
 
-    def executeFirstServalcat(self, withWeight=-1):
+    def executeFirstServalcat(self):
         #create wrapper
-        self.firstServalcat = self.createServalcatJob(withWeight)
+        self.firstServalcat = self.createServalcatJob()
         # Run asynchronously ...this is needed so that commands downstream of process launch
         # (i.e. logwatcher) will be calledbefore process completion
         self.firstServalcat.doAsync = self.doAsync
@@ -267,7 +267,7 @@ class servalcat_pipe(CPluginScript):
            shutil.move(tmpFileName, self.pipelinexmlfile)
            self.xmlLength = len(newXml)
 
-    def createServalcatJob(self, withWeight=-1, inputCoordinates=None, ncyc=-1):
+    def createServalcatJob(self, inputCoordinates=None, ncyc=-1):
         result = self.makePluginObject('servalcat')
         #input data for this servalcat instance is the same as the input data for the program
         result.container.inputData.copyData(self.container.inputData)
@@ -306,11 +306,6 @@ class servalcat_pipe(CPluginScript):
             result.container.controlParameters.PROSMART_NUCLEICACID_ALPHA=self.container.prosmartNucleicAcid.ALPHA
             result.container.controlParameters.PROSMART_NUCLEICACID_DMAX=self.container.prosmartNucleicAcid.DMAX
             result.container.inputData.PROSMART_NUCLEICACID_RESTRAINTS=self.prosmart_nucleicacid.container.outputData.RESTRAINTS
-
-        #Specify weight if a meaningful one has been offered
-        if withWeight>=0.:
-            result.container.controlParameters.WEIGHT_OPT='MANUAL'
-            result.container.controlParameters.WEIGHT = withWeight
 
         if inputCoordinates is not None:
             result.container.inputData.XYZIN.set(inputCoordinates)

--- a/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
+++ b/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
@@ -58,10 +58,6 @@ class Cservalcat_pipe(CCP4TaskWidget.CTaskWidget):
   def __init__(self,parent):
     CCP4TaskWidget.CTaskWidget.__init__(self,parent)
 
-  def ToggleWeightAdjustRmszAvailable(self):
-    return str(self.container.controlParameters.WEIGHT_OPT) == 'AUTO' and \
-      not self.container.controlParameters.WEIGHT_NO_ADJUST
-
   def ToggleRigidModeOn(self):
     return str(self.container.controlParameters.REFINEMENT_MODE) == 'RIGID'
 
@@ -253,14 +249,15 @@ class Cservalcat_pipe(CCP4TaskWidget.CTaskWidget):
   def drawRestraints( self ):
     self.createLine( [ 'subtitle', 'Weights'] )
     self.openSubFrame(frame=[True], toggleFunction=[self.ToggleRigidModeOff,['REFINEMENT_MODE']])
-    auto_weight = self.createLine( [ 'label', 'Weigh the experimental data using', 'widget', 'WEIGHT_OPT', 'label', 'weight'] )
-    self.createLine( [ 'label', 'of', 'widget', 'WEIGHT' ], toggle = ['WEIGHT_OPT', 'open', [ 'MANUAL' ] ], appendLine=auto_weight )
-    self.createLine( [ 'label', 'versus the restraints' ], appendLine=auto_weight )
-    self.createLine( [ 'widget', 'WEIGHT_NO_ADJUST', 'label', 'Do not adjust weight during refinement'], toggle = ['WEIGHT_OPT', 'open', [ 'AUTO' ] ] )
+    self.createLine([
+       'label', 'Starting weight for experimental data versus the restraints:',
+       'widget', 'WEIGHT',
+       ])
+    self.createLine( [ 'widget', 'WEIGHT_NO_ADJUST', 'label', 'Do not adjust weight during refinement'] )
     self.createLine( ['label', 'Bond RMSZ range for weight adjustment:', 'stretch',
                       'widget', 'WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN',
                       'widget', 'WEIGHT_TARGET_BOND_RMSZ_RANGE_MAX'],
-                      toggleFunction = [self.ToggleWeightAdjustRmszAvailable, ['WEIGHT_OPT', 'WEIGHT_NO_ADJUST', 'DATA_METHOD']])
+                      toggle = ['WEIGHT_NO_ADJUST', 'open', [ False ] ])
     self.closeSubFrame()
     self.openSubFrame(frame=[True], toggleFunction=[self.ToggleRigidModeOn,['REFINEMENT_MODE']])
     self.createLine( [ 'label', '<i>Not available in Rigid Body mode.</i>' ] )

--- a/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
+++ b/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
@@ -249,11 +249,10 @@ class Cservalcat_pipe(CCP4TaskWidget.CTaskWidget):
   def drawRestraints( self ):
     self.createLine( [ 'subtitle', 'Weights'] )
     self.openSubFrame(frame=[True], toggleFunction=[self.ToggleRigidModeOff,['REFINEMENT_MODE']])
-    auto_weight = self.createLine([
+    self.createLine([
        'label', 'Starting weight for experimental data versus the restraints:',
-       'widget', 'WEIGHT_OPT',
+       'widget', 'WEIGHT',
        ])
-    self.createLine( [ 'label', ':', 'widget', 'WEIGHT' ], toggle = ['WEIGHT_OPT', 'open', [ 'MANUAL' ] ], appendLine=auto_weight )
     self.createLine( [ 'widget', 'WEIGHT_NO_ADJUST', 'label', 'Do not adjust weight during refinement'] )
     self.createLine( ['label', 'Bond RMSZ range for weight adjustment:', 'stretch',
                       'widget', 'WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN',
@@ -773,19 +772,4 @@ class Cservalcat_pipe(CCP4TaskWidget.CTaskWidget):
                retval = msg.exec_()
                invalidElements.append(self.container.controlParameters.RES_MIN)
 
-      # Check conditional requirement: WEIGHT is required when WEIGHT_OPT is MANUAL
-      if str(self.container.controlParameters.WEIGHT_OPT) == 'MANUAL':
-         if not self.container.controlParameters.WEIGHT.isSet():
-            if functionNames[-2] == 'runTask':
-               from PySide2.QtWidgets import QMessageBox
-               msg = QMessageBox()
-               msg.setIcon(QMessageBox.Critical)
-               msg.setText("Error")
-               msg.setInformativeText("When weight option is set to MANUAL, a weight value must be provided.")
-               msg.setWindowTitle("Weight value required")
-               msg.setStandardButtons(QMessageBox.Cancel)
-               retval = msg.exec_()
-            invalidElements.append(self.container.controlParameters.WEIGHT)
-
       return invalidElements
-

--- a/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
+++ b/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
@@ -773,5 +773,19 @@ class Cservalcat_pipe(CCP4TaskWidget.CTaskWidget):
                retval = msg.exec_()
                invalidElements.append(self.container.controlParameters.RES_MIN)
 
+      # Check conditional requirement: WEIGHT is required when WEIGHT_OPT is MANUAL
+      if str(self.container.controlParameters.WEIGHT_OPT) == 'MANUAL':
+         if not self.container.controlParameters.WEIGHT.isSet():
+            if functionNames[-2] == 'runTask':
+               from PySide2.QtWidgets import QMessageBox
+               msg = QMessageBox()
+               msg.setIcon(QMessageBox.Critical)
+               msg.setText("Error")
+               msg.setInformativeText("When weight option is set to MANUAL, a weight value must be provided.")
+               msg.setWindowTitle("Weight value required")
+               msg.setStandardButtons(QMessageBox.Cancel)
+               retval = msg.exec_()
+            invalidElements.append(self.container.controlParameters.WEIGHT)
+
       return invalidElements
 

--- a/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
+++ b/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
@@ -249,10 +249,11 @@ class Cservalcat_pipe(CCP4TaskWidget.CTaskWidget):
   def drawRestraints( self ):
     self.createLine( [ 'subtitle', 'Weights'] )
     self.openSubFrame(frame=[True], toggleFunction=[self.ToggleRigidModeOff,['REFINEMENT_MODE']])
-    self.createLine([
+    auto_weight = self.createLine([
        'label', 'Starting weight for experimental data versus the restraints:',
-       'widget', 'WEIGHT',
+       'widget', 'WEIGHT_OPT',
        ])
+    self.createLine( [ 'label', ':', 'widget', 'WEIGHT' ], toggle = ['WEIGHT_OPT', 'open', [ 'MANUAL' ] ], appendLine=auto_weight )
     self.createLine( [ 'widget', 'WEIGHT_NO_ADJUST', 'label', 'Do not adjust weight during refinement'] )
     self.createLine( ['label', 'Bond RMSZ range for weight adjustment:', 'stretch',
                       'widget', 'WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN',

--- a/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
+++ b/pipelines/servalcat_pipe/script/servalcat_pipe_gui.py
@@ -252,6 +252,7 @@ class Cservalcat_pipe(CCP4TaskWidget.CTaskWidget):
     self.createLine([
        'label', 'Starting weight for experimental data versus the restraints:',
        'widget', 'WEIGHT',
+       'label', '(automatic if blank)'
        ])
     self.createLine( [ 'widget', 'WEIGHT_NO_ADJUST', 'label', 'Do not adjust weight during refinement'] )
     self.createLine( ['label', 'Bond RMSZ range for weight adjustment:', 'stretch',

--- a/wrappers/servalcat/script/servalcat.def.xml
+++ b/wrappers/servalcat/script/servalcat.def.xml
@@ -313,16 +313,6 @@ hydrogens are only to be used if already present in the input coordinate file.</
                  <toolTip>No positional restraints</toolTip>
              </qualifiers>
           </content>
-          <content id="WEIGHT_OPT">
-            <className>CString</className>
-            <qualifiers>
-              <onlyEnumerators>True</onlyEnumerators>
-              <enumerators>AUTO,MANUAL</enumerators>
-              <menuText>automatic,manual</menuText>
-              <default>AUTO</default>
-                <toolTip>If automatic weighting is selected, Refmac will adjust the weight each refinement cycle in order to try and ensure reasonable geometry on average.</toolTip>
-            </qualifiers>
-          </content>
             <content id="WEIGHT">
                 <className>CFloat</className>
                 <qualifiers>

--- a/wrappers/servalcat/script/servalcat.def.xml
+++ b/wrappers/servalcat/script/servalcat.def.xml
@@ -327,7 +327,7 @@ hydrogens are only to be used if already present in the input coordinate file.</
                 <className>CFloat</className>
                 <qualifiers>
                     <min>0.0</min>
-                    <toolTip>Constant weight controlling the relative contribution of data (reflections) and restraint (geometry) terms.</toolTip>
+                    <toolTip>Starting weight controlling the relative contribution of experiment data and restraint (geometry) terms.</toolTip>
                 </qualifiers>
             </content>
             <content id="WEIGHT_NO_ADJUST">

--- a/wrappers/servalcat/script/servalcat.py
+++ b/wrappers/servalcat/script/servalcat.py
@@ -424,17 +424,15 @@ class servalcat(CPluginScript):
                     else:
                         print(f"WARNING: input restraint dictionary {dictionary} does not exist and so will not be used.")
         # Weight
-        if str(self.container.controlParameters.WEIGHT_OPT) == "MANUAL":
-            if self.container.controlParameters.WEIGHT.isSet():
-                self.appendCommandLine(['--weight', str(self.container.controlParameters.WEIGHT)])
-        else:  # WEIGHT_OPT == "AUTO":
-            if self.container.controlParameters.WEIGHT_NO_ADJUST:
-                self.appendCommandLine(['--no_weight_adjust'])
-            elif self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN.isSet() and \
-                    self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MAX.isSet():
-                self.appendCommandLine(['--target_bond_rmsz_range',
-                                        str(self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN),
-                                        str(self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MAX)])
+        if self.container.controlParameters.WEIGHT.isSet():
+            self.appendCommandLine(['--weight', str(self.container.controlParameters.WEIGHT)])
+        if self.container.controlParameters.WEIGHT_NO_ADJUST:
+            self.appendCommandLine(['--no_weight_adjust'])
+        elif self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN.isSet() and \
+                self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MAX.isSet():
+            self.appendCommandLine(['--target_bond_rmsz_range',
+                                    str(self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN),
+                                    str(self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MAX)])
         # ADP
         if str(self.container.controlParameters.B_REFINEMENT_MODE) == "aniso":
             self.appendCommandLine(['--adp', 'aniso'])

--- a/wrappers/servalcat/script/servalcat.py
+++ b/wrappers/servalcat/script/servalcat.py
@@ -424,9 +424,8 @@ class servalcat(CPluginScript):
                     else:
                         print(f"WARNING: input restraint dictionary {dictionary} does not exist and so will not be used.")
         # Weight
-        if str(self.container.controlParameters.WEIGHT_OPT) == "MANUAL":
-            if self.container.controlParameters.WEIGHT.isSet():
-                self.appendCommandLine(['--weight', str(self.container.controlParameters.WEIGHT)])
+        if self.container.controlParameters.WEIGHT.isSet():
+            self.appendCommandLine(['--weight', str(self.container.controlParameters.WEIGHT)])
         if self.container.controlParameters.WEIGHT_NO_ADJUST:
             self.appendCommandLine(['--no_weight_adjust'])
         elif self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN.isSet() and \

--- a/wrappers/servalcat/script/servalcat.py
+++ b/wrappers/servalcat/script/servalcat.py
@@ -424,8 +424,9 @@ class servalcat(CPluginScript):
                     else:
                         print(f"WARNING: input restraint dictionary {dictionary} does not exist and so will not be used.")
         # Weight
-        if self.container.controlParameters.WEIGHT.isSet():
-            self.appendCommandLine(['--weight', str(self.container.controlParameters.WEIGHT)])
+        if str(self.container.controlParameters.WEIGHT_OPT) == "MANUAL":
+            if self.container.controlParameters.WEIGHT.isSet():
+                self.appendCommandLine(['--weight', str(self.container.controlParameters.WEIGHT)])
         if self.container.controlParameters.WEIGHT_NO_ADJUST:
             self.appendCommandLine(['--no_weight_adjust'])
         elif self.container.controlParameters.WEIGHT_TARGET_BOND_RMSZ_RANGE_MIN.isSet() and \


### PR DESCRIPTION
In servalcat / servalcat_pipe, allow to set starting weight value. Make clear whether "manual" fixes the weight or not

Screenshots of the all 4 combinations:

<img width="598" height="218" alt="image" src="https://github.com/user-attachments/assets/12b34977-0317-41c2-86f1-86001c208e0a" />

<img width="581" height="98" alt="image" src="https://github.com/user-attachments/assets/b3f04434-d4fe-4315-9046-51ab410954df" />

<img width="579" height="132" alt="image" src="https://github.com/user-attachments/assets/8f5f34a1-c538-4e26-9771-fcac064656f7" />

<img width="578" height="94" alt="image" src="https://github.com/user-attachments/assets/cf99b5de-189d-4676-aa2b-98bfaafc095e" />

If a user selects "manual" but doesn't fill a weight value and presses "Run", an error window appears: 
<img width="602" height="226" alt="image" src="https://github.com/user-attachments/assets/4d2d62df-9958-4e3a-875d-714bde7f606c" />

