### PR TITLE
moorhen-wrapper: don't pass /*/*/*/* to centreAndAlignViewOn

### DIFF
--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -275,7 +275,12 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
           newMolecule.addDict(fileContent),
         ]);
         if (!centredFirst) {
-          newMolecule.centreAndAlignViewOn("/*/*/*/*", false, 100);
+          // Pass "" (not "/*/*/*/*"): centreAndAlignViewOn appends "*" and
+          // "CA" to the CID internally, so passing "/*/*/*/*" produces the
+          // malformed "/*/*/*/**" selector and a WebAssembly.Exception from
+          // Coot. The empty-string branch in moorhen's implementation falls
+          // back to the correct "/*/*/*/*" wildcard internally.
+          newMolecule.centreAndAlignViewOn("", false, 100);
           centredFirst = true;
         }
         await newMolecule.fetchIfDirtyAndDraw("ligands");


### PR DESCRIPTION
centreAndAlignViewOn(selectionCid, ...) inside moorhen.js does:

    s = yield this.gemmiAtomsForCid(e + "*");
    l = yield this.gemmiAtomsForCid(e + "CA");

So passing "/*/*/*/*" produces "/*/*/*/**" -- Coot rejects this as 'Invalid selection syntax ("*" in a list)' and the call raises a WebAssembly.Exception. Visible to users as an unhandled rejection in the browser console plus an outsized cold-start map redraw (~23s instead of the usual ~13s) on the file-by-id moorhen page.

Pass "" instead -- moorhen's implementation has an else branch that substitutes "/*/*/*/*" as the wildcard internally, taking us through the working code path.