### PR TITLE
Force cast to Python bool in density_calculator and issues with core.CCP4Data.CBoolean

### DIFF
--- a/wrappers/density_calculator/script/density_calculator.py
+++ b/wrappers/density_calculator/script/density_calculator.py
@@ -56,7 +56,7 @@ class density_calculator(CPluginScript):
         elif params.BLUR_MODE == "custom":
             dencalc.blur = params.BLUR
         dencalc.cutoff = params.CUTOFF
-        use_mott_bethe = params.FORM_FACTOR == "xray" and params.MOTT_BETHE
+        use_mott_bethe = params.FORM_FACTOR == "xray" and params.MOTT_BETHE == True
         if use_mott_bethe:
             dencalc.addends.subtract_z()
         dencalc.set_grid_cell_and_spacegroup(structure)

--- a/wrappers/density_calculator/script/density_calculator.py
+++ b/wrappers/density_calculator/script/density_calculator.py
@@ -56,7 +56,8 @@ class density_calculator(CPluginScript):
         elif params.BLUR_MODE == "custom":
             dencalc.blur = params.BLUR
         dencalc.cutoff = params.CUTOFF
-        use_mott_bethe = params.FORM_FACTOR == "xray" and params.MOTT_BETHE == True
+        use_mott_bethe = params.FORM_FACTOR == "xray" and bool(params.MOTT_BETHE)
+
         if use_mott_bethe:
             dencalc.addends.subtract_z()
         dencalc.set_grid_cell_and_spacegroup(structure)


### PR DESCRIPTION
Dear CCP4 developers!

**Bug description**
I am working CCP4 version 9.0.015 and tried to use the Density Calculator, but it always crashes with the following error message: 
```

<?xml version='1.0' encoding='ASCII'?>
<ccp4:ccp4i2 xmlns:ccp4="http://www.ccp4.ac.uk/ccp4ns">
  <ccp4i2_header>
    <function>LOG</function>
    <userId>...</userId>
    <hostName>...</hostName>
    <creationTime>15:03 11/May/26</creationTime>
    <ccp4iVersion>alpha_rev_90015</ccp4iVersion>
    <pluginName>density_calculator</pluginName>
    <pluginTitle>Density Calculator</pluginTitle>
    <projectName>...</projectName>
    <projectId>23f1cf36430e11f1be4ab115b6dfc3a8</projectId>
    <jobId>aaa5da9c4d3911f1a6f7c1fd2f089d09</jobId>
    <jobNumber>32</jobNumber>
  </ccp4i2_header>
  <ccp4i2_body>
    <errorReport>
      <className>density_calculator</className>
      <code>48</code>
      <description>Error in wrapper density_calculator 0.1:: Error in the plugin script startProcess</description>
      <severity>ERROR</severity>
      <details></details>
      <stack>Traceback (most recent call last):
  File "/software/linuxsoft/ccp4-9.0/ccp4-9/lib/python3.9/site-packages/ccp4i2/core/CCP4PluginScript.py", line 872, in process
    rv = self.startProcess(*[self.command], **kw)
  File "/software/linuxsoft/ccp4-9.0/ccp4-9/lib/python3.9/site-packages/ccp4i2/wrappers/density_calculator/script/density_calculator.py", line 74, in startProcess
    asu_data = sf_grid.prepare_asu_data(
TypeError: prepare_asu_data(): incompatible function arguments. The following argument types are supported:
    1. prepare_asu_data(self, dmin: float = 0.0, unblur: float = 0.0, with_000: bool = False, with_sys_abs: bool = False, mott_bethe: bool = False) -&gt; gemmi.ComplexAsuData

Invoked with types: gemmi.ReciprocalComplexGrid, kwargs = { dmin: float, mott_bethe: core.CCP4Data.CBoolean, unblur: float }
</stack>
    </errorReport>
    <programVersions/>
  </ccp4i2_body>
</ccp4:ccp4i2>
```
Clearly, the function ```prepare_asu_data``` requires the ```bool``` type for its argument ```mott_bethe```. For whatever reason the types did not match as the caller provided the type ```core.CCP4Data.CBoolean```.

Subsequently I have had a look into ```density_calculator.py``` and found the erroneous function call ```asu_data = sf_grid.prepare_asu_data(
            dmin=dencalc.d_min, mott_bethe=use_mott_bethe, unblur=unblur
        )``` with this line doing the assignment of the variable ```use_mott_bethe```:
```
use_mott_bethe = params.FORM_FACTOR == "xray" and params.MOTT_BETHE
``` 

```params.MOTT_BETHE``` indeed has the type ```core.CCP4Data.CBoolean```, but this class implements the ```__bool__``` magic method and should thus handle implicit conversions to the internal Python ```bool``` type. But obviously this not happening here.

**Solution to the problem**
The simplest solution was to changed the asignement to ```use_mott_bethe``` to ```use_mott_bethe = params.FORM_FACTOR == "xray" and bool(params.MOTT_BETHE)``` to explicitly invoke the cast to ```bool```.

**The deeper problem**
The type ```core.CCP4Data.CBoolean``` is in widespread use in CCP4i2 and it appears to just work as intended. Why did it fail in the case of density_calculator.py? I suspected that there might be a problem with the ```and``` in the assignment and did some testing on my machine.

This is the programme I used to understand the behaviour of my version of Python (main, Mar  3 2026, 11:56:32) [GCC 11.4.0] on linux). The class CBool is a stripped down version of ```core.CCP4Data.CBoolean``` and only implements the dunder bool method. 
```
class CBool:
    _value: bool
    
    def __init__(self, val):
    	self._value = val
    
    def __bool__(self):
        return self._value

        
t_true  = CBool(True)
t_false = CBool(False)

tests = dict()

tests["true_and_t_true"] = True and t_true
tests["false_or_t_true"] = False or t_true

tests["true_and_t_false"] = True and t_false
tests["false_or_t_false"] = False or t_false

tests["if_t_true_eq_true"] = t_true == True
tests["if_t_true_eq_false"] = t_true == False
tests["if_t_False_eq_true"] = t_false == True
tests["if_t_False_eq_false"] = t_false == False


if t_true:
	tests["if_t_true"] = True
else:
	tests["if_t_true"] = False

if t_false:
	tests["if_t_false"] = True
else:
	tests["if_t_false"] = False


for name, value in tests.items():
	print(f"{name:<20} {value=} {type(value)}")

```
with the following output
```
true_and_t_true      value=<__main__.CBool object at 0x7fd289b9be80> <class '__main__.CBool'>
false_or_t_true      value=<__main__.CBool object at 0x7fd289b9be80> <class '__main__.CBool'>
true_and_t_false     value=<__main__.CBool object at 0x7fd289b9bca0> <class '__main__.CBool'>
false_or_t_false     value=<__main__.CBool object at 0x7fd289b9bca0> <class '__main__.CBool'>
if_t_true_eq_true    value=False <class 'bool'>
if_t_true_eq_false   value=False <class 'bool'>
if_t_False_eq_true   value=False <class 'bool'>
if_t_False_eq_false  value=False <class 'bool'>
if_t_true            value=True <class 'bool'>
if_t_false           value=False <class 'bool'>
```
The result is probably not like what is expected in the first place and also the explanation for the bug in density_calculator. Python obviously does not apply ```__bool__``` for the second condition in the compound conditional expressions in these test cases.

_Output lines 1-4:_ According to https://docs.python.org/3.10/library/stdtypes.html#boolean-operations-and-or-not is this a normal behaviour. Python returns one of the operands in the case of a compound conditional. 
_Output lines 5-8:_ As the class ```CBool``` does not implement the ```__eq__``` method, the comparison is always done between the non-identical types ```CBool``` and ```bool``` and the result is thus always ```False```.
_Output lines 9-10:_ Finally something that behaves like it was intended to. The ```if``` requires the conversion to ```bool``` and the ```__bool__``` is used for that. 

**Recommendation for ```core.CCP4Data.CBoolean``` and its usage**
- This PR does not include modifications for ```core.CCP4Data.CBoolean```, but from my perspective a ```__eq__``` method should be implemented to make ```core.CCP4Data.CBoolean``` behave more like a normal boolean type. Currently it does not have ```__eq__```.
- Furthermore, the CCP4i2 code base should be checked for the usage of ```core.CCP4Data.CBoolean``` in compound conditionals and explicit conversions (or other appropriate measures) should be applied if necessary. 

**Final note**
Dear CCP4 developers! Thank you for all your work so far and I hope that this PR will help to keep CCP4 up and running in the foreseeable future. 

Kind regards,
Renato