### PR TITLE
Moorhen scenes + worker-isolation infra (cherry-picked from moorhen-scenes)

### DIFF
--- a/client/main/ccp4i2-menu.ts
+++ b/client/main/ccp4i2-menu.ts
@@ -52,6 +52,15 @@ export function addNewWindowMenuItem(NEXT_PORT: number, DJANGO_PORT: number) {
         },
       })
     );
+    fileMenu.submenu?.append(
+      new MenuItem({
+        label: "Moorhen",
+        accelerator: "CmdOrCtrl+Shift+M",
+        click: () => {
+          createWindow(`http://localhost:${NEXT_PORT}/ccp4i2/moorhen-page`, store);
+        },
+      })
+    );
   }
 
   // Find the Edit menu and add Find item

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -43,6 +43,7 @@
         "jquery": "^3.7.1",
         "jspdf": "^3.0.4",
         "jspdf-autotable": "^5.0.2",
+        "jszip": "^3.10.1",
         "moorhen": "file:moorhen-0.23.1-alpha.0.tgz",
         "next": "^15.3.0",
         "pptxgenjs": "^4.0.1",
@@ -59,7 +60,8 @@
         "uuid": "^11.0.5",
         "vis-data": "^8.0.3",
         "vis-network": "^10.0.2",
-        "xml2js": "^0.6.2"
+        "xml2js": "^0.6.2",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@electron/packager": "^18.3.6",
@@ -18241,6 +18243,8 @@
     },
     "node_modules/jszip": {
       "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -30694,9 +30698,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/client/package.json
+++ b/client/package.json
@@ -72,6 +72,7 @@
     "jquery": "^3.7.1",
     "jspdf": "^3.0.4",
     "jspdf-autotable": "^5.0.2",
+    "jszip": "^3.10.1",
     "moorhen": "file:moorhen-0.23.1-alpha.0.tgz",
     "next": "^15.3.0",
     "pptxgenjs": "^4.0.1",
@@ -88,7 +89,8 @@
     "uuid": "^11.0.5",
     "vis-data": "^8.0.3",
     "vis-network": "^10.0.2",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@electron/packager": "^18.3.6",

--- a/client/renderer/MOORHEN_SCENES.md
+++ b/client/renderer/MOORHEN_SCENES.md
@@ -1,0 +1,241 @@
+# Moorhen Scenes — branch handover
+
+A working summary of the `moorhen-scenes` feature work — what it does,
+which files implement it, the design decisions worth knowing about,
+and what's deliberately not done yet.
+
+For the **authoring** reference (how to write a `.scene.yaml`), see
+[`types/moorhen-scene.md`](renderer/types/moorhen-scene.md). This
+document is the implementer's-eye view.
+
+## What it is
+
+A YAML-based scene format for Moorhen. A scene describes *intent*
+(domains, colour rules, representations, superpositions, camera) and
+optionally bundles its own coordinate and dictionary data, so a
+single `.scene.yaml` or `.scene.zip` is enough to reproduce a view on
+any machine — including ones that have never seen the underlying
+project files.
+
+```
+my-view.scene.zip                     ┌─────────────────────────┐
+├── scene.yaml         drop on ─────► │  Moorhen Scenes panel   │
+└── assets/                            │  • Open / Apply / Save  │
+    ├── coords/x0034.cif               │  • Live Monaco editor   │
+    └── dict/x0034_LIG.cif             │  • Validation messages  │
+                                       └─────────────────────────┘
+```
+
+The format supports:
+
+- **PDB IDs** (fetched via PDBe proxy), **ccp4i2 file IDs** (per
+  project), **URLs**, and **bundled assets** (inside a `.scene.zip`).
+- **Per-molecule scoped dictionaries** — the fragment-campaign case
+  where two molecules carry same-named ligands with different chemistry.
+- **Domain definitions** with by-domain colouring.
+- **SSM and LSQ superpositions** (with a `chain`+`range` shorthand).
+- **Inline dict text** (`cifText:`) and **bundle: assets/...**
+  references for sources without a stable URL.
+
+## File map
+
+### Schema and parsing
+
+| File | Role |
+|------|------|
+| `renderer/types/moorhen-scene.ts`         | TypeScript types for the scene model |
+| `renderer/types/moorhen-scene.md`         | Authoring reference (the user-facing doc) |
+| `renderer/lib/moorhen-scene.ts`           | YAML parser, validator, serialiser (`parseScene`, `serialiseScene`, `serialiseSceneWithComments`) |
+
+### Resolver (scene → Moorhen state)
+
+| File | Role |
+|------|------|
+| `renderer/lib/moorhen-scene-resolver.ts`  | The apply-time engine. Fetches files, runs superpositions, applies representations, sets the camera. Exposes a couple of small pure helpers (`splitMultiCid`, `clampRangeToPresent`, `expandLsqMatches`, `isFetchable`) for unit testing. |
+
+### Lifter (Moorhen state → scene)
+
+| File | Role |
+|------|------|
+| `renderer/lib/moorhen-scene-lifter.ts`    | The capture-time engine. `liftScene` writes a plain YAML; `liftSceneToBundle` inlines local coord/dict text into a returned asset map suitable for zipping. Conservative — only lifts things it recognises. |
+
+### UI
+
+| File | Role |
+|------|------|
+| `renderer/components/moorhen/moorhen-scenes-panel.tsx`        | The Scenes side-panel (Monaco editor + toolbar + live-apply + validation log + .scene.zip open/save). |
+| `renderer/components/moorhen/moorhen-ccp4i2-tabbed-panel.tsx` | Tab container holding Controls + Scenes sub-panels under one Moorhen side-panel registration. (Workaround for a Moorhen quirk where registering two `extraSidePanels` only ever surfaces one tab.) |
+| `renderer/components/moorhen/moorhen-wrapper.tsx`             | Wires the resolver + lifter to Moorhen via callbacks: `handleApplyScene`, `handleCaptureScene`, `handleFetchSceneFile`, `handleFetchSceneDictionary`, `handleLoadSceneDictionary`. |
+| `renderer/components/moorhen/moorhen-control-panel.tsx`       | Existing panel; only touched to allow co-existence with the Scenes panel. |
+
+### Supporting infrastructure
+
+| File | Role |
+|------|------|
+| `renderer/app/api/proxy/pdbe/[...path]/route.ts` | Local proxy for PDBe fetches. Adds `Cross-Origin-Resource-Policy: cross-origin` so the COEP-enabled Moorhen page can fetch them. Sibling of the existing `proxy/uniprot/` route. |
+| `renderer/components/task/task-elements/fetch-file-for-param.tsx` | Updated to route PDBe fetches through the new proxy (drive-by fix for an unrelated COEP/CORP issue). |
+| `client/package.json`                           | New dependencies: `yaml` (parser), `jszip` (bundle round-trip). |
+
+### Tests
+
+| File | Tests |
+|------|-------|
+| `renderer/__tests__/moorhen-scene.test.ts`          | Schema, validator, serialiser, round-trip stability (65 tests) |
+| `renderer/__tests__/moorhen-scene-resolver.test.ts` | Pure resolver helpers — clamping, multi-CID splitting, LSQ expansion, isFetchable, chain selectors (28 tests) |
+| `renderer/__tests__/moorhen-scene-lifter.test.ts`   | Lifter behaviour, dict enumeration, round-trip via fake molecules (15 tests) |
+
+**Total: 112 tests**, all passing. Run with `cd client && npx vitest run`.
+
+The resolver itself (the bit that drives Moorhen) is exercised by
+manual verification in the browser — too much runtime state to mock.
+
+## Design decisions worth knowing about
+
+### Two-phase model: format vs runtime
+
+The format itself (parser, validator, serialiser) is pure TypeScript
+and has no Moorhen dependency. The resolver and lifter call into
+Moorhen but accept callbacks for the parts that need wrapper state
+(fetchers, dictionary loader). This kept the test surface tractable
+and means the YAML format could be lifted out into a standalone
+library if it ever needs to be.
+
+### Bundle (`.scene.zip`) is the portable shape
+
+A `.scene.yaml` works fine when every file ref is portable (PDB ID,
+public URL, ccp4i2 fileId in a project the recipient has). For
+fragment campaigns and other "local data" cases, the
+`.scene.zip` bundles `scene.yaml` + `assets/` so the whole view is
+one droppable file. The format uses `bundle: assets/foo.cif` refs;
+the resolver looks them up in an in-memory asset map.
+
+### Lifter behaviour: conservative
+
+The lifter recognises a few common cases (named colour schemes,
+single-hex colours, by-domain pipe-delimited args, multi-domain
+dict ownership) and falls back to a `{raw: ...}` escape hatch for
+anything it doesn't understand. The escape hatch is lossless but
+ugly; the recognised cases produce clean editable YAML. Round-trip
+through `serialiseSceneWithComments(scene, hints)` adds a comment
+above each file entry naming the original source.
+
+### Resolver's "scene owns the look"
+
+When the scene has any element for a molecule, the resolver hides
+**every** loader-default non-custom representation on that molecule
+— not just ones whose style the scene also adds. Without this, a
+fragment-campaign scene that has 25 elements with only `style: ligands`
+would leave 25 default ribbons visible underneath. The user can
+toggle them back via the Models panel if they want.
+
+### One Moorhen side panel, our own tabs inside
+
+Moorhen's `extraSidePanels` API has an upstream quirk: registering
+two panels only ever surfaces one tab in the switcher. We worked
+around this by registering one `ccp4i2Controls` panel whose content
+is a MUI Tabs container hosting the existing Controls UI and the new
+Scenes UI as sub-tabs. Both subtrees stay mounted (one is
+`display: none`) so Monaco's editor state and the open .zip's
+asset map survive tab switches.
+
+### `||`-split for multi-residue selections
+
+Coot's CID grammar (via gemmi) accepts at most a single residue
+number or a `start-end` range in the residue field. Disjoint
+residues need `||`-joined multi-CIDs. The resolver splits on `||`
+and emits one representation per chunk — each becomes a row in
+Moorhen's Models drawer. There's no compact form; this is a
+fundamental gemmi grammar constraint, not something to fix in the
+resolver.
+
+### `style: ligands` is broken for explicit selections
+
+Moorhen's `ligands` representation style overwrites the rep's CID
+with its own auto-discovered ligand list on every apply, throwing
+away whatever `selection:` the author specified. On real cifs the
+auto-discovery misfires (treats glycines as ligands, shares the
+same CID across all molecules in a multi-load session). The
+authoring doc tells the converter to use `style: CBs` with an
+explicit residue-name CID like `//*/(LIG)` for ligand sticks.
+This avoids the auto-discovery path entirely.
+
+### Camera handling: portable subset only
+
+The `view:` block captures origin, quat, zoom, optionally clip and
+fog. Lighting / SSAO / shadow / spec power are deliberately omitted
+because they don't translate meaningfully across structures and they
+bloat the YAML. PyMOL-derived clip values (often ±10000+ Å) should
+be stripped at author time — the doc warns about this.
+
+## Known limitations
+
+These are things the format or implementation explicitly does not
+do today. Listed in case they come up in conversation:
+
+- **`gesamt` superposition is not exposed.** The WASM module is
+  built into Moorhen but the JS binding is commented out. SSM and
+  LSQ are available; gesamt is not. Worth filing upstream.
+- **No UniProt / SIFTS domain import.** The format supports rich
+  domain definitions; there's no automation to populate them from
+  UniProt or PDBe SIFTS yet. Hand-author, or generate from your
+  own script.
+- **Multi-CID highlights produce one drawer row per chunk.** There
+  is no compact CID form for disjoint residue numbers, so a
+  highlight of 12 disjoint residues becomes 12 panel rows. Could be
+  collapsed in a Moorhen UI patch upstream; can't be fixed in our
+  format.
+- **The lifter doesn't capture the loader's default reps.** It
+  captures custom reps the user added via the Scenes apply path,
+  but if you've fiddled with the Models drawer toggles, that state
+  doesn't round-trip into the saved scene.
+- **No project-attached scene storage.** Today scenes live in
+  `.yaml` / `.zip` files on the user's local filesystem (or
+  download folder). A future iteration could add a `scenes/`
+  directory under each ccp4i2 project, exposed via REST.
+
+## End-to-end smoke test
+
+Without the test data we use internally, the cheapest way to verify
+the round-trip works on a fresh install:
+
+1. Open Moorhen in the Electron app or web build.
+2. Pick a structure (any PDB ID — `3jbt` is small).
+3. Open the Scenes panel (CCP4i2 side panel → Scenes tab).
+4. Paste this and click Apply:
+
+   ```yaml
+   scene: smoke-test
+   version: 1
+   files:
+     - { name: thing, pdb: 3jbt }
+   domains:
+     - { name: a, chain: A, range: 1-50,   color: "#4b8bbe" }
+     - { name: b, chain: A, range: 51-100, color: "#e74c3c" }
+   elements:
+     - file: thing
+       representations:
+         - { style: CRs, selection: "//A", colour: by-domain }
+   ```
+
+5. Should see a structure load from PDBe and render with two
+   coloured blocks on chain A.
+
+## Branching suggestion
+
+Worth its own branch off the current `django` branch — the change
+set is large enough (12 new files, ~3000 lines including tests)
+that reviewers will want to read it in one place. Suggested name:
+`moorhen-scenes`. The Electron menu addition in
+`client/main/ccp4i2-menu.ts` is the only main-process touch; the
+rest is renderer-side.
+
+Two existing files are touched non-trivially:
+
+- `client/renderer/components/moorhen/moorhen-wrapper.tsx` —
+  +279 lines, mostly the scene callbacks and the bundle/dict
+  fetcher wiring.
+- `client/renderer/components/task/task-elements/fetch-file-for-param.tsx` —
+  a small change that routes PDBe fetches through the new
+  `/api/proxy/pdbe` route. Worth a separate commit so it can be
+  cherry-picked back to `django` independently if needed (it's
+  not scenes-specific).

--- a/client/renderer/__tests__/fixtures/demo.scene.yaml
+++ b/client/renderer/__tests__/fixtures/demo.scene.yaml
@@ -1,0 +1,32 @@
+scene: gamma-demo
+version: 1
+
+# Sample scene for verifying the upload flow.
+#
+# Designed against demo_data/gamma/gamma_model.pdb (chain A, residues
+# 703-822). The three named domains slice that range into three blocks
+# with distinct colours. The fourth ("tail") deliberately extends past
+# residue 822 to exercise the clamp-and-log resolver path — when applied
+# you'll see it clamped to 800-822 in the resolver log.
+#
+# v0 file-matching: this scene's `files:` entry uses path-only matching,
+# which works when you've loaded gamma_model.pdb in the file browser.
+# (When ccp4i2 fileId matching is the path actually used, you'd swap
+# to fileId/projectId. Either form should resolve.)
+
+files:
+  - name: gamma
+    path: demo_data/gamma/gamma_model.pdb
+
+domains:
+  - { name: head,   chain: A, range: 703-740, color: "#4b8bbe" }
+  - { name: middle, chain: A, range: 741-780, color: "#f1c40f" }
+  - { name: tail,   chain: A, range: 800-900, color: "#e74c3c" }
+
+elements:
+  - file: gamma
+    representations:
+      - { style: CRs, selection: "//A", colour: by-domain }
+
+resolver:
+  onMissingResidues: clamp-and-log

--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -445,3 +445,132 @@ describe("liftScene — dictionary lifting", () => {
     expect(dictRefs).toHaveLength(0);
   });
 });
+
+function fakeMap(opts: {
+  name: string;
+  molNo: number;
+  uniqueId: string;
+  isDifference?: boolean;
+  selectedColumns?: Partial<moorhen.selectedMtzColumns>;
+}): moorhen.Map {
+  return {
+    name: opts.name,
+    molNo: opts.molNo,
+    uniqueId: opts.uniqueId,
+    isDifference: !!opts.isDifference,
+    selectedColumns: (opts.selectedColumns ?? { F: "FWT", PHI: "PHWT" }) as moorhen.selectedMtzColumns,
+  } as unknown as moorhen.Map;
+}
+
+describe("liftScene — maps", () => {
+  it("emits an MTZ file ref + SceneMap with columns + isDifference", () => {
+    const scene = liftScene({
+      molecules: [],
+      glRef: fakeGlRef,
+      maps: [
+        fakeMap({
+          name: "best",
+          molNo: 5,
+          uniqueId: "https://example/best.mtz",
+          selectedColumns: { F: "FWT", PHI: "PHWT" },
+        }),
+        fakeMap({
+          name: "diff",
+          molNo: 6,
+          uniqueId: "https://example/diff.mtz",
+          isDifference: true,
+          selectedColumns: { F: "DELFWT", PHI: "PHDELWT" },
+        }),
+      ],
+    });
+    const mtzFiles = scene.files!.filter((f) => f.kind === "mtz");
+    expect(mtzFiles).toHaveLength(2);
+    expect(scene.maps).toHaveLength(2);
+    expect(scene.maps![0]).toMatchObject({
+      file: mtzFiles[0].name,
+      columns: { F: "FWT", PHI: "PHWT" },
+    });
+    expect(scene.maps![0].isDifference).toBeUndefined();
+    expect(scene.maps![1].isDifference).toBe(true);
+  });
+
+  it("uses fileId+projectId for ccp4i2-loaded MTZs", () => {
+    const scene = liftScene({
+      molecules: [],
+      glRef: fakeGlRef,
+      projectId: "proj-uuid",
+      projectName: "Demo",
+      maps: [
+        fakeMap({
+          name: "best",
+          molNo: 5,
+          uniqueId: "/api/proxy/ccp4i2/files/777/download/",
+        }),
+      ],
+    });
+    const mtzFile = scene.files!.find((f) => f.kind === "mtz");
+    expect(mtzFile).toMatchObject({
+      fileId: 777,
+      projectId: "proj-uuid",
+      projectName: "Demo",
+    });
+  });
+
+  it("promotes activeMap by molNo to scene.activeMap", () => {
+    const scene = liftScene({
+      molecules: [],
+      glRef: fakeGlRef,
+      maps: [
+        fakeMap({ name: "best", molNo: 5, uniqueId: "https://example/best.mtz" }),
+        fakeMap({ name: "diff", molNo: 6, uniqueId: "https://example/diff.mtz", isDifference: true }),
+      ],
+      activeMapMolNo: 5,
+    });
+    expect(scene.activeMap).toBe(scene.maps![0].name);
+  });
+
+  it("captures render state from mapState keyed by molNo", () => {
+    const scene = liftScene({
+      molecules: [],
+      glRef: fakeGlRef,
+      maps: [
+        fakeMap({ name: "best", molNo: 5, uniqueId: "https://example/best.mtz" }),
+      ],
+      mapState: {
+        5: {
+          contourLevel: 1.234,
+          radius: 17.5,
+          alpha: 0.9,
+          style: "solid",
+          colour: "#336699",
+          visible: false,
+        },
+      },
+    });
+    expect(scene.maps![0]).toMatchObject({
+      contourLevel: 1.234,
+      radius: 17.5,
+      alpha: 0.9,
+      style: "solid",
+      colour: "#336699",
+      visible: false,
+    });
+  });
+
+  it("emits positive/negative colours only for difference maps", () => {
+    const scene = liftScene({
+      molecules: [],
+      glRef: fakeGlRef,
+      maps: [
+        fakeMap({ name: "diff", molNo: 5, uniqueId: "https://example/diff.mtz", isDifference: true }),
+      ],
+      mapState: {
+        5: { colour: "#000000", positiveColour: "#00ff00", negativeColour: "#ff0000" },
+      },
+    });
+    const m = scene.maps![0];
+    expect(m.positiveColour).toBe("#00ff00");
+    expect(m.negativeColour).toBe("#ff0000");
+    expect(m.colour).toBeUndefined();
+  });
+});

--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Lifter tests: Moorhen state → MoorhenScene → YAML → MoorhenScene.
+ *
+ * We construct minimal stand-in objects for moorhen.Molecule and
+ * moorhen.MoleculeRepresentation rather than mocking the full runtime —
+ * the lifter only reads a handful of fields, and using duck-typed plain
+ * objects keeps the tests focused on the lift logic itself.
+ */
+import { describe, it, expect } from "vitest";
+import type { moorhen } from "moorhen/types/moorhen";
+
+import { liftScene, liftSceneWithHints } from "../lib/moorhen-scene-lifter";
+import {
+  parseScene,
+  serialiseScene,
+  serialiseSceneWithComments,
+} from "../lib/moorhen-scene";
+
+// Build a fake-but-valid molecule by hand. Cast to moorhen.Molecule via
+// unknown — the lifter only reads `name`, `molNo`, `uniqueId`, and
+// `representations`, so we don't need a real instance.
+function fakeMol(opts: {
+  name: string;
+  molNo: number;
+  uniqueId: string;
+  representations?: Partial<moorhen.MoleculeRepresentation>[];
+  /** Ligand info as Moorhen would surface it via mol.ligands. */
+  ligands?: Partial<moorhen.LigandInfo>[];
+  /** Map from comp_id → dict text, mimicking Moorhen's mol.getDict. */
+  dicts?: Record<string, string>;
+}): moorhen.Molecule {
+  const dicts = opts.dicts ?? {};
+  return {
+    name: opts.name,
+    molNo: opts.molNo,
+    uniqueId: opts.uniqueId,
+    representations: (opts.representations ?? []) as moorhen.MoleculeRepresentation[],
+    ligands: (opts.ligands ?? []) as moorhen.LigandInfo[],
+    getDict: (comp_id: string) => dicts[comp_id] ?? "",
+  } as unknown as moorhen.Molecule;
+}
+
+const fakeGlRef = {
+  origin: [10.0, 20.0, 30.0],
+  quat: [0, 0, 0, -1],
+  zoom: 1.5,
+};
+
+describe("liftScene", () => {
+  it("captures camera and a single file with a single visible representation", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "thing",
+          molNo: 0,
+          uniqueId: "/api/proxy/ccp4i2/files/287/download/",
+          representations: [
+            { style: "CRs", cid: "/*/*/*/*", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+      projectId: "proj-uuid",
+      projectName: "kinase-2026",
+      sceneName: "test",
+      createdBy: "user@example.com",
+    });
+
+    expect(scene.scene).toBe("test");
+    expect(scene.authoredIn?.projectId).toBe("proj-uuid");
+    expect(scene.authoredIn?.createdBy).toBe("user@example.com");
+    expect(scene.files).toHaveLength(1);
+    expect(scene.files![0]).toMatchObject({
+      name: "thing",
+      projectId: "proj-uuid",
+      projectName: "kinase-2026",
+      fileId: 287,
+    });
+    expect(scene.view?.origin).toEqual([10, 20, 30]);
+    expect(scene.view?.zoom).toBe(1.5);
+    expect(scene.elements).toHaveLength(1);
+    expect(scene.elements![0].representations![0].style).toBe("CRs");
+    // CID == default wildcard is omitted from the serialised form.
+    expect(scene.elements![0].representations![0].selection).toBeUndefined();
+  });
+
+  it("falls back to url: when the molecule wasn't loaded via ccp4i2", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "pdb",
+          molNo: 0,
+          uniqueId: "https://www.ebi.ac.uk/pdbe/entry-files/download/3jbt.cif",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.files![0]).toEqual({
+      name: "pdb",
+      url: "https://www.ebi.ac.uk/pdbe/entry-files/download/3jbt.cif",
+    });
+  });
+
+  it("hides representations that are explicitly hidden", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            { style: "MolecularSurface", visible: false, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.elements![0].representations).toHaveLength(1);
+    expect(scene.elements![0].representations![0].style).toBe("CRs");
+  });
+
+  it("lifts a named multi-rule colour scheme", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [
+            {
+              style: "CRs",
+              visible: true,
+              colourRules: [{ ruleType: "b-factor", isMultiColourRule: true, args: [] } as unknown as moorhen.ColourRule],
+            } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.elements![0].representations![0].colour).toBe("b-factor");
+  });
+
+  it("lifts a single-colour hex rule", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [
+            {
+              style: "ligands",
+              visible: true,
+              colourRules: [
+                {
+                  ruleType: "molecule",
+                  isMultiColourRule: false,
+                  color: "#2ecc71",
+                  args: [],
+                } as unknown as moorhen.ColourRule,
+              ],
+            } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.elements![0].representations![0].colour).toBe("#2ecc71");
+  });
+
+  it("recognises by-domain pipe-delimited args", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [
+            {
+              style: "CRs",
+              visible: true,
+              colourRules: [
+                {
+                  ruleType: "by-domain",
+                  isMultiColourRule: true,
+                  args: ["//A/1-120^#4b8bbe|//A/121-130^#f1c40f|//A/131-300^#e74c3c"],
+                } as unknown as moorhen.ColourRule,
+              ],
+            } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.elements![0].representations![0].colour).toBe("by-domain");
+  });
+
+  it("falls back to the raw escape hatch for unrecognised rules", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [
+            {
+              style: "CRs",
+              visible: true,
+              colourRules: [
+                {
+                  ruleType: "some-bespoke-thing",
+                  isMultiColourRule: true,
+                  args: ["weird", 42],
+                  applyColourToNonCarbonAtoms: true,
+                } as unknown as moorhen.ColourRule,
+              ],
+            } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.elements![0].representations![0].colour).toEqual({
+      raw: {
+        ruleType: "some-bespoke-thing",
+        args: ["weird", 42],
+        isMultiColourRule: true,
+        applyColourToNonCarbonAtoms: true,
+      },
+    });
+  });
+
+  it("round-trips: lift → serialise → parse produces an equivalent scene", () => {
+    const lifted = liftScene({
+      molecules: [
+        fakeMol({
+          name: "thing",
+          molNo: 0,
+          uniqueId: "/api/proxy/ccp4i2/files/42/download/",
+          representations: [
+            {
+              style: "CRs",
+              cid: "//A",
+              visible: true,
+              colourRules: [{ ruleType: "b-factor", isMultiColourRule: true, args: [] } as unknown as moorhen.ColourRule],
+            } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+      projectId: "p",
+      sceneName: "rt",
+    });
+    const yaml = serialiseScene(lifted);
+    const parsed = parseScene(yaml);
+    expect(parsed.scene).toBe("rt");
+    expect(parsed.files![0]).toMatchObject({ name: "thing", fileId: 42, projectId: "p" });
+    expect(parsed.elements![0].representations![0]).toEqual({
+      style: "CRs",
+      selection: "//A",
+      colour: "b-factor",
+    });
+  });
+});
+
+describe("serialiseSceneWithComments", () => {
+  it("attaches a per-file comment above the corresponding entry", () => {
+    const { scene, hints } = liftSceneWithHints({
+      molecules: [
+        fakeMol({
+          name: "thing",
+          molNo: 0,
+          uniqueId: "https://example.org/foo.pdb",
+          representations: [{ style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const yaml = serialiseSceneWithComments(scene, hints.fileComments);
+    expect(yaml).toContain("# loaded from https://example.org/foo.pdb");
+    // And it still parses cleanly.
+    expect(() => parseScene(yaml)).not.toThrow();
+  });
+
+  it("falls back to plain serialisation when there are no comments", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [{ style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const withComments = serialiseSceneWithComments(scene, {});
+    const plain = serialiseScene(scene);
+    expect(withComments).toBe(plain);
+  });
+});
+
+describe("liftScene — dictionary lifting", () => {
+  it("emits a kind: dictionary file ref for each non-standard ligand", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "complex",
+          molNo: 0,
+          uniqueId: "/api/proxy/ccp4i2/files/482/download/",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+          ligands: [
+            { resName: "LIG", chainName: "A", resNum: "401" } as Partial<moorhen.LigandInfo>,
+          ],
+          dicts: {
+            LIG: "data_comp_LIG\n_chem_comp.id LIG\n",
+          },
+        }),
+      ],
+      glRef: fakeGlRef,
+      projectId: "p-uuid",
+    });
+
+    expect(scene.files).toHaveLength(2); // complex + dict
+    const dictRef = scene.files!.find((f) => f.kind === "dictionary");
+    expect(dictRef).toBeDefined();
+    expect(dictRef!.cifText).toContain("data_comp_LIG");
+    // Element should reference the dict by name.
+    expect(scene.elements![0].dictionaries).toEqual([dictRef!.name]);
+  });
+
+  it("skips standard amino acids and water", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "protein",
+          molNo: 0,
+          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+          ligands: [
+            { resName: "HOH" } as Partial<moorhen.LigandInfo>,
+            { resName: "ALA" } as Partial<moorhen.LigandInfo>,
+            { resName: "GLU" } as Partial<moorhen.LigandInfo>,
+          ],
+          dicts: {
+            HOH: "data_comp_HOH\n",
+            ALA: "data_comp_ALA\n",
+            GLU: "data_comp_GLU\n",
+          },
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    // Only one file (the coords), no dict refs.
+    expect(scene.files).toHaveLength(1);
+    expect(scene.files![0].kind).toBeUndefined();
+  });
+
+  it("dedupes by comp_id across multiple ligand instances", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "complex",
+          molNo: 0,
+          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+          ligands: [
+            { resName: "LIG", resNum: "401" } as Partial<moorhen.LigandInfo>,
+            { resName: "LIG", resNum: "402" } as Partial<moorhen.LigandInfo>,
+            { resName: "LIG", resNum: "403" } as Partial<moorhen.LigandInfo>,
+          ],
+          dicts: { LIG: "data_comp_LIG\n" },
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const dictRefs = scene.files!.filter((f) => f.kind === "dictionary");
+    expect(dictRefs).toHaveLength(1);
+  });
+
+  it("emits separate dict refs for two molecules with same-named ligands", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "complex-A",
+          molNo: 0,
+          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+          ligands: [{ resName: "LIG" } as Partial<moorhen.LigandInfo>],
+          dicts: { LIG: "data_comp_LIG\nA chemistry\n" },
+        }),
+        fakeMol({
+          name: "complex-B",
+          molNo: 1,
+          uniqueId: "/api/proxy/ccp4i2/files/200/download/",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+          ligands: [{ resName: "LIG" } as Partial<moorhen.LigandInfo>],
+          dicts: { LIG: "data_comp_LIG\nB chemistry\n" },
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const dictRefs = scene.files!.filter((f) => f.kind === "dictionary");
+    expect(dictRefs).toHaveLength(2);
+    // Different dict bodies — that's the whole point of per-molecule scoping.
+    expect(dictRefs[0].cifText).toContain("A chemistry");
+    expect(dictRefs[1].cifText).toContain("B chemistry");
+    // Each element references its own dict.
+    expect(scene.elements![0].dictionaries).toEqual([dictRefs[0].name]);
+    expect(scene.elements![1].dictionaries).toEqual([dictRefs[1].name]);
+  });
+
+  it("skips non-standard ligands when no dict is stored on the molecule", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "complex",
+          molNo: 0,
+          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+          ligands: [{ resName: "MYS" } as Partial<moorhen.LigandInfo>],
+          // No dicts entry for MYS — getDict returns "" so we skip emission.
+          dicts: {},
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const dictRefs = scene.files!.filter((f) => f.kind === "dictionary");
+    expect(dictRefs).toHaveLength(0);
+  });
+});

--- a/client/renderer/__tests__/moorhen-scene-resolver.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-resolver.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the residue-range clamping logic in the scene resolver.
+ *
+ * The rest of the resolver touches Moorhen runtime objects (molecules,
+ * Redux dispatch, ColourRule construction) and is exercised end-to-end
+ * via manual verification in the browser. The clamp logic is pure and
+ * the most failure-prone bit, so it's worth a focused unit test.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  clampRangeToPresent,
+  expandLsqMatches,
+  isFetchable,
+  resolveChainSelector,
+  splitMultiCid,
+} from "../lib/moorhen-scene-resolver";
+
+const present = (...nums: number[]) => new Set(nums);
+
+describe("clampRangeToPresent", () => {
+  it("returns the request unchanged when all residues are present", () => {
+    const p = present(1, 2, 3, 4, 5);
+    expect(clampRangeToPresent(1, 5, p)).toEqual([[1, 5]]);
+  });
+
+  it("clamps the start inward when leading residues are missing", () => {
+    const p = present(5, 6, 7, 8, 9, 10);
+    expect(clampRangeToPresent(1, 10, p)).toEqual([[5, 10]]);
+  });
+
+  it("clamps the end inward when trailing residues are missing", () => {
+    const p = present(1, 2, 3, 4, 5);
+    expect(clampRangeToPresent(1, 10, p)).toEqual([[1, 5]]);
+  });
+
+  it("splits across internal gaps", () => {
+    const p = present(1, 2, 3, 7, 8, 9);
+    expect(clampRangeToPresent(1, 10, p)).toEqual([
+      [1, 3],
+      [7, 9],
+    ]);
+  });
+
+  it("returns empty when no requested residue is present", () => {
+    const p = present(50, 51, 52);
+    expect(clampRangeToPresent(1, 10, p)).toEqual([]);
+  });
+
+  it("handles a single-residue request", () => {
+    expect(clampRangeToPresent(42, 42, present(42))).toEqual([[42, 42]]);
+    expect(clampRangeToPresent(42, 42, present(41, 43))).toEqual([]);
+  });
+
+  it("handles multiple gaps", () => {
+    const p = present(1, 2, 4, 5, 7, 9, 10);
+    expect(clampRangeToPresent(1, 10, p)).toEqual([
+      [1, 2],
+      [4, 5],
+      [7, 7],
+      [9, 10],
+    ]);
+  });
+
+  it("handles a request narrower than the present set", () => {
+    const p = present(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    expect(clampRangeToPresent(3, 6, p)).toEqual([[3, 6]]);
+  });
+});
+
+describe("resolveChainSelector", () => {
+  const presentByChain = new Map<string, Set<number>>([
+    ["A", present(1, 2)],
+    ["B", present(1, 2)],
+    ["C", present(1, 2)],
+  ]);
+
+  it("returns a single-element array for a non-wildcard string", () => {
+    expect(resolveChainSelector("A", presentByChain)).toEqual(["A"]);
+  });
+
+  it('expands "*" to every present chain, sorted', () => {
+    expect(resolveChainSelector("*", presentByChain)).toEqual(["A", "B", "C"]);
+  });
+
+  it('returns empty for "*" against an unloaded molecule', () => {
+    expect(resolveChainSelector("*", new Map())).toEqual([]);
+  });
+
+  it("returns explicit lists verbatim", () => {
+    expect(resolveChainSelector(["B", "A"], presentByChain)).toEqual(["B", "A"]);
+  });
+
+  it("preserves single-chain references to chains not present", () => {
+    // The resolver is responsible for surfacing absent-chain errors later;
+    // selector resolution only decides which chains we're targeting.
+    expect(resolveChainSelector("Z", presentByChain)).toEqual(["Z"]);
+  });
+});
+
+describe("isFetchable", () => {
+  it("returns true for a pdb: ref", () => {
+    expect(isFetchable({ name: "x", pdb: "1m17" })).toBe(true);
+  });
+
+  it("returns true for a url: ref", () => {
+    expect(isFetchable({ name: "x", url: "https://example.com/foo.cif" })).toBe(true);
+  });
+
+  it("returns true for a fileId + projectId ref", () => {
+    expect(
+      isFetchable({ name: "x", fileId: 42, projectId: "uuid" }),
+    ).toBe(true);
+  });
+
+  it("returns false for a fileId without projectId", () => {
+    expect(isFetchable({ name: "x", fileId: 42 })).toBe(false);
+  });
+
+  it("returns false for a path-only ref (we don't read local paths from the browser)", () => {
+    expect(isFetchable({ name: "x", path: "/abs/foo.pdb" })).toBe(false);
+  });
+
+  it("returns false for an empty ref", () => {
+    expect(isFetchable({ name: "x" })).toBe(false);
+  });
+});
+
+describe("expandLsqMatches", () => {
+  it("expands chain+range shorthand into a single same-on-both-sides match", () => {
+    expect(expandLsqMatches({ chain: "A", range: "104-260" })).toEqual([
+      { refChain: "A", movChain: "A", refRange: "104-260", movRange: "104-260" },
+    ]);
+  });
+
+  it("returns explicit matches verbatim when no shorthand is set", () => {
+    const matches = [
+      { refChain: "A", refRange: "1-100", movChain: "A", movRange: "1-100" },
+      { refChain: "B", refRange: "50-150", movChain: "B", movRange: "60-160" },
+    ];
+    expect(expandLsqMatches({ matches })).toEqual(matches);
+  });
+
+  it("prefers the shorthand when both are present (shouldn't happen — validator rejects this)", () => {
+    // Defensive: if the validator ever lets both through, shorthand wins
+    // because that's the more specific instruction.
+    const result = expandLsqMatches({
+      chain: "A",
+      range: "104-260",
+      matches: [
+        { refChain: "B", refRange: "1-50", movChain: "B", movRange: "1-50" },
+      ],
+    });
+    expect(result).toEqual([
+      { refChain: "A", movChain: "A", refRange: "104-260", movRange: "104-260" },
+    ]);
+  });
+
+  it("returns an empty list when neither shorthand nor matches is set", () => {
+    expect(expandLsqMatches({})).toEqual([]);
+  });
+});
+
+describe("splitMultiCid", () => {
+  it("returns a single-element array for a plain CID", () => {
+    expect(splitMultiCid("//A/100-200")).toEqual(["//A/100-200"]);
+  });
+
+  it("splits a ||-joined multi-CID into chunks", () => {
+    expect(splitMultiCid("//A/115||//A/116||//A/121-122")).toEqual([
+      "//A/115",
+      "//A/116",
+      "//A/121-122",
+    ]);
+  });
+
+  it("trims whitespace and drops empty chunks", () => {
+    expect(splitMultiCid("//A/1 ||  //A/2 ||  || //A/3")).toEqual([
+      "//A/1",
+      "//A/2",
+      "//A/3",
+    ]);
+  });
+
+  it("returns the wildcard verbatim", () => {
+    expect(splitMultiCid("/*/*/*/*")).toEqual(["/*/*/*/*"]);
+  });
+
+  it("returns [] for an all-empty multi-CID", () => {
+    expect(splitMultiCid("||||")).toEqual([]);
+  });
+});

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -569,7 +569,7 @@ version: 1
 files:
   - { name: f, kind: weird, url: https://example/f.cif }
 `;
-    expect(() => parseScene(yaml)).toThrow(/must be "coordinates" or "dictionary"/);
+    expect(() => parseScene(yaml)).toThrow(/must be "coordinates", "dictionary", or "mtz"/);
   });
 
   it("rejects pdb: on a dictionary ref (pdb makes no sense for dicts)", () => {
@@ -831,5 +831,183 @@ superpose:
     const scene = parseScene(yaml);
     const sp = scene.superpose![0] as { range: string };
     expect(sp.range).toBe("200-200");
+  });
+});
+
+describe("parseScene — maps block", () => {
+  it("parses a minimal MTZ map", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/best.mtz
+maps:
+  - name: best
+    file: mtz1
+    columns: { F: FWT, PHI: PHWT }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.maps).toHaveLength(1);
+    expect(scene.maps![0]).toMatchObject({
+      name: "best",
+      file: "mtz1",
+      columns: { F: "FWT", PHI: "PHWT" },
+    });
+  });
+
+  it("captures full render state and difference-map colours", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/diff.mtz
+maps:
+  - name: fofc
+    file: mtz1
+    columns: { F: DELFWT, PHI: PHDELWT }
+    isDifference: true
+    contourLevel: 3.2
+    radius: 17.5
+    alpha: 0.85
+    style: solid
+    positiveColour: "#00ff00"
+    negativeColour: "#ff0000aa"
+    visible: false
+activeMap: fofc
+`;
+    const scene = parseScene(yaml);
+    expect(scene.maps![0]).toMatchObject({
+      isDifference: true,
+      contourLevel: 3.2,
+      radius: 17.5,
+      alpha: 0.85,
+      style: "solid",
+      positiveColour: "#00ff00",
+      negativeColour: "#ff0000aa",
+      visible: false,
+    });
+    expect(scene.activeMap).toBe("fofc");
+  });
+
+  it("rejects a map referencing a non-existent file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/best.mtz
+maps:
+  - name: best
+    file: nope
+    columns: { F: FWT, PHI: PHWT }
+`;
+    expect(() => parseScene(yaml)).toThrow(/unknown file "nope"/);
+  });
+
+  it("rejects a map pointing at a coord file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: coords
+    url: https://example/model.pdb
+maps:
+  - name: best
+    file: coords
+    columns: { F: FWT, PHI: PHWT }
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be a file with kind: "mtz"/);
+  });
+
+  it("rejects a map without F+PHI (and no calcStructFact)", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/best.mtz
+maps:
+  - name: best
+    file: mtz1
+    columns: { F: FWT }
+`;
+    expect(() => parseScene(yaml)).toThrow(/must set F \+ PHI/);
+  });
+
+  it("accepts calcStructFact when Fobs+SigFobs are supplied", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/data.mtz
+maps:
+  - name: calc
+    file: mtz1
+    columns: { Fobs: FP, SigFobs: SIGFP, FreeR: FREE, calcStructFact: true }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.maps![0].columns.calcStructFact).toBe(true);
+  });
+
+  it("rejects an unknown style", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/best.mtz
+maps:
+  - name: best
+    file: mtz1
+    columns: { F: FWT, PHI: PHWT }
+    style: chunky
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be "lines", "solid", or "lit-lines"/);
+  });
+
+  it("rejects activeMap referencing a non-existent entry", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/best.mtz
+maps:
+  - name: best
+    file: mtz1
+    columns: { F: FWT, PHI: PHWT }
+activeMap: missing
+`;
+    expect(() => parseScene(yaml)).toThrow(/does not name any entry in maps:/);
+  });
+
+  it("round-trips maps through serialise → parse", async () => {
+    const { serialiseScene } = await import("../lib/moorhen-scene");
+    const scene = parseScene(`scene: round
+version: 1
+files:
+  - name: mtz1
+    kind: mtz
+    url: https://example/best.mtz
+maps:
+  - name: best
+    file: mtz1
+    columns: { F: FWT, PHI: PHWT }
+    contourLevel: 1.2
+    colour: "#336699"
+activeMap: best
+`);
+    const yaml = serialiseScene(scene);
+    const parsed = parseScene(yaml);
+    expect(parsed.maps![0]).toMatchObject({
+      name: "best",
+      file: "mtz1",
+      columns: { F: "FWT", PHI: "PHWT" },
+      contourLevel: 1.2,
+      colour: "#336699",
+    });
+    expect(parsed.activeMap).toBe("best");
   });
 });

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -1,0 +1,835 @@
+/**
+ * Moorhen Scene parser / serialiser tests.
+ *
+ * The point of these tests is to lock down the format itself —
+ * what's valid, what isn't, and that a scene survives round-trip
+ * (parse → serialise → re-parse → deep-equal). The lifter (Moorhen state
+ * → scene) and the resolver (scene → Moorhen session) are tested
+ * separately and are not exercised here.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  parseScene,
+  serialiseScene,
+  validateScene,
+  SceneParseError,
+} from "../lib/moorhen-scene";
+import {
+  MoorhenScene,
+  SCENE_SCHEMA_VERSION,
+} from "../types/moorhen-scene";
+
+// --------------------------------------------------------------------------
+// Worked example: matches the design conversation.
+// --------------------------------------------------------------------------
+
+const KINASE_YAML = `scene: kinase-domain-view
+version: 1
+authoredIn:
+  projectId: 3f8a-aaaa-bbbb-cccc-uuid
+  projectName: kinase-2026
+  createdAt: 2026-05-22T14:30:00Z
+  createdBy: martin.noble@ncl.ac.uk
+files:
+  - name: protein
+    projectId: 3f8a-aaaa-bbbb-cccc-uuid
+    projectName: kinase-2026
+    job: 14
+    param: XYZOUT
+  - name: reference
+    url: https://ddudatabase/api/ccp4i2/fileBy/abc
+  - name: external
+    path: /abs/path/to/foo.pdb
+domains:
+  - name: N-lobe
+    chain: A
+    range: 1-120
+    color: "#4b8bbe"
+  - name: hinge
+    chain: A
+    range: 121-130
+    color: "#f1c40f"
+  - name: C-lobe
+    chain: A
+    range: 131-300
+    color: "#e74c3c"
+elements:
+  - file: protein
+    representations:
+      - style: CRs
+        selection: //A
+        colour: by-domain
+      - style: ligands
+        selection: //*/LIG
+        colour: "#2ecc71"
+view:
+  origin: [10.5, 20.0, -5.25]
+  quat: [0, 0, 0, -1]
+  zoom: 1.5
+resolver:
+  onMissingResidues: clamp-and-log
+`;
+
+describe("Moorhen scene — worked kinase example", () => {
+  it("parses the example without errors", () => {
+    const scene = parseScene(KINASE_YAML);
+    expect(scene.scene).toBe("kinase-domain-view");
+    expect(scene.version).toBe(SCENE_SCHEMA_VERSION);
+    expect(scene.authoredIn?.projectName).toBe("kinase-2026");
+    expect(scene.files).toHaveLength(3);
+    expect(scene.files![0]).toMatchObject({
+      name: "protein",
+      job: 14,
+      param: "XYZOUT",
+      projectId: "3f8a-aaaa-bbbb-cccc-uuid",
+    });
+    expect(scene.domains).toHaveLength(3);
+    expect(scene.domains![1]).toEqual({
+      name: "hinge",
+      chain: "A",
+      range: "121-130",
+      color: "#f1c40f",
+    });
+    expect(scene.elements).toHaveLength(1);
+    expect(scene.elements![0].representations).toHaveLength(2);
+    expect(scene.elements![0].representations![0].colour).toBe("by-domain");
+    expect(scene.elements![0].representations![1].colour).toBe("#2ecc71");
+    expect(scene.view?.origin).toEqual([10.5, 20.0, -5.25]);
+    expect(scene.resolver?.onMissingResidues).toBe("clamp-and-log");
+  });
+
+  it("round-trips: parse → serialise → re-parse is stable", () => {
+    const first = parseScene(KINASE_YAML);
+    const yaml = serialiseScene(first);
+    const second = parseScene(yaml);
+    expect(second).toEqual(first);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Validation: each error class.
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — validation errors", () => {
+  it("rejects non-mapping root", () => {
+    expect(() => parseScene("- not a map")).toThrow(SceneParseError);
+  });
+
+  it("rejects wrong schema version", () => {
+    const yaml = `scene: x\nversion: 99\n`;
+    expect(() => parseScene(yaml)).toThrow(/unsupported scene version 99/);
+  });
+
+  it("rejects a file ref with no resolution method", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: orphan\n`;
+    expect(() => parseScene(yaml)).toThrow(
+      /must set one of: pdb, url, path, bundle, fileId/,
+    );
+  });
+
+  it("accepts a pdb: file ref with a 4-char id", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: structure\n    pdb: 1m17\n`;
+    const scene = parseScene(yaml);
+    expect(scene.files![0].pdb).toBe("1m17");
+  });
+
+  it("accepts a pdb: file ref with an extended id", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: s\n    pdb: pdb_00001m17\n`;
+    expect(() => parseScene(yaml)).not.toThrow();
+  });
+
+  it("rejects an obviously malformed pdb id", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: s\n    pdb: my-favourite-protein\n`;
+    expect(() => parseScene(yaml)).toThrow(/does not look like a PDB ID/);
+  });
+
+  it("requires projectId when fileId is set", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: f\n    fileId: 42\n`;
+    expect(() => parseScene(yaml)).toThrow(
+      /projectId.*required when fileId or job\+param is set/,
+    );
+  });
+
+  it("requires job and param to be set together", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: f\n    projectId: p\n    job: 14\n`;
+    expect(() => parseScene(yaml)).toThrow(/job and param must be set together/);
+  });
+
+  it("rejects duplicate file names", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: a\n    url: u1\n  - name: a\n    url: u2\n`;
+    expect(() => parseScene(yaml)).toThrow(/duplicate file name "a"/);
+  });
+
+  it("rejects malformed residue range", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - name: d\n    chain: A\n    range: not-a-range\n    color: "#ffffff"\n`;
+    expect(() => parseScene(yaml)).toThrow(/must be "start-end"/);
+  });
+
+  it("rejects reversed residue range", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - name: d\n    chain: A\n    range: 100-50\n    color: "#ffffff"\n`;
+    expect(() => parseScene(yaml)).toThrow(/end \(50\) must be >= start \(100\)/);
+  });
+
+  it("rejects non-hex domain colour", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - name: d\n    chain: A\n    range: 1-10\n    color: red\n`;
+    expect(() => parseScene(yaml)).toThrow(/must be hex like "#rrggbb"/);
+  });
+
+  it("rejects an element referencing an unknown file", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: a\n    url: u\nelements:\n  - file: b\n`;
+    expect(() => parseScene(yaml)).toThrow(/unknown file "b"/);
+  });
+
+  it("rejects unknown named colour", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: a\n    url: u\nelements:\n  - file: a\n    representations:\n      - style: CRs\n        colour: by-something-weird\n`;
+    expect(() => parseScene(yaml)).toThrow(/unknown colour "by-something-weird"/);
+  });
+
+  it("accepts the raw colour escape hatch", () => {
+    const yaml = `scene: x\nversion: 1\nfiles:\n  - name: a\n    url: u\nelements:\n  - file: a\n    representations:\n      - style: CRs\n        colour:\n          raw:\n            ruleType: custom\n            args: ["//A/1-50^#ff0000", 42]\n            isMultiColourRule: true\n`;
+    const scene = parseScene(yaml);
+    const c = scene.elements![0].representations![0].colour;
+    expect(c).toEqual({
+      raw: {
+        ruleType: "custom",
+        args: ["//A/1-50^#ff0000", 42],
+        isMultiColourRule: true,
+        applyColourToNonCarbonAtoms: undefined,
+      },
+    });
+  });
+
+  it("rejects bad resolver policy", () => {
+    const yaml = `scene: x\nversion: 1\nresolver:\n  onMissingResidues: pretend-they-exist\n`;
+    expect(() => parseScene(yaml)).toThrow(
+      /must be "clamp-and-log" or "strict"/,
+    );
+  });
+
+  it("collects multiple errors in a single pass", () => {
+    const yaml = `scene: ""\nversion: 1\ndomains:\n  - name: d\n    chain: A\n    range: oops\n    color: red\n`;
+    const { errors } = validateScene({
+      scene: "x",
+      version: 1,
+      domains: [{ name: "d", chain: "A", range: "oops", color: "red" }],
+    });
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+    expect(errors.map((e) => e.path)).toEqual(
+      expect.arrayContaining(["domains[0].range", "domains[0].color"]),
+    );
+  });
+});
+
+// --------------------------------------------------------------------------
+// Serialisation: omits empty/undefined fields for stable round-trip.
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — serialiser canonicalisation", () => {
+  it("omits empty top-level blocks", () => {
+    const scene: MoorhenScene = { scene: "minimal", version: 1 };
+    const yaml = serialiseScene(scene);
+    expect(yaml).toContain("scene: minimal");
+    expect(yaml).toContain("version: 1");
+    expect(yaml).not.toContain("files:");
+    expect(yaml).not.toContain("domains:");
+    expect(yaml).not.toContain("elements:");
+    expect(yaml).not.toContain("view:");
+    expect(yaml).not.toContain("resolver:");
+    expect(yaml).not.toContain("authoredIn:");
+  });
+
+  it("omits undefined fields inside authoredIn", () => {
+    const scene: MoorhenScene = {
+      scene: "x",
+      version: 1,
+      authoredIn: { projectName: "only-this" },
+    };
+    const yaml = serialiseScene(scene);
+    expect(yaml).toContain("projectName: only-this");
+    expect(yaml).not.toContain("projectId:");
+    expect(yaml).not.toContain("createdAt:");
+  });
+
+  it("preserves field order: scene, version, authoredIn, files, domains, elements, view, resolver", () => {
+    const scene = parseScene(KINASE_YAML);
+    const yaml = serialiseScene(scene);
+    const order = [
+      "scene:",
+      "version:",
+      "authoredIn:",
+      "files:",
+      "domains:",
+      "elements:",
+      "view:",
+      "resolver:",
+    ].map((k) => yaml.indexOf(k));
+    for (let i = 1; i < order.length; i++) {
+      expect(order[i]).toBeGreaterThan(order[i - 1]);
+    }
+  });
+});
+
+// --------------------------------------------------------------------------
+// chain: extended forms (string | "*" | array)
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — chain field forms", () => {
+  it("accepts a single-string chain (the legacy form)", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: A, range: 1-10, color: "#ffffff" }\n`;
+    const scene = parseScene(yaml);
+    expect(scene.domains![0].chain).toBe("A");
+  });
+
+  it('accepts "*" as a wildcard chain string', () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: "*", range: 1-10, color: "#ffffff" }\n`;
+    const scene = parseScene(yaml);
+    expect(scene.domains![0].chain).toBe("*");
+  });
+
+  it("accepts a chain list", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: [A, B, C], range: 1-10, color: "#ffffff" }\n`;
+    const scene = parseScene(yaml);
+    expect(scene.domains![0].chain).toEqual(["A", "B", "C"]);
+  });
+
+  it("rejects an empty chain list", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: [], range: 1-10, color: "#ffffff" }\n`;
+    expect(() => parseScene(yaml)).toThrow(/chain list must not be empty/);
+  });
+
+  it("rejects a chain list with non-string entries", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: [A, 42], range: 1-10, color: "#ffffff" }\n`;
+    expect(() => parseScene(yaml)).toThrow(/chain list entries must all be strings/);
+  });
+
+  it("rejects a chain field of the wrong type", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: 42, range: 1-10, color: "#ffffff" }\n`;
+    expect(() => parseScene(yaml)).toThrow(/must be a string or sequence of strings/);
+  });
+
+  it("round-trips a wildcard and a list through serialise → parse", () => {
+    const yaml = `scene: x\nversion: 1\ndomains:\n  - { name: a, chain: "*",     range: 1-10,  color: "#ffffff" }\n  - { name: b, chain: [A, B],   range: 11-20, color: "#000000" }\n`;
+    const first = parseScene(yaml);
+    const second = parseScene(serialiseScene(first));
+    expect(second).toEqual(first);
+  });
+});
+
+// --------------------------------------------------------------------------
+// superpose: block
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — superpose block", () => {
+  it("accepts an SSM entry referencing two files", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: apo,  pdb: 1m17 }
+  - { name: holo, pdb: 1m14 }
+superpose:
+  - { method: ssm, move: holo, onto: apo, movChain: A, refChain: A }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.superpose).toHaveLength(1);
+    expect(scene.superpose![0]).toEqual({
+      method: "ssm",
+      move: "holo",
+      onto: "apo",
+      movChain: "A",
+      refChain: "A",
+    });
+  });
+
+  it("accepts an LSQ entry with explicit residue matches", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: ref, pdb: 1m17 }
+  - { name: mov, pdb: 1m14 }
+superpose:
+  - method: lsq
+    move: mov
+    onto: ref
+    matches:
+      - { refChain: A, refRange: 1-100, movChain: A, movRange: 1-100 }
+      - { refChain: B, refRange: 50-150, movChain: B, movRange: 60-160 }
+    matchType: ca
+`;
+    const scene = parseScene(yaml);
+    expect(scene.superpose![0]).toEqual({
+      method: "lsq",
+      move: "mov",
+      onto: "ref",
+      matchType: "ca",
+      matches: [
+        { refChain: "A", refRange: "1-100", movChain: "A", movRange: "1-100" },
+        { refChain: "B", refRange: "50-150", movChain: "B", movRange: "60-160" },
+      ],
+    });
+  });
+
+  it("rejects an unknown method", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: tm-align, move: b, onto: a }
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be "ssm" or "lsq"/);
+  });
+
+  it("rejects move == onto", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+superpose:
+  - { method: ssm, move: a, onto: a, movChain: A, refChain: A }
+`;
+    expect(() => parseScene(yaml)).toThrow(/cannot superpose a file onto itself/);
+  });
+
+  it("rejects an SSM entry missing movChain", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: ssm, move: b, onto: a, refChain: A }
+`;
+    expect(() => parseScene(yaml)).toThrow(/movChain.*required for ssm/);
+  });
+
+  it("rejects an LSQ entry missing matches", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: lsq, move: b, onto: a }
+`;
+    expect(() => parseScene(yaml)).toThrow(/matches.*required for lsq/);
+  });
+
+  it("rejects an LSQ entry with empty matches", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: lsq, move: b, onto: a, matches: [] }
+`;
+    expect(() => parseScene(yaml)).toThrow(/at least one match entry/);
+  });
+
+  it("rejects a malformed residue range in an LSQ match", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - method: lsq
+    move: b
+    onto: a
+    matches:
+      - { refChain: A, refRange: oops, movChain: A, movRange: 1-100 }
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be "start-end"/);
+  });
+
+  it("rejects superpose entries referencing unknown file names", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+superpose:
+  - { method: ssm, move: ghost, onto: a, movChain: A, refChain: A }
+`;
+    expect(() => parseScene(yaml)).toThrow(/unknown file "ghost"/);
+  });
+
+  it("round-trips an SSM entry through serialise → parse", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: apo,  pdb: 1m17 }
+  - { name: holo, pdb: 1m14 }
+superpose:
+  - { method: ssm, move: holo, onto: apo, movChain: A, refChain: A }
+`;
+    const first = parseScene(yaml);
+    const second = parseScene(serialiseScene(first));
+    expect(second.superpose).toEqual(first.superpose);
+  });
+
+  it("accepts the LSQ chain+range shorthand", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: lsq, move: b, onto: a, chain: A, range: 104-260 }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.superpose![0]).toEqual({
+      method: "lsq",
+      move: "b",
+      onto: "a",
+      chain: "A",
+      range: "104-260",
+    });
+  });
+
+  it("rejects mixing `matches` with the chain+range shorthand", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - method: lsq
+    move: b
+    onto: a
+    chain: A
+    range: 1-100
+    matches:
+      - { refChain: A, refRange: 1-100, movChain: A, movRange: 1-100 }
+`;
+    expect(() => parseScene(yaml)).toThrow(
+      /use either `matches` or the `chain`\+`range` shorthand/,
+    );
+  });
+
+  it("rejects a shorthand entry missing range", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: lsq, move: b, onto: a, chain: A }
+`;
+    expect(() => parseScene(yaml)).toThrow(/range.*required when chain is set/);
+  });
+
+  it("rejects a shorthand entry with a malformed range", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: lsq, move: b, onto: a, chain: A, range: nope }
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be "start-end"/);
+  });
+
+  it("round-trips a shorthand LSQ entry through serialise → parse", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: lsq, move: b, onto: a, chain: A, range: 104-260, matchType: main }
+`;
+    const first = parseScene(yaml);
+    const second = parseScene(serialiseScene(first));
+    expect(second.superpose).toEqual(first.superpose);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Dictionary scoping (kind: dictionary, globalDictionaries, element.dictionaries)
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — dictionary scoping", () => {
+  it("accepts a dictionary file ref with kind: dictionary", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: lig-A, kind: dictionary, url: https://example/dict-A.cif }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.files![0].kind).toBe("dictionary");
+    expect(scene.files![0].url).toBe("https://example/dict-A.cif");
+  });
+
+  it("rejects an unknown kind value", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: f, kind: weird, url: https://example/f.cif }
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be "coordinates" or "dictionary"/);
+  });
+
+  it("rejects pdb: on a dictionary ref (pdb makes no sense for dicts)", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: d, kind: dictionary, pdb: 1abc }
+`;
+    expect(() => parseScene(yaml)).toThrow(/pdb: is only valid for coordinate refs/);
+  });
+
+  it("accepts globalDictionaries referencing a dictionary file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: coords, pdb: 1abc }
+  - { name: cofactor, kind: dictionary, url: https://example/cof.cif }
+globalDictionaries: [cofactor]
+`;
+    const scene = parseScene(yaml);
+    expect(scene.globalDictionaries).toEqual(["cofactor"]);
+  });
+
+  it("rejects globalDictionaries referencing a non-dictionary file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: coords, pdb: 1abc }
+  - { name: other-coords, pdb: 1xyz }
+globalDictionaries: [other-coords]
+`;
+    expect(() => parseScene(yaml)).toThrow(
+      /file "other-coords" is not a dictionary/,
+    );
+  });
+
+  it("rejects globalDictionaries referencing an unknown file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: coords, pdb: 1abc }
+globalDictionaries: [missing]
+`;
+    expect(() => parseScene(yaml)).toThrow(/unknown file "missing"/);
+  });
+
+  it("accepts an element with dictionaries pointing at dict files", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: coords-A, pdb: 1abc }
+  - { name: lig-A, kind: dictionary, url: https://example/A.cif }
+elements:
+  - file: coords-A
+    dictionaries: [lig-A]
+    representations:
+      - { style: ligands, selection: "//*/LIG", colour: "#2ecc71" }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.elements![0].dictionaries).toEqual(["lig-A"]);
+  });
+
+  it("rejects an element.dictionaries referencing a non-dictionary file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: coords-A, pdb: 1abc }
+  - { name: coords-B, pdb: 1xyz }
+elements:
+  - file: coords-A
+    dictionaries: [coords-B]
+`;
+    expect(() => parseScene(yaml)).toThrow(
+      /file "coords-B" is not a dictionary/,
+    );
+  });
+
+  it("round-trips a scene with dicts through serialise → parse", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: coords-A, pdb: 1abc }
+  - { name: lig-A, kind: dictionary, url: https://example/A.cif }
+  - { name: cofactor, kind: dictionary, url: https://example/cof.cif }
+globalDictionaries: [cofactor]
+elements:
+  - file: coords-A
+    dictionaries: [lig-A]
+    representations:
+      - { style: ligands, selection: "//*/LIG", colour: "#2ecc71" }
+`;
+    const first = parseScene(yaml);
+    const second = parseScene(serialiseScene(first));
+    expect(second).toEqual(first);
+  });
+});
+
+describe("Moorhen scene — inline dict (cifText)", () => {
+  it("accepts a dictionary with cifText as its sole source", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: lig
+    kind: dictionary
+    cifText: |
+      data_comp_LIG
+      _chem_comp.id LIG
+`;
+    const scene = parseScene(yaml);
+    expect(scene.files![0].kind).toBe("dictionary");
+    expect(scene.files![0].cifText).toContain("data_comp_LIG");
+  });
+
+  it("rejects cifText on a coordinate ref", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: coords
+    cifText: some-cif-content
+`;
+    expect(() => parseScene(yaml)).toThrow(
+      /cifText: is only valid for dictionary refs/,
+    );
+  });
+
+  it("includes cifText in the must-set-one-of message", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: orphan
+    kind: dictionary
+`;
+    expect(() => parseScene(yaml)).toThrow(
+      /must set one of:.*cifText/,
+    );
+  });
+
+  it("round-trips an inline-dict scene", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: coords-A
+    pdb: 1abc
+  - name: lig
+    kind: dictionary
+    cifText: |
+      data_comp_LIG
+      _chem_comp.id LIG
+elements:
+  - file: coords-A
+    dictionaries: [lig]
+`;
+    const first = parseScene(yaml);
+    const second = parseScene(serialiseScene(first));
+    expect(second).toEqual(first);
+  });
+});
+
+describe("Moorhen scene — bundle refs", () => {
+  it("accepts a coord file ref whose only source is bundle:", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: complex, bundle: assets/complex.pdb }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.files![0].bundle).toBe("assets/complex.pdb");
+  });
+
+  it("accepts a dictionary ref whose only source is bundle:", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: lig, kind: dictionary, bundle: assets/lig.cif }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.files![0].kind).toBe("dictionary");
+    expect(scene.files![0].bundle).toBe("assets/lig.cif");
+  });
+
+  it("round-trips a full bundle scene", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: complex, bundle: assets/complex.pdb }
+  - { name: lig,     kind: dictionary, bundle: assets/lig.cif }
+elements:
+  - file: complex
+    dictionaries: [lig]
+    representations:
+      - { style: ligands, selection: "//*/LIG", colour: "#2ecc71" }
+`;
+    const first = parseScene(yaml);
+    const second = parseScene(serialiseScene(first));
+    expect(second).toEqual(first);
+  });
+});
+
+describe("Moorhen scene — bare-int residue ranges", () => {
+  it("accepts a bare integer in a domain range and normalises to N-N", () => {
+    const yaml = `scene: x
+version: 1
+domains:
+  - { name: catalytic, chain: A, range: 115, color: "#e74c3c" }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.domains![0].range).toBe("115-115");
+  });
+
+  it("still accepts the string form for domain range", () => {
+    const yaml = `scene: x
+version: 1
+domains:
+  - { name: helix, chain: A, range: 100-130, color: "#e74c3c" }
+`;
+    const scene = parseScene(yaml);
+    expect(scene.domains![0].range).toBe("100-130");
+  });
+
+  it("rejects a non-integer number as range", () => {
+    // Floats and other numeric oddities shouldn't sneak through —
+    // residues are integers.
+    const yaml = `scene: x
+version: 1
+domains:
+  - { name: d, chain: A, range: 1.5, color: "#e74c3c" }
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be a string or integer/);
+  });
+
+  it("accepts bare ints in lsq match refRange/movRange", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - method: lsq
+    move: b
+    onto: a
+    matches:
+      - { refChain: A, refRange: 100, movChain: A, movRange: 100 }
+`;
+    const scene = parseScene(yaml);
+    const sp = scene.superpose![0] as { matches: { refRange: string; movRange: string }[] };
+    expect(sp.matches[0].refRange).toBe("100-100");
+    expect(sp.matches[0].movRange).toBe("100-100");
+  });
+
+  it("accepts a bare int in the lsq chain+range shorthand", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - { name: a, pdb: 1m17 }
+  - { name: b, pdb: 1m14 }
+superpose:
+  - { method: lsq, move: b, onto: a, chain: A, range: 200 }
+`;
+    const scene = parseScene(yaml);
+    const sp = scene.superpose![0] as { range: string };
+    expect(sp.range).toBe("200-200");
+  });
+});

--- a/client/renderer/app/api/proxy/pdbe/[...path]/route.ts
+++ b/client/renderer/app/api/proxy/pdbe/[...path]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * PDBe Proxy Route
+ *
+ * /api/proxy/pdbe/* -> https://www.ebi.ac.uk/pdbe/*
+ *
+ * Why this exists: the Moorhen viewer needs SharedArrayBuffer, so the
+ * pages serving it carry `Cross-Origin-Embedder-Policy: require-corp`.
+ * Under COEP, the browser blocks any cross-origin fetch whose response
+ * does not advertise `Cross-Origin-Resource-Policy: cross-origin`. The
+ * PDBe API and its `entry-files` download host both send permissive
+ * CORS but neither sends CORP — so direct browser fetches fail with
+ * the famously opaque `TypeError: Failed to fetch`.
+ *
+ * This route re-emits the upstream response with `Cross-Origin-Resource-
+ * Policy: cross-origin` added, which satisfies COEP.
+ *
+ * Covers everything under /pdbe/ — `/pdbe/api/pdb/entry/files/{pdbId}`
+ * (the JSON metadata) and `/pdbe/entry-files/download/{pdbId}.cif`
+ * (the actual coords) both flow through here.
+ *
+ * Constraint: this proxy never sends anything from the user's local
+ * structures to PDBe. It only forwards the URL path and query string.
+ */
+
+const UPSTREAM = "https://www.ebi.ac.uk/pdbe";
+
+async function proxy(
+  req: NextRequest,
+  params: Promise<{ path: string[] }>,
+  method: "GET" | "HEAD",
+) {
+  const { path } = await params;
+  const subPath = path ? path.join("/") : "";
+  const search = req.nextUrl.searchParams.toString();
+  const queryString = search ? `?${search}` : "";
+  const targetUrl = `${UPSTREAM}/${subPath}${queryString}`;
+
+  try {
+    const res = await fetch(targetUrl, { method, redirect: "follow" });
+    const body = method === "HEAD" ? null : await res.arrayBuffer();
+
+    const headers = new Headers();
+    const contentType = res.headers.get("Content-Type");
+    if (contentType) headers.set("Content-Type", contentType);
+    const contentLength = res.headers.get("Content-Length");
+    if (contentLength) headers.set("Content-Length", contentLength);
+    headers.set("Cross-Origin-Resource-Policy", "cross-origin");
+
+    return new NextResponse(body, { status: res.status, headers });
+  } catch (err: any) {
+    console.error("[PDBE PROXY] Error:", err);
+    return NextResponse.json(
+      { error: `PDBe proxy error: ${err.message}` },
+      { status: 502 },
+    );
+  }
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxy(req, params, "GET");
+}
+
+export async function HEAD(
+  req: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxy(req, params, "HEAD");
+}

--- a/client/renderer/components/moorhen/moorhen-ccp4i2-tabbed-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-ccp4i2-tabbed-panel.tsx
@@ -1,0 +1,137 @@
+/**
+ * CCP4i2 tabbed side-panel — hosts both Controls and Scenes under one
+ * Moorhen side-panel registration.
+ *
+ * Why: registering two custom extraSidePanels with Moorhen surfaces only
+ * one tab (an upstream Moorhen behaviour we couldn't work around in the
+ * panel-switcher's local state). MUI Tabs in our own panel content side-
+ * steps the issue entirely — one Moorhen side-panel tab, two sub-tabs
+ * under our control.
+ *
+ * The two sub-panels are kept mounted (Tabs hide the inactive one with
+ * display:none) so Monaco's editor state survives switching back and
+ * forth, and so live-apply continues working while the user is on the
+ * Controls tab.
+ */
+import React, { useState, useMemo } from "react";
+import { Box, Tab, Tabs } from "@mui/material";
+import { moorhen } from "moorhen/types/moorhen";
+
+import { MoorhenControlPanel } from "./moorhen-control-panel";
+import { MoorhenScenesPanel, SceneBundleAssets } from "./moorhen-scenes-panel";
+import type { SceneResolveResult } from "../../lib/moorhen-scene-resolver";
+import type { SceneLiftHints } from "../../lib/moorhen-scene-lifter";
+import type { MoorhenScene } from "../../types/moorhen-scene";
+
+export interface MoorhenCcp4i2TabbedPanelProps {
+  onFileSelect: (fileId: number) => Promise<void>;
+  onJobLoad?: (jobId: number) => Promise<void>;
+  getViewUrl?: () => string;
+  molecules: moorhen.Molecule[];
+  maps: moorhen.Map[];
+  onMapContourLevelChange: (molNo: number, level: number) => void;
+  onRunServalcat?: (mol: moorhen.Molecule) => Promise<void>;
+  servalcatStatus?: string | null;
+  onApplyScene: (
+    yamlText: string,
+    assets: SceneBundleAssets,
+  ) => Promise<SceneResolveResult>;
+  onCaptureScene: () => Promise<{
+    scene: MoorhenScene;
+    hints: SceneLiftHints;
+    assets: SceneBundleAssets;
+  }>;
+  cootInitialized: boolean;
+}
+
+export const MoorhenCcp4i2TabbedPanel: React.FC<MoorhenCcp4i2TabbedPanelProps> = ({
+  onApplyScene,
+  onCaptureScene,
+  cootInitialized,
+  ...controlsProps
+}) => {
+  const [activeTab, setActiveTab] = useState<"controls" | "scenes">("controls");
+
+  // Memoise the two sub-panels so switching tabs doesn't rebuild them
+  // (Monaco re-init is expensive; preserving the Controls subtree keeps
+  // the existing slider/list state too).
+  const controlsContent = useMemo(
+    () => <MoorhenControlPanel {...controlsProps} />,
+    // Spread deps must match props the panel actually reads. Re-render
+    // whenever any of these change, as the original site did.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      controlsProps.onFileSelect,
+      controlsProps.onJobLoad,
+      controlsProps.getViewUrl,
+      controlsProps.molecules,
+      controlsProps.maps,
+      controlsProps.onMapContourLevelChange,
+      controlsProps.onRunServalcat,
+      controlsProps.servalcatStatus,
+    ],
+  );
+
+  const scenesContent = useMemo(
+    () => (
+      <MoorhenScenesPanel
+        onApplyScene={onApplyScene}
+        onCaptureScene={onCaptureScene}
+        enabled={cootInitialized}
+      />
+    ),
+    [onApplyScene, onCaptureScene, cootInitialized],
+  );
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        width: "100%",
+        minWidth: 0,
+      }}
+    >
+      <Tabs
+        value={activeTab}
+        onChange={(_, v) => setActiveTab(v)}
+        variant="fullWidth"
+        sx={{ borderBottom: 1, borderColor: "divider", minHeight: 36 }}
+      >
+        <Tab
+          label="Controls"
+          value="controls"
+          sx={{ minHeight: 36, py: 0.5, fontSize: "0.75rem", textTransform: "none" }}
+        />
+        <Tab
+          label="Scenes"
+          value="scenes"
+          sx={{ minHeight: 36, py: 0.5, fontSize: "0.75rem", textTransform: "none" }}
+        />
+      </Tabs>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          width: "100%",
+          overflow: "hidden",
+          display: activeTab === "controls" ? "block" : "none",
+        }}
+      >
+        {controlsContent}
+      </Box>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          width: "100%",
+          overflow: "hidden",
+          display: activeTab === "scenes" ? "block" : "none",
+        }}
+      >
+        {scenesContent}
+      </Box>
+    </Box>
+  );
+};

--- a/client/renderer/components/moorhen/moorhen-ccp4i2-tabbed-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-ccp4i2-tabbed-panel.tsx
@@ -41,12 +41,21 @@ export interface MoorhenCcp4i2TabbedPanelProps {
     hints: SceneLiftHints;
     assets: SceneBundleAssets;
   }>;
+  onPromoteSceneToPortable: (
+    yamlText: string,
+    currentAssets: SceneBundleAssets,
+  ) => Promise<{
+    yamlText: string;
+    assets: SceneBundleAssets;
+    warnings: string[];
+  }>;
   cootInitialized: boolean;
 }
 
 export const MoorhenCcp4i2TabbedPanel: React.FC<MoorhenCcp4i2TabbedPanelProps> = ({
   onApplyScene,
   onCaptureScene,
+  onPromoteSceneToPortable,
   cootInitialized,
   ...controlsProps
 }) => {
@@ -77,10 +86,11 @@ export const MoorhenCcp4i2TabbedPanel: React.FC<MoorhenCcp4i2TabbedPanelProps> =
       <MoorhenScenesPanel
         onApplyScene={onApplyScene}
         onCaptureScene={onCaptureScene}
+        onPromoteSceneToPortable={onPromoteSceneToPortable}
         enabled={cootInitialized}
       />
     ),
-    [onApplyScene, onCaptureScene, cootInitialized],
+    [onApplyScene, onCaptureScene, onPromoteSceneToPortable, cootInitialized],
   );
 
   return (

--- a/client/renderer/components/moorhen/moorhen-control-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-control-panel.tsx
@@ -32,6 +32,8 @@ import {
 import { CCP4i2HierarchyBrowser } from "./ccp4i2-hierarchy-browser";
 import { CopyViewLinkButton } from "./copy-view-link-button";
 import { PasteViewLinkField } from "./paste-view-link-field";
+// Scene-related UI (upload/download/edit) lives in the dedicated Scenes
+// side-panel (moorhen-scenes-panel.tsx). Don't add scene buttons here.
 import { PushToCCP4i2Panel } from "./push-to-ccp4i2-panel";
 import { useTheme } from "../../theme/theme-provider";
 
@@ -204,8 +206,9 @@ export const MoorhenControlPanel: React.FC<MoorhenControlPanelProps> = ({
     <Stack
       direction="column"
       sx={{
-        height: "calc(100vh - 100px)",
+        height: "100%",
         width: "100%",
+        minWidth: 0,
       }}
     >
       {/* Copy / Paste View Link */}

--- a/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
@@ -25,9 +25,11 @@ import React, {
 import {
   Box,
   Button,
+  ButtonGroup,
   Checkbox,
   FormControlLabel,
-  IconButton,
+  Menu,
+  MenuItem,
   Stack,
   Tooltip,
   Typography,
@@ -37,6 +39,7 @@ import {
   FileOpen as OpenIcon,
   Save as SaveIcon,
   PlayArrow as ApplyIcon,
+  ArrowDropDown as DropDownIcon,
 } from "@mui/icons-material";
 import { Editor } from "@monaco-editor/react";
 import JSZip from "jszip";
@@ -95,6 +98,18 @@ interface MoorhenScenesPanelProps {
     hints: SceneLiftHints;
     assets: SceneBundleAssets;
   }>;
+  /** Promote the editor YAML to a fully self-contained scene: every
+   *  URL-resolvable ref is fetched, library-dict comp_ids are re-
+   *  collected, and everything lands in the returned asset map under
+   *  bundle: paths. Used by Save (self-contained). */
+  onPromoteSceneToPortable: (
+    yamlText: string,
+    currentAssets: SceneBundleAssets,
+  ) => Promise<{
+    yamlText: string;
+    assets: SceneBundleAssets;
+    warnings: string[];
+  }>;
   /** True once Moorhen / Coot is ready. Disables apply until then. */
   enabled: boolean;
 }
@@ -110,6 +125,7 @@ interface PanelMessage {
 export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
   onApplyScene,
   onCaptureScene,
+  onPromoteSceneToPortable,
   enabled,
 }) => {
   const [yamlText, setYamlText] = useState<string>("");
@@ -268,53 +284,121 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
     void applyNow(yamlText, { silentOnParseError: false });
   }, [applyNow, yamlText]);
 
-  const handleSave = useCallback(async () => {
+  // --- save (light vs self-contained) ------------------------------------
+  //
+  // Light: write whatever the editor holds. If any ref already uses a
+  // bundle: path AND we have bytes for it, emit a .scene.zip carrying
+  // only the referenced assets (orphan assets from a previously-opened
+  // zip are dropped — they're not the saved scene's concern). Otherwise
+  // emit a plain .scene.yaml.
+  //
+  // Self-contained: hand the YAML to the wrapper's promoter, which
+  // fetches every URL-resolvable ref into bundle assets and re-collects
+  // library-resolvable ligand dicts. Always emits a .scene.zip.
+
+  const triggerDownload = useCallback((blob: Blob, filename: string) => {
+    const a = document.createElement("a");
+    document.body.appendChild(a);
+    const url = URL.createObjectURL(blob);
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+  }, []);
+
+  const handleSaveLight = useCallback(async () => {
     if (!yamlText.trim()) {
       setMessage({ severity: "warning", text: "Nothing to save" });
       return;
     }
     let sceneName = "scene";
-    let hasBundleRefs = false;
+    let referencedBundlePaths: Set<string> | null = null;
     try {
       const parsed = parseScene(yamlText);
       sceneName = parsed.scene || "scene";
-      hasBundleRefs = (parsed.files ?? []).some((f) => !!f.bundle);
+      referencedBundlePaths = new Set(
+        (parsed.files ?? []).filter((f) => !!f.bundle).map((f) => f.bundle as string),
+      );
     } catch {
       // Save the raw text anyway so the user doesn't lose work in progress.
     }
 
     const safe = sceneName.replace(/[^A-Za-z0-9._-]+/g, "_");
-    const a = document.createElement("a");
-    document.body.appendChild(a);
+    const shouldBundle =
+      referencedBundlePaths !== null &&
+      referencedBundlePaths.size > 0 &&
+      [...referencedBundlePaths].some((p) => assetsRef.current.has(p));
 
-    // Save as .scene.zip when the scene has any bundle: refs AND we
-    // have asset bytes for them — otherwise the zip would be missing
-    // its own attachments. Falls back to plain yaml if there's nothing
-    // to attach.
-    const shouldBundle = hasBundleRefs && assetsRef.current.size > 0;
     if (shouldBundle) {
       const zip = new JSZip();
       zip.file("scene.yaml", yamlText);
+      // Only include assets the YAML actually references; orphans from
+      // a previous-opened zip are noise and bloat the save.
+      let kept = 0;
       for (const [relPath, buf] of assetsRef.current.entries()) {
+        if (referencedBundlePaths!.has(relPath)) {
+          zip.file(relPath, buf);
+          kept++;
+        }
+      }
+      const blob = await zip.generateAsync({ type: "blob" });
+      triggerDownload(blob, `${safe}.scene.zip`);
+      setMessage({
+        severity: "info",
+        text: `Saved ${safe}.scene.zip (${kept} bundled asset${kept === 1 ? "" : "s"})`,
+      });
+    } else {
+      const blob = new Blob([yamlText], { type: "application/x-yaml;charset=utf-8" });
+      triggerDownload(blob, `${safe}.scene.yaml`);
+      setMessage({ severity: "info", text: `Saved ${safe}.scene.yaml` });
+    }
+  }, [yamlText, triggerDownload]);
+
+  const handleSaveSelfContained = useCallback(async () => {
+    if (!yamlText.trim()) {
+      setMessage({ severity: "warning", text: "Nothing to save" });
+      return;
+    }
+    setMessage({ severity: "info", text: "Gathering assets…" });
+    try {
+      const { yamlText: portableYaml, assets, warnings } =
+        await onPromoteSceneToPortable(yamlText, assetsRef.current);
+      let sceneName = "scene";
+      try {
+        sceneName = parseScene(portableYaml).scene || "scene";
+      } catch {
+        /* fall back to "scene" */
+      }
+      const safe = sceneName.replace(/[^A-Za-z0-9._-]+/g, "_");
+      const zip = new JSZip();
+      zip.file("scene.yaml", portableYaml);
+      for (const [relPath, buf] of assets.entries()) {
         zip.file(relPath, buf);
       }
       const blob = await zip.generateAsync({ type: "blob" });
-      const url = URL.createObjectURL(blob);
-      a.href = url;
-      a.download = `${safe}.scene.zip`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } else {
-      const blob = new Blob([yamlText], { type: "application/x-yaml;charset=utf-8" });
-      const url = URL.createObjectURL(blob);
-      a.href = url;
-      a.download = `${safe}.scene.yaml`;
-      a.click();
-      URL.revokeObjectURL(url);
+      triggerDownload(blob, `${safe}.scene.zip`);
+      // Adopt the promoted YAML + assets into the editor so subsequent
+      // Apply / Save use the now-self-contained scene without a re-promote.
+      setYamlText(portableYaml);
+      assetsRef.current = assets;
+      setMessage({
+        severity: warnings.length > 0 ? "warning" : "success",
+        text:
+          `Saved ${safe}.scene.zip (${assets.size} asset${assets.size === 1 ? "" : "s"})` +
+          (warnings.length > 0 ? ` — ${warnings.length} warning${warnings.length === 1 ? "" : "s"}` : ""),
+        log: warnings.map((w) => ({ file: "", domain: "promote", message: w })),
+      });
+    } catch (err) {
+      setMessage({
+        severity: "error",
+        text: `Self-contained save failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      });
     }
-    document.body.removeChild(a);
-    setMessage({ severity: "info", text: `Saved ${a.download}` });
-  }, [yamlText]);
+  }, [yamlText, onPromoteSceneToPortable, triggerDownload]);
+
+  // Split-button state for the Save dropdown.
+  const [saveMenuAnchor, setSaveMenuAnchor] = useState<HTMLElement | null>(null);
 
   // --- live apply ---------------------------------------------------------
 
@@ -392,13 +476,41 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
           </span>
         </Tooltip>
 
-        <Tooltip title="Save the editor's YAML to disk">
-          <span>
-            <IconButton size="small" onClick={handleSave}>
-              <SaveIcon fontSize="small" />
-            </IconButton>
-          </span>
-        </Tooltip>
+        <ButtonGroup variant="outlined" size="small" sx={{ "& .MuiButton-root": { fontSize: "0.75rem", textTransform: "none" } }}>
+          <Tooltip title="Save the editor's YAML (zips only the assets the YAML references)">
+            <Button startIcon={<SaveIcon />} onClick={handleSaveLight}>
+              Save
+            </Button>
+          </Tooltip>
+          <Tooltip title="More save options">
+            <Button
+              size="small"
+              onClick={(e) => setSaveMenuAnchor(e.currentTarget)}
+              sx={{ px: 0.5, minWidth: 0 }}
+            >
+              <DropDownIcon fontSize="small" />
+            </Button>
+          </Tooltip>
+        </ButtonGroup>
+        <Menu
+          anchorEl={saveMenuAnchor}
+          open={Boolean(saveMenuAnchor)}
+          onClose={() => setSaveMenuAnchor(null)}
+        >
+          <MenuItem
+            onClick={() => {
+              setSaveMenuAnchor(null);
+              void handleSaveSelfContained();
+            }}
+          >
+            <Stack>
+              <Typography variant="body2">Save self-contained…</Typography>
+              <Typography variant="caption" sx={{ color: "#666" }}>
+                Fetch every URL-resolvable ref and bundle into one .scene.zip
+              </Typography>
+            </Stack>
+          </MenuItem>
+        </Menu>
 
         <FormControlLabel
           control={

--- a/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
@@ -1,0 +1,487 @@
+/**
+ * Moorhen Scenes side-panel.
+ *
+ * One home for all yaml-scene operations:
+ *   - Live YAML editor (Monaco) with syntax highlighting
+ *   - Capture current view → editor (lifter)
+ *   - Open a .scene.yaml from disk → editor
+ *   - Save current editor contents → browser download
+ *   - Apply now (parse + resolve + render)
+ *   - Live apply (debounced, silent on parse errors)
+ *   - Validation/log panel below the editor (parse errors, resolver log)
+ *
+ * The Apply / Download / Open actions previously lived inline next to
+ * Copy View Link; they've been consolidated here so there's one place
+ * for everything yaml-scene-related.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Camera as CaptureIcon,
+  FileOpen as OpenIcon,
+  Save as SaveIcon,
+  PlayArrow as ApplyIcon,
+} from "@mui/icons-material";
+import { Editor } from "@monaco-editor/react";
+import JSZip from "jszip";
+
+import { parseScene, serialiseSceneWithComments, SceneParseError } from "../../lib/moorhen-scene";
+import type { MoorhenScene } from "../../types/moorhen-scene";
+import type {
+  SceneResolveResult,
+  SceneResolveLogEntry,
+} from "../../lib/moorhen-scene-resolver";
+import type { SceneLiftHints } from "../../lib/moorhen-scene-lifter";
+
+const DEFAULT_PLACEHOLDER = `# Type or paste a scene YAML here, or click "Capture" to
+# initialise from the current Moorhen view.
+#
+# scene: my-scheme
+# version: 1
+# files:
+#   - name: thing
+#     fileId: 123
+#     projectId: <project-uuid>
+# domains:
+#   - { name: domain-A, chain: A, range: 1-100, color: "#4b8bbe" }
+# elements:
+#   - file: thing
+#     representations:
+#       - { style: CRs, selection: "//A", colour: by-domain }
+# resolver:
+#   onMissingResidues: clamp-and-log
+`;
+
+const LIVE_APPLY_DEBOUNCE_MS = 750;
+
+/**
+ * Bundle asset map — keys are paths inside the .scene.zip (e.g.
+ * "assets/complex.pdb"); values are the raw bytes. The Scenes panel
+ * builds this when a .zip is opened and hands it to the apply callback
+ * so the resolver's bundle: fetcher can look entries up. Lifter
+ * populates a fresh map when capturing a scene that has bundle: refs.
+ */
+export type SceneBundleAssets = Map<string, ArrayBuffer>;
+
+interface MoorhenScenesPanelProps {
+  /** Apply YAML text to the current view. The second argument is the
+   *  bundle-asset map (empty when not opened from a .scene.zip). */
+  onApplyScene: (
+    yamlText: string,
+    assets: SceneBundleAssets,
+  ) => Promise<SceneResolveResult>;
+  /** Capture the current view as a scene + lift hints + bundle assets.
+   *  The lifter may inline non-portable molecule coords/dicts into the
+   *  assets map; the panel will save as .scene.zip when assets are
+   *  present, plain .scene.yaml otherwise. */
+  onCaptureScene: () => Promise<{
+    scene: MoorhenScene;
+    hints: SceneLiftHints;
+    assets: SceneBundleAssets;
+  }>;
+  /** True once Moorhen / Coot is ready. Disables apply until then. */
+  enabled: boolean;
+}
+
+type Severity = "info" | "success" | "warning" | "error";
+
+interface PanelMessage {
+  severity: Severity;
+  text: string;
+  log?: SceneResolveLogEntry[];
+}
+
+export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
+  onApplyScene,
+  onCaptureScene,
+  enabled,
+}) => {
+  const [yamlText, setYamlText] = useState<string>("");
+  // Live apply is opt-in. Loading / capturing a scene populates the editor
+  // but does not touch the viewer until the user clicks Apply (or enables
+  // Live apply). This lets the user inspect/edit a YAML before committing.
+  const [liveApply, setLiveApply] = useState<boolean>(false);
+  const [message, setMessage] = useState<PanelMessage | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Bundle assets keyed by their path inside the .scene.zip. Populated
+  // by Open when the user picks a .zip; consumed by Apply to satisfy
+  // bundle: refs without any network or filesystem access.
+  const assetsRef = useRef<SceneBundleAssets>(new Map());
+
+  // --- actions ------------------------------------------------------------
+
+  const handleCapture = useCallback(async () => {
+    try {
+      const { scene, hints, assets } = await onCaptureScene();
+      const yaml = serialiseSceneWithComments(scene, hints.fileComments);
+      setYamlText(yaml);
+      // Take ownership of any bundle assets the lifter produced — Save
+      // will bundle them up if the YAML actually references them.
+      assetsRef.current = assets;
+      const n = assets.size;
+      setMessage({
+        severity: "info",
+        text:
+          n > 0
+            ? `Captured current view (${n} asset${n === 1 ? "" : "s"} ready for bundling)`
+            : "Captured current view",
+      });
+    } catch (err) {
+      console.error("Failed to capture scene:", err);
+      setMessage({
+        severity: "error",
+        text: `Capture failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      });
+    }
+  }, [onCaptureScene]);
+
+  const handleOpenClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleOpenFile = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      e.target.value = "";
+      if (!file) return;
+      const isZip =
+        file.name.endsWith(".zip") ||
+        file.name.endsWith(".scene.zip") ||
+        file.type === "application/zip";
+      try {
+        if (isZip) {
+          // Unpack: scene.yaml at the root (required), everything else
+          // becomes an asset keyed by its relative path.
+          const buffer = await file.arrayBuffer();
+          const zip = await JSZip.loadAsync(buffer);
+          const yamlEntry = zip.file("scene.yaml") || zip.file("scene.yml");
+          if (!yamlEntry) {
+            setMessage({
+              severity: "error",
+              text: `${file.name} is missing scene.yaml at the root`,
+            });
+            return;
+          }
+          const yaml = await yamlEntry.async("string");
+          const assets: SceneBundleAssets = new Map();
+          // Iterate every entry; skip directories and the scene.yaml itself.
+          const promises: Promise<void>[] = [];
+          zip.forEach((relPath, entry) => {
+            if (entry.dir) return;
+            if (relPath === "scene.yaml" || relPath === "scene.yml") return;
+            promises.push(
+              entry.async("arraybuffer").then((buf) => {
+                assets.set(relPath, buf);
+              }),
+            );
+          });
+          await Promise.all(promises);
+          assetsRef.current = assets;
+          setYamlText(yaml);
+          setMessage({
+            severity: "info",
+            text: `Loaded ${file.name} (${assets.size} bundled asset${assets.size === 1 ? "" : "s"})`,
+          });
+        } else {
+          const text = await file.text();
+          // Opening a plain yaml clears any previously-loaded bundle
+          // assets — they're tied to the zip they came from.
+          assetsRef.current = new Map();
+          setYamlText(text);
+          setMessage({ severity: "info", text: `Loaded ${file.name}` });
+        }
+      } catch (err) {
+        setMessage({
+          severity: "error",
+          text: `Could not read ${file.name}: ${(err as Error).message}`,
+        });
+      }
+    },
+    [],
+  );
+
+  const applyNow = useCallback(
+    async (text: string, opts: { silentOnParseError: boolean }) => {
+      try {
+        parseScene(text); // validate first for a clean error
+      } catch (err) {
+        if (opts.silentOnParseError) return;
+        if (err instanceof SceneParseError) {
+          const first = err.errors[0];
+          setMessage({
+            severity: "error",
+            text: `Invalid scene${first.path ? ` at ${first.path}` : ""}: ${first.message}`,
+          });
+        } else {
+          setMessage({
+            severity: "error",
+            text: `Invalid scene: ${(err as Error).message}`,
+          });
+        }
+        return;
+      }
+
+      try {
+        const result = await onApplyScene(text, assetsRef.current);
+        const repTotal = result.applied.reduce((sum, a) => sum + a.representations, 0);
+        const severity: Severity =
+          result.unresolvedFiles.length > 0 || repTotal === 0 ? "warning" : "success";
+        const parts: string[] = [
+          `Applied ${repTotal} representation${repTotal === 1 ? "" : "s"} across ${result.applied.length} file${result.applied.length === 1 ? "" : "s"}`,
+        ];
+        if (result.unresolvedFiles.length > 0) {
+          parts.push(`unresolved: ${result.unresolvedFiles.join(", ")}`);
+        }
+        setMessage({ severity, text: parts.join(" — "), log: result.log });
+      } catch (err) {
+        console.error("Failed to apply scene:", err);
+        setMessage({
+          severity: "error",
+          text: `Apply failed: ${err instanceof Error ? err.message : "unknown error"}`,
+        });
+      }
+    },
+    [onApplyScene],
+  );
+
+  const handleApplyNow = useCallback(() => {
+    if (!yamlText.trim()) {
+      setMessage({ severity: "warning", text: "Editor is empty" });
+      return;
+    }
+    void applyNow(yamlText, { silentOnParseError: false });
+  }, [applyNow, yamlText]);
+
+  const handleSave = useCallback(async () => {
+    if (!yamlText.trim()) {
+      setMessage({ severity: "warning", text: "Nothing to save" });
+      return;
+    }
+    let sceneName = "scene";
+    let hasBundleRefs = false;
+    try {
+      const parsed = parseScene(yamlText);
+      sceneName = parsed.scene || "scene";
+      hasBundleRefs = (parsed.files ?? []).some((f) => !!f.bundle);
+    } catch {
+      // Save the raw text anyway so the user doesn't lose work in progress.
+    }
+
+    const safe = sceneName.replace(/[^A-Za-z0-9._-]+/g, "_");
+    const a = document.createElement("a");
+    document.body.appendChild(a);
+
+    // Save as .scene.zip when the scene has any bundle: refs AND we
+    // have asset bytes for them — otherwise the zip would be missing
+    // its own attachments. Falls back to plain yaml if there's nothing
+    // to attach.
+    const shouldBundle = hasBundleRefs && assetsRef.current.size > 0;
+    if (shouldBundle) {
+      const zip = new JSZip();
+      zip.file("scene.yaml", yamlText);
+      for (const [relPath, buf] of assetsRef.current.entries()) {
+        zip.file(relPath, buf);
+      }
+      const blob = await zip.generateAsync({ type: "blob" });
+      const url = URL.createObjectURL(blob);
+      a.href = url;
+      a.download = `${safe}.scene.zip`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } else {
+      const blob = new Blob([yamlText], { type: "application/x-yaml;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      a.href = url;
+      a.download = `${safe}.scene.yaml`;
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+    document.body.removeChild(a);
+    setMessage({ severity: "info", text: `Saved ${a.download}` });
+  }, [yamlText]);
+
+  // --- live apply ---------------------------------------------------------
+
+  // Re-apply on edit when liveApply is on. Silent on parse errors so
+  // intermediate broken yaml doesn't spam the message panel; the user's
+  // next valid keystroke will re-apply cleanly.
+  useEffect(() => {
+    if (!liveApply || !enabled || !yamlText.trim()) return;
+    const handle = setTimeout(() => {
+      void applyNow(yamlText, { silentOnParseError: true });
+    }, LIVE_APPLY_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [liveApply, enabled, yamlText, applyNow]);
+
+  // --- rendering ----------------------------------------------------------
+
+  const messageColor = useMemo(() => {
+    if (!message) return "transparent";
+    return ({
+      info: "#e3f2fd",
+      success: "#e8f5e9",
+      warning: "#fff8e1",
+      error: "#ffebee",
+    } as const)[message.severity];
+  }, [message]);
+
+  return (
+    <Stack
+      direction="column"
+      spacing={1}
+      sx={{ p: 1, height: "100%", overflow: "hidden" }}
+    >
+      {/* Toolbar */}
+      <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", alignItems: "center" }}>
+        <Tooltip title="Capture the current view into the editor (lifter)">
+          <span>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<CaptureIcon />}
+              onClick={handleCapture}
+              sx={{ fontSize: "0.75rem", textTransform: "none" }}
+            >
+              Capture
+            </Button>
+          </span>
+        </Tooltip>
+
+        <Tooltip title="Open a .scene.yaml or .scene.zip from disk (zips bring their bundled assets along)">
+          <span>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<OpenIcon />}
+              onClick={handleOpenClick}
+              sx={{ fontSize: "0.75rem", textTransform: "none" }}
+            >
+              Open…
+            </Button>
+          </span>
+        </Tooltip>
+
+        <Tooltip title="Apply the editor's current YAML now">
+          <span>
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<ApplyIcon />}
+              onClick={handleApplyNow}
+              disabled={!enabled}
+              sx={{ fontSize: "0.75rem", textTransform: "none" }}
+            >
+              Apply
+            </Button>
+          </span>
+        </Tooltip>
+
+        <Tooltip title="Save the editor's YAML to disk">
+          <span>
+            <IconButton size="small" onClick={handleSave}>
+              <SaveIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+
+        <FormControlLabel
+          control={
+            <Checkbox
+              size="small"
+              checked={liveApply}
+              onChange={(e) => setLiveApply(e.target.checked)}
+            />
+          }
+          label={<Typography variant="caption">Live apply</Typography>}
+          sx={{ ml: "auto", mr: 0 }}
+        />
+      </Stack>
+
+      {/* Editor */}
+      <Box sx={{ flex: "1 1 auto", minHeight: 200, border: "1px solid #ddd" }}>
+        <Editor
+          height="100%"
+          value={yamlText}
+          language="yaml"
+          theme="vs"
+          options={{
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            fontSize: 12,
+            wordWrap: "on",
+            tabSize: 2,
+            renderLineHighlight: "none",
+            scrollbar: { vertical: "auto", horizontal: "auto" },
+            placeholder: DEFAULT_PLACEHOLDER,
+          }}
+          onChange={(v) => setYamlText(v ?? "")}
+        />
+      </Box>
+
+      {/* Message + resolver log */}
+      <Box
+        sx={{
+          flex: "0 0 auto",
+          maxHeight: 160,
+          overflow: "auto",
+          p: 1,
+          fontSize: "0.75rem",
+          backgroundColor: messageColor,
+          border: "1px solid #eee",
+          borderRadius: 1,
+        }}
+      >
+        {message ? (
+          <>
+            <Typography variant="caption" sx={{ display: "block", fontWeight: 600 }}>
+              {message.text}
+            </Typography>
+            {message.log && message.log.length > 0 && (
+              <Box component="ul" sx={{ m: 0, pl: 2, mt: 0.5 }}>
+                {message.log.map((entry, i) => (
+                  <Typography
+                    key={i}
+                    component="li"
+                    variant="caption"
+                    sx={{ display: "list-item" }}
+                  >
+                    <strong>{entry.domain}</strong> ({entry.file}): {entry.message}
+                  </Typography>
+                ))}
+              </Box>
+            )}
+          </>
+        ) : (
+          <Typography variant="caption" sx={{ color: "#666" }}>
+            No messages — edit YAML above and (with Live apply on) the view
+            will update automatically when it parses.
+          </Typography>
+        )}
+      </Box>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".yaml,.yml,.scene.yaml,.zip,.scene.zip,text/yaml,application/x-yaml,application/zip"
+        style={{ display: "none" }}
+        onChange={handleOpenFile}
+      />
+    </Stack>
+  );
+};

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -33,11 +33,16 @@ import { MoorhenCcp4i2TabbedPanel } from "./moorhen-ccp4i2-tabbed-panel";
 import { apiGet, apiText, apiArrayBuffer, apiPost, apiUpload } from "../../api-fetch";
 import { useTheme } from "../../theme/theme-provider";
 import { useMoorhenViewState } from "../../hooks/use-moorhen-view-state";
-import { parseScene } from "../../lib/moorhen-scene";
+import { parseScene, serialiseScene } from "../../lib/moorhen-scene";
 import { applyScene, SceneResolveResult, SceneFileFetcher } from "../../lib/moorhen-scene-resolver";
 import type { SceneFileRef } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
-import { liftSceneToBundle, SceneLiftHints } from "../../lib/moorhen-scene-lifter";
+import {
+  liftSceneToBundle,
+  promoteSceneToPortable,
+  SceneLiftHints,
+  SceneRefUrlResolver,
+} from "../../lib/moorhen-scene-lifter";
 import type { MoorhenScene } from "../../types/moorhen-scene";
 import {
   MoorhenFallback,
@@ -745,6 +750,41 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   // pdb id / fileId / url) the lifter inlines its coords into the
   // returned asset map, the YAML gets bundle: refs, and Save writes a
   // .scene.zip. Portable refs (pdb / fileId / url) stay as-is.
+  // Centralised URL-derivation for any URL-shaped ref kind. Shared by
+  // the fetcher (apply path) and the promoter (export path) so they
+  // agree on what counts as "a resolvable ref".
+  const resolveSceneRefUrl: SceneRefUrlResolver = useCallback((ref) => {
+    if (ref.pdb) return `/api/proxy/pdbe/entry-files/download/${ref.pdb.toLowerCase()}.cif`;
+    if (ref.fileId !== undefined && ref.projectId) {
+      return `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
+    }
+    if (ref.url) return ref.url;
+    return null;
+  }, []);
+
+  // Promote an editor YAML to a fully self-contained scene + asset
+  // bundle: every URL-resolvable ref is fetched into assets/ and
+  // rewritten to bundle: form; ligand dicts that live in Moorhen's
+  // monomer library are re-collected (the lifter omits them so the
+  // captured YAML stays small, but self-contained mode wants them).
+  const handlePromoteSceneToPortable = useCallback(
+    async (
+      yamlText: string,
+      currentAssets: SceneBundleAssets,
+    ): Promise<{ yamlText: string; assets: SceneBundleAssets; warnings: string[] }> => {
+      const scene = parseScene(yamlText);
+      const { scene: out, assets, warnings } = await promoteSceneToPortable({
+        scene,
+        existingAssets: currentAssets,
+        resolveUrl: resolveSceneRefUrl,
+        molecules,
+        monomerLibraryPath: molecules[0]?.monomerLibraryPath,
+      });
+      return { yamlText: serialiseScene(out), assets, warnings };
+    },
+    [molecules, resolveSceneRefUrl],
+  );
+
   const handleCaptureScene = useCallback(async (): Promise<{
     scene: MoorhenScene;
     hints: SceneLiftHints;
@@ -765,6 +805,10 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       glRef: glRefState,
       projectId: projectInfo?.id,
       projectName: projectInfo?.name,
+      // First molecule's monomerLibraryPath is the canonical Moorhen
+      // root (all molecules share it via the wrapper's construction).
+      // Without it the lifter falls back to STANDARD_MONOMERS only.
+      monomerLibraryPath: molecules[0]?.monomerLibraryPath,
     });
   }, [store, molecules, projectInfo]);
 
@@ -791,11 +835,12 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
           servalcatStatus={servalcatStatus}
           onApplyScene={handleApplyScene}
           onCaptureScene={handleCaptureScene}
+          onPromoteSceneToPortable={handlePromoteSceneToPortable}
           cootInitialized={cootInitialized}
         />
       ),
     },
-  }), [fetchFile, fetchJobFiles, getViewUrl, molecules, maps, handleMapContourLevelChange, jobId, handleRunServalcat, servalcatStatus, handleApplyScene, handleCaptureScene, cootInitialized]);
+  }), [fetchFile, fetchJobFiles, getViewUrl, molecules, maps, handleMapContourLevelChange, jobId, handleRunServalcat, servalcatStatus, handleApplyScene, handleCaptureScene, handlePromoteSceneToPortable, cootInitialized]);
 
   const collectedProps = useMemo(() => ({
     glRef,

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -29,10 +29,16 @@ import {
 import { moorhen } from "moorhen/types/moorhen";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import { webGL } from "moorhen/types/mgWebGL";
-import { MoorhenControlPanel } from "./moorhen-control-panel";
+import { MoorhenCcp4i2TabbedPanel } from "./moorhen-ccp4i2-tabbed-panel";
 import { apiGet, apiText, apiArrayBuffer, apiPost, apiUpload } from "../../api-fetch";
 import { useTheme } from "../../theme/theme-provider";
 import { useMoorhenViewState } from "../../hooks/use-moorhen-view-state";
+import { parseScene } from "../../lib/moorhen-scene";
+import { applyScene, SceneResolveResult, SceneFileFetcher } from "../../lib/moorhen-scene-resolver";
+import type { SceneFileRef } from "../../types/moorhen-scene";
+import type { SceneBundleAssets } from "./moorhen-scenes-panel";
+import { liftSceneToBundle, SceneLiftHints } from "../../lib/moorhen-scene-lifter";
+import type { MoorhenScene } from "../../types/moorhen-scene";
 import {
   MoorhenFallback,
   MoorhenErrorBoundary,
@@ -95,7 +101,11 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     dispatch(setTheme(theme.mode === "light" ? "flatly" : "darkly"));
   }, [theme.mode]);
 
-  // Auto-open the CCP4i2 controls side panel
+  // Auto-open the (single) CCP4i2 side panel on mount. Multi-panel
+  // registration in Moorhen's extension API has a bug where only one
+  // tab renders even with both panels in extraSidePanels; sub-tabs for
+  // scenes vs controls are handled inside the panel content via MUI Tabs
+  // instead.
   useEffect(() => {
     dispatch(setShownSidePanel("ccp4i2Controls"));
   }, [dispatch]);
@@ -123,8 +133,25 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     return state.glRef.origin;
   }, [store]);
 
-  const fetchMolecule = useCallback(async (url: string, molName: string) => {
-    if (!commandCentre.current) return;
+  /**
+   * Core "fetch text, build MoorhenMolecule, register in store" path.
+   * Returns the molecule so callers (notably the scene fetcher) can use
+   * the result; fetchMolecule below wraps this and returns void to keep
+   * existing callers' contract unchanged.
+   */
+  /**
+   * Build a MoorhenMolecule from already-fetched coord text and register
+   * it in the store. Use when bytes are in memory (e.g. from a scene
+   * bundle); skips the apiText round-trip that loadStructure does.
+   * Sets uniqueId from the supplied marker so callers can later identify
+   * the molecule (e.g. `bundle:assets/foo.pdb`).
+   */
+  const loadStructureFromText = useCallback(async (
+    coordText: string,
+    molName: string,
+    uniqueIdMarker: string,
+  ): Promise<moorhen.Molecule | null> => {
+    if (!commandCentre.current) return null;
     const newMolecule = new MoorhenMolecule(
       commandCentre as RefObject<moorhen.CommandCentre>,
       store as any,
@@ -133,12 +160,11 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     newMolecule.setBackgroundColour(backgroundColor);
     newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness;
     try {
-      const pdbData = await apiText(url);
-      await newMolecule.loadToCootFromString(pdbData, molName);
+      await newMolecule.loadToCootFromString(coordText, molName);
       if (newMolecule.molNo === -1) {
         throw new Error("Cannot read the fetched molecule...");
       }
-      newMolecule.uniqueId = url;
+      newMolecule.uniqueId = uniqueIdMarker;
 
       // Try ribbon representation first (better for protein overview)
       // Fall back to CBs if ribbons fail (e.g., no protein backbone)
@@ -152,17 +178,37 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       try {
         await newMolecule.addRepresentation("ligands", "/*/*/*/*");
       } catch {
-        console.warn("[fetchMolecule] Ligands representation failed");
+        console.warn("[loadStructureFromText] Ligands representation failed");
       }
 
       await newMolecule.centreOn("/*/*/*/*", false, true);
       dispatch(addMolecule(newMolecule));
       dispatch(showMolecule({ molNo: newMolecule.molNo } as any));
+      return newMolecule;
+    } catch (err) {
+      console.warn(err);
+      console.warn(`Cannot parse coords for ${molName} (${uniqueIdMarker})`);
+      return null;
+    }
+  }, [commandCentre, store, monomerLibraryPath, backgroundColor, defaultBondSmoothness, dispatch]);
+
+  const loadStructure = useCallback(async (
+    url: string,
+    molName: string,
+  ): Promise<moorhen.Molecule | null> => {
+    try {
+      const pdbData = await apiText(url);
+      return loadStructureFromText(pdbData, molName, url);
     } catch (err) {
       console.warn(err);
       console.warn(`Cannot fetch PDB entry from ${url}, doing nothing...`);
+      return null;
     }
-  }, [commandCentre, store, monomerLibraryPath, backgroundColor, defaultBondSmoothness, dispatch]);
+  }, [loadStructureFromText]);
+
+  const fetchMolecule = useCallback(async (url: string, molName: string) => {
+    await loadStructure(url, molName);
+  }, [loadStructure]);
 
   const fetchMap = useCallback(async (
     url: string,
@@ -522,13 +568,219 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     [jobId]
   );
 
-  // Custom side panel containing our control panel
+  // Scene fetcher: invoked by the resolver for file refs that aren't
+  // already loaded. Routes by ref shape:
+  //   pdb:                       → PDBe proxy (mmCIF)
+  //   fileId + projectId         → ccp4i2 proxy (per-project file id)
+  //   url:                       → direct URL fetch
+  // Returns the molecule that ends up in the store, or null if the fetch
+  // path fails (the resolver then leaves it in unresolvedFiles).
+  //
+  // Bundle assets are kept in a ref that handleApplyScene refreshes
+  // before each apply — keeps the fetcher callbacks stable while
+  // letting per-apply asset maps reach them.
+  const bundleAssetsRef = useRef<SceneBundleAssets>(new Map());
+
+  const handleFetchSceneFile: SceneFileFetcher = useCallback(
+    async (ref: SceneFileRef) => {
+      // Bundle: decode bytes from the in-memory asset map and hand the
+      // text straight to loadStructureFromText — no network round-trip,
+      // no Blob URL (which would get prefixed by the ccp4i2 api-fetch
+      // helper and 404).
+      if (ref.bundle) {
+        const buf = bundleAssetsRef.current.get(ref.bundle);
+        if (!buf) {
+          console.warn(
+            `[scene] bundle lookup miss: wanted "${ref.bundle}"; keys in map (${bundleAssetsRef.current.size}):`,
+            Array.from(bundleAssetsRef.current.keys()).slice(0, 10),
+          );
+          return null;
+        }
+        try {
+          const coordText = new TextDecoder("utf-8").decode(buf);
+          return await loadStructureFromText(
+            coordText,
+            ref.name || ref.bundle,
+            // Sentinel so matchOneFile recognises re-applies of the
+            // same bundle ref instead of re-fetching.
+            `bundle:${ref.bundle}`,
+          );
+        } catch (err) {
+          console.warn(`[scene] failed to load bundle coord ${ref.bundle}:`, err);
+          return null;
+        }
+      }
+      if (ref.pdb) {
+        const pdbId = ref.pdb.toLowerCase();
+        const url = `/api/proxy/pdbe/entry-files/download/${pdbId}.cif`;
+        return loadStructure(url, ref.name || pdbId);
+      }
+      if (ref.fileId !== undefined && ref.projectId) {
+        const url = `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
+        return loadStructure(url, ref.name || `file_${ref.fileId}`);
+      }
+      if (ref.url) {
+        return loadStructure(ref.url, ref.name || ref.url);
+      }
+      return null;
+    },
+    [loadStructure],
+  );
+
+  // Dictionary fetcher: returns raw CIF text for a `kind: dictionary`
+  // ref. PDB id form is not allowed (validator should reject) — only
+  // url, path, fileId+projectId, cifText, and bundle are valid for dicts.
+  // Dicts may contain multiple `data_comp_*` blocks; the resolver hands
+  // the whole text to Coot in one call so all blocks get parsed in one shot.
+  const handleFetchSceneDictionary = useCallback(
+    async (ref: SceneFileRef): Promise<string | null> => {
+      // Inline text: no network needed. The lifter produces these for
+      // dicts loaded from job outputs where there's no stable URL.
+      if (ref.cifText) return ref.cifText;
+      // Bundle: decode the asset bytes as UTF-8 text.
+      if (ref.bundle) {
+        const buf = bundleAssetsRef.current.get(ref.bundle);
+        if (!buf) return null;
+        try {
+          return new TextDecoder("utf-8").decode(buf);
+        } catch (err) {
+          console.warn(`[scene] dictionary ${ref.name} bundle decode failed:`, err);
+          return null;
+        }
+      }
+      let url: string | null = null;
+      if (ref.fileId !== undefined && ref.projectId) {
+        url = `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
+      } else if (ref.url) {
+        url = ref.url;
+      }
+      if (!url) return null;
+      try {
+        return await apiText(url);
+      } catch (err) {
+        console.warn(`[scene] failed to fetch dictionary ${ref.name}:`, err);
+        return null;
+      }
+    },
+    [],
+  );
+
+  // Dictionary loader: tells Coot to parse the given CIF and associate
+  // it with the given molNo (use -999999 for global). Matches the
+  // existing fragment-campaign pattern in fetchJobFiles.
+  const handleLoadSceneDictionary = useCallback(
+    async (dictText: string, molNo: number): Promise<void> => {
+      if (!commandCentre.current) return;
+      await commandCentre.current.cootCommand(
+        {
+          returnType: "status",
+          command: "read_dictionary_string",
+          commandArgs: [dictText, molNo],
+          changesMolecules: molNo >= 0 ? [molNo] : [],
+        },
+        false,
+      );
+    },
+    [],
+  );
+
+  // Apply a scene YAML: validate, then hand to the resolver with the
+  // refs/state it needs. Defined here because the wrapper owns dispatch
+  // and the command-centre ref. The optional assets map carries bytes
+  // for any `bundle:` refs the YAML uses; the Scenes panel passes it
+  // when a .scene.zip is loaded.
+  const handleApplyScene = useCallback(
+    async (
+      yamlText: string,
+      assets: SceneBundleAssets = new Map(),
+    ): Promise<SceneResolveResult> => {
+      // Refresh the bundle-assets ref so the (stable-identity) fetchers
+      // see this apply's assets. Cleared back to empty by the next
+      // non-bundled apply.
+      bundleAssetsRef.current = assets;
+      const scene = parseScene(yamlText);
+      return applyScene({
+        scene,
+        molecules,
+        dispatch,
+        fetcher: handleFetchSceneFile,
+        dictionaryFetcher: handleFetchSceneDictionary,
+        dictionaryLoader: handleLoadSceneDictionary,
+      });
+    },
+    [
+      molecules,
+      dispatch,
+      handleFetchSceneFile,
+      handleFetchSceneDictionary,
+      handleLoadSceneDictionary,
+    ],
+  );
+
+  // Resolve project context from jobId so downloaded scenes can include
+  // a stable projectId on their file references. Looked up once on mount;
+  // null when the wrapper isn't tied to a job.
+  const [projectInfo, setProjectInfo] = useState<{ id: string; name?: string } | null>(null);
+  useEffect(() => {
+    if (!jobId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const jobInfo = await apiGet(`jobs/${jobId}`);
+        if (cancelled || !jobInfo?.project) return;
+        // jobInfo.project is the project pk; fetch the uuid + name.
+        const proj = await apiGet(`projects/${jobInfo.project}`);
+        if (cancelled || !proj?.uuid) return;
+        setProjectInfo({ id: proj.uuid, name: proj.name });
+      } catch (err) {
+        console.warn("[wrapper] failed to resolve project for scene authoring:", err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [jobId]);
+
+  // Capture current state as a scene. Pulls glRef from the store on each
+  // click so the camera reflects the most recent rotation. Uses the
+  // bundle-aware lifter: if any molecule's source isn't portable (no
+  // pdb id / fileId / url) the lifter inlines its coords into the
+  // returned asset map, the YAML gets bundle: refs, and Save writes a
+  // .scene.zip. Portable refs (pdb / fileId / url) stay as-is.
+  const handleCaptureScene = useCallback(async (): Promise<{
+    scene: MoorhenScene;
+    hints: SceneLiftHints;
+    assets: SceneBundleAssets;
+  }> => {
+    const state = store.getState() as moorhen.State;
+    const glRefState = (state as unknown as { glRef: {
+      origin: number[] | Float32Array;
+      quat: number[] | Float32Array;
+      zoom: number;
+      clipStart?: number;
+      clipEnd?: number;
+      fogStart?: number;
+      fogEnd?: number;
+    } }).glRef;
+    return liftSceneToBundle({
+      molecules,
+      glRef: glRefState,
+      projectId: projectInfo?.id,
+      projectName: projectInfo?.name,
+    });
+  }, [store, molecules, projectInfo]);
+
+  // Custom side panels: CCP4i2 controls + Scenes (YAML editor + lifter +
+  // apply). Scene operations live in the Scenes panel exclusively; the
+  // CCP4i2 control row no longer carries the inline Apply/Download buttons.
+  // Single Moorhen side-panel registration whose content is our own MUI
+  // Tabs container hosting Controls and Scenes sub-panels. This sidesteps
+  // an upstream Moorhen quirk where registering two extraSidePanels only
+  // surfaces one tab in the panel switcher.
   const extraSidePanels: Record<string, MoorhenPanel> = useMemo(() => ({
     ccp4i2Controls: {
       icon: "MatSymSettings",
       label: "CCP4i2",
       panelContent: (
-        <MoorhenControlPanel
+        <MoorhenCcp4i2TabbedPanel
           onFileSelect={fetchFile}
           onJobLoad={fetchJobFiles}
           getViewUrl={getViewUrl}
@@ -537,10 +789,13 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
           onMapContourLevelChange={handleMapContourLevelChange}
           onRunServalcat={jobId ? handleRunServalcat : undefined}
           servalcatStatus={servalcatStatus}
+          onApplyScene={handleApplyScene}
+          onCaptureScene={handleCaptureScene}
+          cootInitialized={cootInitialized}
         />
       ),
     },
-  }), [fetchFile, fetchJobFiles, getViewUrl, molecules, maps, handleMapContourLevelChange, jobId, handleRunServalcat, servalcatStatus]);
+  }), [fetchFile, fetchJobFiles, getViewUrl, molecules, maps, handleMapContourLevelChange, jobId, handleRunServalcat, servalcatStatus, handleApplyScene, handleCaptureScene, cootInitialized]);
 
   const collectedProps = useMemo(() => ({
     glRef,

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -34,11 +34,17 @@ import { apiGet, apiText, apiArrayBuffer, apiPost, apiUpload } from "../../api-f
 import { useTheme } from "../../theme/theme-provider";
 import { useMoorhenViewState } from "../../hooks/use-moorhen-view-state";
 import { parseScene, serialiseScene } from "../../lib/moorhen-scene";
-import { applyScene, SceneResolveResult, SceneFileFetcher } from "../../lib/moorhen-scene-resolver";
+import {
+  applyScene,
+  SceneFileFetcher,
+  SceneMapFetcher,
+  SceneResolveResult,
+} from "../../lib/moorhen-scene-resolver";
 import type { SceneFileRef } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
 import {
   liftSceneToBundle,
+  MapRenderState,
   promoteSceneToPortable,
   SceneLiftHints,
   SceneRefUrlResolver,
@@ -689,6 +695,79 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     [],
   );
 
+  // Centralised URL-derivation for any URL-shaped ref kind. Shared by
+  // the fetcher (apply path), the map fetcher, and the promoter (export
+  // path) so they agree on what counts as "a resolvable ref". Declared
+  // here (above the consumers) so the closures pick it up cleanly.
+  const resolveSceneRefUrl: SceneRefUrlResolver = useCallback((ref) => {
+    if (ref.pdb) return `/api/proxy/pdbe/entry-files/download/${ref.pdb.toLowerCase()}.cif`;
+    if (ref.fileId !== undefined && ref.projectId) {
+      return `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
+    }
+    if (ref.url) return ref.url;
+    return null;
+  }, []);
+
+  // Map fetcher: produces a loaded MoorhenMap for a scene `kind: "mtz"`
+  // ref + SceneMap column spec. Bundle-asset bytes short-circuit the
+  // network; URL-resolvable refs go via the existing scene-file URL
+  // logic. Always uses loadToCootFromMtzData (taking raw bytes) so the
+  // bundle path doesn't need a Blob round-trip.
+  const handleFetchSceneMap: SceneMapFetcher = useCallback(
+    async (ref, sceneMap) => {
+      if (!commandCentre.current) return null;
+      let bytes: ArrayBuffer | null = null;
+      let uniqueId: string | null = null;
+      if (ref.bundle) {
+        const buf = bundleAssetsRef.current.get(ref.bundle);
+        if (!buf) {
+          console.warn(`[scene] map bundle miss: ${ref.bundle}`);
+          return null;
+        }
+        bytes = buf;
+        uniqueId = `bundle:${ref.bundle}`;
+      } else {
+        const url = resolveSceneRefUrl(ref);
+        if (!url) return null;
+        try {
+          bytes = await apiArrayBuffer(url);
+          uniqueId = url;
+        } catch (err) {
+          console.warn(`[scene] map fetch failed for ${ref.name}:`, err);
+          return null;
+        }
+      }
+      try {
+        const newMap = new MoorhenMap(
+          commandCentre as RefObject<moorhen.CommandCentre>,
+          store as any,
+        );
+        await newMap.loadToCootFromMtzData(
+          new Uint8Array(bytes as ArrayBuffer),
+          sceneMap.name,
+          {
+            F: sceneMap.columns.F,
+            PHI: sceneMap.columns.PHI,
+            Fobs: sceneMap.columns.Fobs,
+            SigFobs: sceneMap.columns.SigFobs,
+            FreeR: sceneMap.columns.FreeR,
+            useWeight: !!sceneMap.columns.useWeight,
+            calcStructFact: !!sceneMap.columns.calcStructFact,
+            isDifference: !!sceneMap.isDifference,
+          } as moorhen.selectedMtzColumns,
+        );
+        if (newMap.molNo === -1) return null;
+        if (uniqueId) newMap.uniqueId = uniqueId;
+        dispatch(addMap(newMap));
+        return newMap;
+      } catch (err) {
+        console.warn(`[scene] failed to load MTZ for ${ref.name}:`, err);
+        return null;
+      }
+    },
+    [commandCentre, store, dispatch, resolveSceneRefUrl],
+  );
+
   // Apply a scene YAML: validate, then hand to the resolver with the
   // refs/state it needs. Defined here because the wrapper owns dispatch
   // and the command-centre ref. The optional assets map carries bytes
@@ -707,18 +786,22 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       return applyScene({
         scene,
         molecules,
+        maps,
         dispatch,
         fetcher: handleFetchSceneFile,
         dictionaryFetcher: handleFetchSceneDictionary,
         dictionaryLoader: handleLoadSceneDictionary,
+        mapFetcher: handleFetchSceneMap,
       });
     },
     [
       molecules,
+      maps,
       dispatch,
       handleFetchSceneFile,
       handleFetchSceneDictionary,
       handleLoadSceneDictionary,
+      handleFetchSceneMap,
     ],
   );
 
@@ -743,24 +826,6 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     })();
     return () => { cancelled = true; };
   }, [jobId]);
-
-  // Capture current state as a scene. Pulls glRef from the store on each
-  // click so the camera reflects the most recent rotation. Uses the
-  // bundle-aware lifter: if any molecule's source isn't portable (no
-  // pdb id / fileId / url) the lifter inlines its coords into the
-  // returned asset map, the YAML gets bundle: refs, and Save writes a
-  // .scene.zip. Portable refs (pdb / fileId / url) stay as-is.
-  // Centralised URL-derivation for any URL-shaped ref kind. Shared by
-  // the fetcher (apply path) and the promoter (export path) so they
-  // agree on what counts as "a resolvable ref".
-  const resolveSceneRefUrl: SceneRefUrlResolver = useCallback((ref) => {
-    if (ref.pdb) return `/api/proxy/pdbe/entry-files/download/${ref.pdb.toLowerCase()}.cif`;
-    if (ref.fileId !== undefined && ref.projectId) {
-      return `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
-    }
-    if (ref.url) return ref.url;
-    return null;
-  }, []);
 
   // Promote an editor YAML to a fully self-contained scene + asset
   // bundle: every URL-resolvable ref is fetched into assets/ and
@@ -800,6 +865,14 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       fogStart?: number;
       fogEnd?: number;
     } }).glRef;
+    // Flatten Moorhen's per-attribute contour slices into one
+    // MapRenderState per molNo. mapContourSettings is keyed by
+    // molNo across several parallel lists in the redux slice; we
+    // gather them so the lifter can read off a single object.
+    const mapState = collectMapRenderState(state);
+    const activeMapMolNo =
+      (state as unknown as { generalStates?: { activeMap?: moorhen.Map | null } })
+        .generalStates?.activeMap?.molNo;
     return liftSceneToBundle({
       molecules,
       glRef: glRefState,
@@ -809,8 +882,11 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       // root (all molecules share it via the wrapper's construction).
       // Without it the lifter falls back to STANDARD_MONOMERS only.
       monomerLibraryPath: molecules[0]?.monomerLibraryPath,
+      maps,
+      mapState,
+      activeMapMolNo: typeof activeMapMolNo === "number" ? activeMapMolNo : undefined,
     });
-  }, [store, molecules, projectInfo]);
+  }, [store, molecules, maps, projectInfo]);
 
   // Custom side panels: CCP4i2 controls + Scenes (YAML editor + lifter +
   // apply). Scene operations live in the Scenes panel exclusively; the
@@ -899,3 +975,74 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
 };
 
 export default MoorhenWrapper;
+
+// --------------------------------------------------------------------------
+// Helpers — capture-path
+// --------------------------------------------------------------------------
+
+interface ContourEntry {
+  molNo: number;
+  contourLevel?: number;
+  radius?: number;
+  alpha?: number;
+  style?: "lines" | "solid" | "lit-lines";
+  rgb?: { r: number; g: number; b: number };
+}
+
+/**
+ * Flatten Moorhen's mapContourSettings slice — which stores per-attribute
+ * arrays keyed by molNo — into a single MapRenderState per molNo for the
+ * lifter to consume. Defensive: every field is optional, and we tolerate
+ * the slice being absent (older Moorhen versions, or no maps loaded).
+ */
+function collectMapRenderState(
+  state: unknown,
+): Record<number, MapRenderState> {
+  const out: Record<number, MapRenderState> = {};
+  const slice = (state as { mapContourSettings?: Record<string, unknown> })
+    .mapContourSettings;
+  if (!slice) return out;
+  const ensure = (molNo: number): MapRenderState => {
+    if (!out[molNo]) out[molNo] = {};
+    return out[molNo];
+  };
+  const merge = (
+    rows: unknown,
+    setter: (s: MapRenderState, v: ContourEntry) => void,
+  ) => {
+    if (!Array.isArray(rows)) return;
+    for (const row of rows as ContourEntry[]) {
+      if (typeof row?.molNo === "number") setter(ensure(row.molNo), row);
+    }
+  };
+  merge(slice.contourLevels, (s, v) => { if (v.contourLevel !== undefined) s.contourLevel = v.contourLevel; });
+  merge(slice.mapRadii, (s, v) => { if (v.radius !== undefined) s.radius = v.radius; });
+  merge(slice.mapAlpha, (s, v) => { if (v.alpha !== undefined) s.alpha = v.alpha; });
+  merge(slice.mapStyles, (s, v) => { if (v.style) s.style = v.style; });
+  merge(slice.mapColours, (s, v) => { if (v.rgb) s.colour = rgb01ToHex(v.rgb); });
+  merge(slice.positiveMapColours, (s, v) => { if (v.rgb) s.positiveColour = rgb01ToHex(v.rgb); });
+  merge(slice.negativeMapColours, (s, v) => { if (v.rgb) s.negativeColour = rgb01ToHex(v.rgb); });
+  const visible = (slice as { visibleMaps?: unknown }).visibleMaps;
+  if (Array.isArray(visible)) {
+    const visibleSet = new Set<number>(
+      (visible as unknown[]).filter((n): n is number => typeof n === "number"),
+    );
+    // visibleMaps lists the *visible* molNos; map state already includes
+    // every molNo we've seen, but make sure we don't drop a map that has
+    // no other contour settings touched.
+    for (const molNo of visibleSet) ensure(molNo);
+    for (const molNo of Object.keys(out).map(Number)) {
+      out[molNo].visible = visibleSet.has(molNo);
+    }
+  }
+  return out;
+}
+
+/** Convert Moorhen's {r,g,b} 0-1 shape to a 6-hex string. */
+function rgb01ToHex(rgb: { r: number; g: number; b: number }): string {
+  const to8 = (v: number) =>
+    Math.max(0, Math.min(255, Math.round(v * 255)))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${to8(rgb.r)}${to8(rgb.g)}${to8(rgb.b)}`;
+}

--- a/client/renderer/components/task/task-elements/fetch-file-for-param.tsx
+++ b/client/renderer/components/task/task-elements/fetch-file-for-param.tsx
@@ -170,18 +170,28 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
   const handleEbiCoordFetch = useCallback(async () => {
     if (identifier) {
       try {
-        const url = `https://www.ebi.ac.uk/pdbe/api/pdb/entry/files/${identifier.toLowerCase()}`;
+        // Route through the local /api/proxy/pdbe/... proxy so the response
+        // carries Cross-Origin-Resource-Policy: cross-origin and survives
+        // the Moorhen COEP page. Direct fetches to www.ebi.ac.uk surface
+        // as TypeError: Failed to fetch under COEP.
+        const url = `/api/proxy/pdbe/api/pdb/entry/files/${identifier.toLowerCase()}`;
         const result = await apiFetch(url);
         const data = await result.json();
         if (data && data[identifier.toLowerCase()]) {
           const file = data[identifier.toLowerCase()];
-          let fetchURL = file.PDB.downloads
+          const upstreamURL = file.PDB.downloads
             .filter((item: any) => item.label === "Archive mmCIF file")
             .at(0).url;
-          setMessage(`Fetching file from ${fetchURL}`);
+          // The PDBe API returns absolute URLs into www.ebi.ac.uk/pdbe/...
+          // Rewrite through the same proxy so the download is COEP-safe.
+          const fetchURL = upstreamURL.replace(
+            /^https?:\/\/www\.ebi\.ac\.uk\/pdbe\//,
+            "/api/proxy/pdbe/",
+          );
+          setMessage(`Fetching file from ${upstreamURL}`);
           const content = await apiBlob(fetchURL);
-          setMessage(`Fetched file from ${fetchURL}`);
-          uploadFile(content, fetchURL.split("/").at(-1));
+          setMessage(`Fetched file from ${upstreamURL}`);
+          uploadFile(content, upstreamURL.split("/").at(-1));
           onClose();
         } else {
           const errorText = await result.text();

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -60,6 +60,12 @@ export interface LiftCtx {
   sceneName?: string;
   /** Optional: who is authoring (email/username). */
   createdBy?: string;
+  /** Optional: Moorhen's monomer library URL root (e.g. "/baby-gru/monomers").
+   *  When set, the lifter HEAD-probes `${monomerLibraryPath}/<l>/<UPPER>.cif`
+   *  per ligand and skips dicts that already resolve there, so common
+   *  cofactors (ATP, HEM, NAD, …) don't bloat the captured YAML.
+   *  Without it, only the built-in STANDARD_MONOMERS set is skipped. */
+  monomerLibraryPath?: string;
 }
 
 /**
@@ -244,6 +250,39 @@ export async function liftSceneToBundle(ctx: LiftCtx): Promise<{
   const { scene, hints } = liftSceneWithHints(ctx);
   const assets = new Map<string, ArrayBuffer>();
 
+  // 0. Drop dict refs whose comp_id is already in Moorhen's monomer
+  //    library: when the receiving Moorhen loads coords, its
+  //    loadMissingMonomer machinery will fetch the same dict from the
+  //    same library, so carrying our copy in the scene only bloats the
+  //    YAML and risks shipping a stale variant. The probe is keyed off
+  //    the comp_id, which we rebuild by mirroring liftDictionariesForMolecule.
+  if (ctx.monomerLibraryPath) {
+    const libraryHas = await probeMonomerLibrary(
+      ctx.molecules,
+      ctx.monomerLibraryPath,
+    );
+    if (libraryHas.size > 0) {
+      const dropNames = new Set<string>();
+      for (const ref of scene.files ?? []) {
+        if (ref.kind !== "dictionary") continue;
+        // Names are `dict-<molFileName>-<COMP_ID>` from liftDictionariesForMolecule.
+        // Pull the trailing comp_id off rather than slicing on first hyphen
+        // (the molFileName may itself contain hyphens).
+        const m = /^dict-.*-([A-Za-z0-9]+)$/.exec(ref.name);
+        if (!m) continue;
+        if (libraryHas.has(m[1].toUpperCase())) dropNames.add(ref.name);
+      }
+      if (dropNames.size > 0) {
+        scene.files = (scene.files ?? []).filter((f) => !dropNames.has(f.name));
+        for (const el of scene.elements ?? []) {
+          if (!el.dictionaries) continue;
+          el.dictionaries = el.dictionaries.filter((n) => !dropNames.has(n));
+          if (el.dictionaries.length === 0) delete el.dictionaries;
+        }
+      }
+    }
+  }
+
   // 1. Replace each coord file ref with a bundle: ref carrying the
   //    current coords. Skip refs the lifter wrote as PDB IDs / project
   //    fileIds — those are already self-resolving and don't need
@@ -293,6 +332,208 @@ export async function liftSceneToBundle(ctx: LiftCtx): Promise<{
   }
 
   return { scene, hints, assets };
+}
+
+/**
+ * Resolve a SceneFileRef to a URL the browser can `fetch()`, or null
+ * if the ref doesn't carry enough information (e.g. a bare `path:` or
+ * an already-bundled ref). Supplied by the wrapper, which knows the
+ * site-specific proxy routes.
+ */
+export type SceneRefUrlResolver = (ref: SceneFileRef) => string | null;
+
+export interface PromoteCtx {
+  /** Parsed scene to promote. Mutated in place; pass a clone if you
+   *  need the original. */
+  scene: MoorhenScene;
+  /** Asset bytes already present (e.g. from a .scene.zip the user opened).
+   *  New assets are merged into a fresh map so the caller can choose to
+   *  keep, discard, or diff. */
+  existingAssets: Map<string, ArrayBuffer>;
+  /** Function that yields a fetchable URL for any URL-shaped ref kind
+   *  (pdb / url / fileId+projectId / path-as-URL). */
+  resolveUrl: SceneRefUrlResolver;
+  /** Live molecules — used to re-collect library-resolvable dicts that
+   *  the lifter omitted from the YAML. Optional: if not provided, no
+   *  library-dict re-collection happens. */
+  molecules?: moorhen.Molecule[];
+  /** Optional monomer library URL root for library-dict re-collection. */
+  monomerLibraryPath?: string;
+}
+
+/**
+ * Walk a scene and gather every external dependency into a single
+ * self-contained bundle. For each URL-resolvable ref (pdb / url /
+ * fileId+projectId / path), fetch the bytes and rewrite the ref to
+ * `bundle: assets/<unique>.<ext>`. For each ligand whose dict was
+ * skipped at lift time (because it lives in the monomer library),
+ * fetch it from the library and add a fresh dict ref.
+ *
+ * Asset paths are name-mangled on collision (`name.cif`, `name-2.cif`).
+ *
+ * Returns the in-place-mutated scene and a fresh assets map (merging
+ * `existingAssets` with all newly-fetched bytes). The caller is
+ * responsible for serialising the scene to YAML and zipping the assets.
+ */
+export async function promoteSceneToPortable(ctx: PromoteCtx): Promise<{
+  scene: MoorhenScene;
+  assets: Map<string, ArrayBuffer>;
+  warnings: string[];
+}> {
+  const { scene, existingAssets, resolveUrl, molecules, monomerLibraryPath } = ctx;
+  const assets = new Map(existingAssets);
+  const warnings: string[] = [];
+
+  // Names already taken in the asset map — used to mangle on collision.
+  const usedPaths = new Set<string>(assets.keys());
+  const claim = (preferred: string): string => {
+    if (!usedPaths.has(preferred)) {
+      usedPaths.add(preferred);
+      return preferred;
+    }
+    const dot = preferred.lastIndexOf(".");
+    const base = dot > 0 ? preferred.slice(0, dot) : preferred;
+    const ext = dot > 0 ? preferred.slice(dot) : "";
+    for (let i = 2; ; i++) {
+      const candidate = `${base}-${i}${ext}`;
+      if (!usedPaths.has(candidate)) {
+        usedPaths.add(candidate);
+        return candidate;
+      }
+    }
+  };
+
+  // 1. URL-resolvable refs → bundle. Coord and dict refs alike: anything
+  //    with a fetchable URL gets pulled and stashed under assets/.
+  for (const ref of scene.files ?? []) {
+    if (ref.bundle) continue; // already bundled
+    if (ref.kind === "dictionary" && ref.cifText) {
+      // Inline cifText: move it to a bundle asset (mirrors liftSceneToBundle
+      // step 2). Cheaper than refetching and works without a URL.
+      const assetPath = claim(`assets/${ref.name}.cif`);
+      assets.set(assetPath, new TextEncoder().encode(ref.cifText).buffer);
+      ref.bundle = assetPath;
+      delete ref.cifText;
+      continue;
+    }
+    const url = resolveUrl(ref);
+    if (!url) {
+      warnings.push(`No URL for ref "${ref.name}"; left as-is`);
+      continue;
+    }
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        warnings.push(`Fetch ${url} for "${ref.name}" returned ${res.status}; left as-is`);
+        continue;
+      }
+      const buf = await res.arrayBuffer();
+      const ext = extForRef(ref, url);
+      const assetPath = claim(`assets/${ref.name}.${ext}`);
+      assets.set(assetPath, buf);
+      // Replace symbolic source fields with the bundle reference. Keep
+      // `kind` since downstream resolver cares.
+      delete ref.pdb;
+      delete ref.url;
+      delete ref.path;
+      delete ref.fileId;
+      delete ref.projectId;
+      delete ref.projectName;
+      ref.bundle = assetPath;
+    } catch (err) {
+      warnings.push(
+        `Fetch ${url} for "${ref.name}" failed (${err instanceof Error ? err.message : "unknown"}); left as-is`,
+      );
+    }
+  }
+
+  // 2. Library-dict re-collection. The lifter strips dicts whose
+  //    comp_id resolves to the monomer library; self-contained mode
+  //    wants them back. Walk live molecules; for each non-standard
+  //    comp_id that the library has AND isn't already in the scene's
+  //    dict refs, fetch it and append a fresh ref.
+  if (molecules && monomerLibraryPath) {
+    const existingDictNames = new Set(
+      (scene.files ?? []).filter((f) => f.kind === "dictionary").map((f) => f.name),
+    );
+    for (const mol of molecules) {
+      const molFileName = findFileNameForMol(scene, mol);
+      if (!molFileName) continue;
+      const ligands = mol.ligands ?? [];
+      const compIds = Array.from(new Set(ligands.map((l) => l.resName).filter(Boolean)));
+      for (const compId of compIds) {
+        if (STANDARD_MONOMERS.has(compId)) continue; // never travelled
+        const dictName = `dict-${molFileName}-${compId}`;
+        if (existingDictNames.has(dictName)) continue;
+        const url = `${monomerLibraryPath}/${compId[0].toLowerCase()}/${compId.toUpperCase()}.cif`;
+        try {
+          const res = await fetch(url);
+          if (!res.ok) continue;
+          const buf = await res.arrayBuffer();
+          const assetPath = claim(`assets/${dictName}.cif`);
+          assets.set(assetPath, buf);
+          const newRef: SceneFileRef = {
+            name: dictName,
+            kind: "dictionary",
+            bundle: assetPath,
+          };
+          (scene.files ??= []).push(newRef);
+          existingDictNames.add(dictName);
+          const el = (scene.elements ?? []).find((e) => e.file === molFileName);
+          if (el) {
+            el.dictionaries = el.dictionaries ?? [];
+            if (!el.dictionaries.includes(dictName)) el.dictionaries.push(dictName);
+          }
+        } catch {
+          // network errors → leave the dict out; receiver's own Moorhen
+          // will fetch from its own library at apply time.
+        }
+      }
+    }
+  }
+
+  return { scene, assets, warnings };
+}
+
+/**
+ * Best-effort extension picker for a fetched asset. Dict refs are CIF;
+ * coord refs fall back to the URL's trailing extension, else "cif".
+ */
+function extForRef(ref: SceneFileRef, url: string): string {
+  if (ref.kind === "dictionary") return "cif";
+  const m = /\.([A-Za-z0-9]{2,4})(?:\?|$)/.exec(url);
+  if (m) return m[1].toLowerCase();
+  return "cif";
+}
+
+/**
+ * Find which scene.files entry corresponds to a loaded molecule, using
+ * the same heuristics as liftScene: sanitised name or mol-index. Used
+ * by promote to attach re-collected dict refs to the right element.
+ */
+function findFileNameForMol(
+  scene: MoorhenScene,
+  mol: moorhen.Molecule,
+): string | null {
+  const sanitised = sanitiseName(mol.name);
+  for (const f of scene.files ?? []) {
+    if (f.name === sanitised) return f.name;
+  }
+  // Project-internal: match by fileId in uniqueId.
+  const fid = extractFileIdFromUniqueId(mol.uniqueId ?? "");
+  if (fid !== null) {
+    for (const f of scene.files ?? []) {
+      if (f.fileId === fid) return f.name;
+    }
+  }
+  // Bundle round-trip: uniqueId is `bundle:<path>`.
+  if (mol.uniqueId?.startsWith("bundle:")) {
+    const path = mol.uniqueId.slice("bundle:".length);
+    for (const f of scene.files ?? []) {
+      if (f.bundle === path) return f.name;
+    }
+  }
+  return null;
 }
 
 // --------------------------------------------------------------------------
@@ -404,7 +645,9 @@ function liftColour(rules: moorhen.ColourRule[]): SceneColour | undefined {
 
   // 2. Single-colour rule with a hex colour (Moorhen's "molecule" ruleType
   //    or anything with isMultiColourRule=false).
-  if (!r.isMultiColourRule && typeof r.color === "string" && /^#[0-9a-fA-F]{6}$/.test(r.color)) {
+  // Accept 6-hex (#rrggbb) and 8-hex with alpha (#rrggbbaa) — Moorhen's
+  // default per-chain rules typically come out as 8-hex.
+  if (!r.isMultiColourRule && typeof r.color === "string" && /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(r.color)) {
     return r.color;
   }
 
@@ -416,7 +659,7 @@ function liftColour(rules: moorhen.ColourRule[]): SceneColour | undefined {
   if (
     r.isMultiColourRule &&
     typeof r.args?.[0] === "string" &&
-    /^\/\/[^/]+\/-?\d+--?\d+\^#[0-9a-fA-F]{6}(\|\/\/[^/]+\/-?\d+--?\d+\^#[0-9a-fA-F]{6})*$/.test(
+    /^\/\/[^/]+\/-?\d+--?\d+\^#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?(\|\/\/[^/]+\/-?\d+--?\d+\^#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?)*$/.test(
       r.args[0] as string,
     )
   ) {
@@ -463,4 +706,42 @@ function round(n: number, dp: number): number {
 
 function hasAnyValue(o: Record<string, unknown>): boolean {
   return Object.values(o).some((v) => v !== undefined);
+}
+
+/**
+ * HEAD-probe each candidate comp_id against the monomer library and
+ * return the set that resolves there (uppercase). A non-2xx (or thrown
+ * fetch) is treated as "not present" — conservative: we'd rather ship
+ * a dict the receiver might already have than drop one they don't.
+ *
+ * `STANDARD_MONOMERS` are short-circuited (always treated as present)
+ * so we don't issue probes for the 20 amino acids on every capture.
+ */
+async function probeMonomerLibrary(
+  molecules: moorhen.Molecule[],
+  monomerLibraryPath: string,
+): Promise<Set<string>> {
+  const compIds = new Set<string>();
+  for (const mol of molecules) {
+    for (const lig of mol.ligands ?? []) {
+      if (lig.resName) compIds.add(lig.resName.toUpperCase());
+    }
+  }
+  const present = new Set<string>();
+  await Promise.all(
+    [...compIds].map(async (cid) => {
+      if (STANDARD_MONOMERS.has(cid)) {
+        present.add(cid);
+        return;
+      }
+      const url = `${monomerLibraryPath}/${cid[0].toLowerCase()}/${cid}.cif`;
+      try {
+        const res = await fetch(url, { method: "HEAD" });
+        if (res.ok) present.add(cid);
+      } catch {
+        // network errors → treat as not-present; the dict will travel.
+      }
+    }),
+  );
+  return present;
 }

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -30,6 +30,8 @@ import {
   SceneDomain,
   SceneElement,
   SceneFileRef,
+  SceneMap,
+  SceneMapColumns,
   SceneRepresentation,
   SceneView,
 } from "../types/moorhen-scene";
@@ -66,6 +68,37 @@ export interface LiftCtx {
    *  cofactors (ATP, HEM, NAD, …) don't bloat the captured YAML.
    *  Without it, only the built-in STANDARD_MONOMERS set is skipped. */
   monomerLibraryPath?: string;
+  /** Moorhen maps currently in the store. Each must carry a populated
+   *  uniqueId (the MTZ loader URL) plus selectedColumns + isDifference
+   *  for the lifter to emit a SceneMap. */
+  maps?: moorhen.Map[];
+  /** Per-map render state from the mapContourSettings slice, keyed by
+   *  map.molNo. The wrapper flattens this from the store before calling
+   *  lift — keeps the lifter store-agnostic and easier to unit-test. */
+  mapState?: Record<number, MapRenderState>;
+  /** molNo of the currently-active map (state.generalStates.activeMap.molNo).
+   *  Drives scene.activeMap. */
+  activeMapMolNo?: number;
+}
+
+/**
+ * Per-map render state pulled from Moorhen's redux slices and handed to
+ * the lifter in LiftCtx.mapState. All fields optional — the lifter only
+ * emits the ones whose captured value differs from Moorhen's defaults
+ * so the YAML stays terse.
+ */
+export interface MapRenderState {
+  contourLevel?: number;
+  radius?: number;
+  alpha?: number;
+  style?: "lines" | "solid" | "lit-lines";
+  /** Hex (#rrggbb) — for non-difference maps. */
+  colour?: string;
+  /** Hex — for the positive lobe of a difference map. */
+  positiveColour?: string;
+  /** Hex — for the negative lobe of a difference map. */
+  negativeColour?: string;
+  visible?: boolean;
 }
 
 /**
@@ -126,6 +159,31 @@ export function liftScene(ctx: LiftCtx): MoorhenScene {
   }
 
   if (elements.length > 0) scene.elements = elements;
+
+  // Maps. Each map gets a SceneFileRef (kind: "mtz") appended to
+  // scene.files plus a SceneMap entry referencing it by name. The
+  // wrapper flattens map render state from the contour-settings slice
+  // into LiftCtx.mapState; activeMap is the molNo whose name we
+  // promote to scene.activeMap.
+  if (ctx.maps && ctx.maps.length > 0) {
+    const maps: SceneMap[] = [];
+    ctx.maps.forEach((map, i) => {
+      const fileRef = liftMapFileRef(map, ctx, i);
+      // De-dupe file refs by name. (Possible if a map and a molecule
+      // share a sanitised loader URL — rare but defensive.)
+      if (!(scene.files ?? []).some((f) => f.name === fileRef.name)) {
+        scene.files = scene.files ?? [];
+        scene.files.push(fileRef);
+      }
+      const mapName = sanitiseName(map.name) || `map${i}`;
+      const sceneMap = liftSceneMap(map, fileRef.name, mapName, ctx.mapState);
+      maps.push(sceneMap);
+      if (ctx.activeMapMolNo !== undefined && map.molNo === ctx.activeMapMolNo) {
+        scene.activeMap = mapName;
+      }
+    });
+    if (maps.length > 0) scene.maps = maps;
+  }
 
   return scene;
 }
@@ -501,6 +559,7 @@ export async function promoteSceneToPortable(ctx: PromoteCtx): Promise<{
  */
 function extForRef(ref: SceneFileRef, url: string): string {
   if (ref.kind === "dictionary") return "cif";
+  if (ref.kind === "mtz") return "mtz";
   const m = /\.([A-Za-z0-9]{2,4})(?:\?|$)/.exec(url);
   if (m) return m[1].toLowerCase();
   return "cif";
@@ -566,6 +625,96 @@ function liftFileRef(mol: moorhen.Molecule, ctx: LiftCtx): SceneFileRef {
 
   // Last resort: a placeholder url that the user will edit.
   return { name, url: "TODO: source URL for this molecule" };
+}
+
+// --------------------------------------------------------------------------
+// Maps
+// --------------------------------------------------------------------------
+
+/**
+ * Lift a SceneFileRef for an MTZ-loaded map. Mirrors liftFileRef for
+ * coordinate molecules but tags the ref with kind: "mtz" and disambiguates
+ * the name from any coord ref by suffixing with the map index.
+ */
+function liftMapFileRef(map: moorhen.Map, ctx: LiftCtx, index: number): SceneFileRef {
+  const baseName = sanitiseName(map.name) || `map${index}`;
+  const name = `${baseName}__mtz`;
+
+  const fileId = extractFileIdFromUniqueId(map.uniqueId ?? "");
+  if (fileId !== null && ctx.projectId) {
+    return {
+      name,
+      kind: "mtz",
+      projectId: ctx.projectId,
+      projectName: ctx.projectName,
+      fileId,
+    };
+  }
+  if (map.uniqueId && /^https?:\/\//.test(map.uniqueId)) {
+    return { name, kind: "mtz", url: map.uniqueId };
+  }
+  if (map.uniqueId) {
+    return { name, kind: "mtz", path: map.uniqueId };
+  }
+  return { name, kind: "mtz", url: "TODO: MTZ URL for this map" };
+}
+
+/**
+ * Build a SceneMap entry for a loaded MoorhenMap. Pulls the column
+ * spec straight from `map.selectedColumns` and reads optional render
+ * state from the wrapper-supplied `mapState` keyed by molNo. Difference
+ * maps only emit positive/negative colours; non-difference maps emit
+ * a single `colour` field.
+ */
+function liftSceneMap(
+  map: moorhen.Map,
+  fileName: string,
+  mapName: string,
+  mapState?: Record<number, MapRenderState>,
+): SceneMap {
+  const columns = stripUndefinedColumns(map.selectedColumns);
+  const out: SceneMap = {
+    name: mapName,
+    file: fileName,
+    columns,
+  };
+  if (map.isDifference) out.isDifference = true;
+
+  const s = mapState?.[map.molNo];
+  if (!s) return out;
+
+  if (s.contourLevel !== undefined) out.contourLevel = round(s.contourLevel, 4);
+  if (s.radius !== undefined) out.radius = round(s.radius, 2);
+  if (s.alpha !== undefined && s.alpha !== 1) out.alpha = round(s.alpha, 3);
+  if (s.style && s.style !== "lit-lines") out.style = s.style;
+  if (s.visible === false) out.visible = false;
+
+  // Colour fields: difference maps split into positive/negative;
+  // non-difference maps carry a single colour.
+  if (map.isDifference) {
+    if (s.positiveColour) out.positiveColour = s.positiveColour;
+    if (s.negativeColour) out.negativeColour = s.negativeColour;
+  } else if (s.colour) {
+    out.colour = s.colour;
+  }
+  return out;
+}
+
+/**
+ * Drop undefined / empty-string fields from a column spec so the YAML
+ * doesn't carry no-op entries like `Fobs:` (with no value).
+ */
+function stripUndefinedColumns(c: Partial<SceneMapColumns> | undefined): SceneMapColumns {
+  const out: SceneMapColumns = {};
+  if (!c) return out;
+  const strKeys: (keyof SceneMapColumns)[] = ["F", "PHI", "Fobs", "SigFobs", "FreeR"];
+  for (const k of strKeys) {
+    const v = c[k];
+    if (typeof v === "string" && v.length > 0) (out as Record<string, unknown>)[k] = v;
+  }
+  if (c.useWeight) out.useWeight = true;
+  if (c.calcStructFact) out.calcStructFact = true;
+  return out;
 }
 
 // --------------------------------------------------------------------------

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -1,0 +1,466 @@
+/**
+ * Moorhen Scene lifter: Moorhen state → MoorhenScene.
+ *
+ * Captures what's currently shown in the viewer as a scene the user can
+ * download, hand-edit, and re-apply. v0 scope mirrors the user's actual
+ * authoring workflow:
+ *
+ *  - Always lifted: files, camera, per-molecule representation list with
+ *    their CID selections.
+ *  - Lifted if recognisable: colour rules — only named multi-rule schemes
+ *    (b-factor, af2-plddt, secondary-structure, ...), single-colour hex,
+ *    and the by-domain pipe-delimited shape that parses back cleanly.
+ *  - Unknown colour rules: emitted under the `{ raw: { ruleType, args } }`
+ *    escape hatch so they round-trip losslessly even when unreadable.
+ *  - Dropped: bond options, m2t params, lighting, SSAO. The user can add
+ *    these by hand in the yaml if they want them.
+ *
+ * No serialisation in this file — it returns a MoorhenScene. The
+ * companion serialiser (moorhen-scene.ts) handles YAML conversion.
+ * The "download scene" UI button glues the two together.
+ */
+
+import type { moorhen } from "moorhen/types/moorhen";
+
+import { extractFileIdFromUniqueId } from "./moorhen-view-state";
+import {
+  MoorhenScene,
+  SCENE_SCHEMA_VERSION,
+  SceneColour,
+  SceneDomain,
+  SceneElement,
+  SceneFileRef,
+  SceneRepresentation,
+  SceneView,
+} from "../types/moorhen-scene";
+
+// --------------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------------
+
+export interface LiftCtx {
+  /** The molecules currently in Moorhen. */
+  molecules: moorhen.Molecule[];
+  /** glRef state (origin, quat, zoom, clip*, fog*). Pass `store.getState().glRef`. */
+  glRef: {
+    origin: number[] | Float32Array;
+    quat: number[] | Float32Array;
+    zoom: number;
+    clipStart?: number;
+    clipEnd?: number;
+    fogStart?: number;
+    fogEnd?: number;
+  };
+  /** Optional: the ccp4i2 project UUID. If set, file refs get both
+   *  projectId and (derivable) fileId. */
+  projectId?: string;
+  /** Optional: human-readable project name (advisory). */
+  projectName?: string;
+  /** Optional: scene name. Default "scene-<isoDate>". */
+  sceneName?: string;
+  /** Optional: who is authoring (email/username). */
+  createdBy?: string;
+}
+
+/**
+ * Capture the current Moorhen state as a MoorhenScene. The returned
+ * object is independently serialisable by serialiseScene().
+ *
+ * Per-rep `uniqueId` strings (the loader URL) survive as carried-over
+ * properties on the returned SceneFileRef under a non-enumerable internal
+ * symbol, used by the serialiser to emit a YAML comment naming the
+ * original source. Callers that go through serialiseSceneWithLiftHints
+ * see those comments; everyone else sees a clean MoorhenScene.
+ */
+export function liftScene(ctx: LiftCtx): MoorhenScene {
+  const scene: MoorhenScene = {
+    scene: ctx.sceneName ?? `scene-${new Date().toISOString().slice(0, 19).replace(/[T:]/g, "-")}`,
+    version: SCENE_SCHEMA_VERSION,
+  };
+
+  scene.authoredIn = {
+    projectId: ctx.projectId,
+    projectName: ctx.projectName,
+    createdAt: new Date().toISOString(),
+    createdBy: ctx.createdBy,
+  };
+  if (!hasAnyValue(scene.authoredIn as Record<string, unknown>)) {
+    delete scene.authoredIn;
+  }
+
+  scene.files = ctx.molecules.map((mol) => liftFileRef(mol, ctx));
+  if (scene.files.length === 0) delete scene.files;
+
+  // Lift dictionaries scoped to each molecule. For each loaded molecule
+  // we enumerate non-standard residue types and ask Moorhen for the
+  // stored dict text. We emit them as `kind: dictionary` file refs with
+  // an inline `cifText:`, keyed by molecule + comp_id so the same dict
+  // applied to two molecules ends up as two separate entries (matches
+  // the per-molecule scoping semantics).
+  const liftedDicts: { mol: moorhen.Molecule; molFileName: string; refs: { name: string; comp_id: string }[] }[] = [];
+  ctx.molecules.forEach((mol, i) => {
+    const molFileName = scene.files?.[i]?.name ?? `mol${i}`;
+    const liftedRefs = liftDictionariesForMolecule(mol, molFileName, scene.files!);
+    if (liftedRefs.length > 0) {
+      liftedDicts.push({ mol, molFileName, refs: liftedRefs });
+    }
+  });
+
+  const view = liftView(ctx.glRef);
+  if (view) scene.view = view;
+
+  const elements = ctx.molecules
+    .map((mol, i) => liftElement(mol, scene.files?.[i]?.name ?? `mol${i}`))
+    .filter((el): el is SceneElement => el !== null);
+
+  // Attach the lifted dict refs to the element for their molecule.
+  for (const { molFileName, refs } of liftedDicts) {
+    const el = elements.find((e) => e.file === molFileName);
+    if (el) el.dictionaries = refs.map((r) => r.name);
+  }
+
+  if (elements.length > 0) scene.elements = elements;
+
+  return scene;
+}
+
+/**
+ * Enumerate non-standard residues in a molecule and emit a SceneFileRef
+ * per (molecule, comp_id) pair where Moorhen has a stored dictionary
+ * for that residue. Appends the new refs to `allFiles` (the scene's
+ * `files:` block) and returns the (name, comp_id) list for the caller
+ * to use when wiring them into the element.
+ *
+ * Naming: dict refs get names like `dict-<molFileName>-<comp_id>` to
+ * stay readable while staying unique across multiple molecules with
+ * same-named ligands.
+ */
+function liftDictionariesForMolecule(
+  mol: moorhen.Molecule,
+  molFileName: string,
+  allFiles: SceneFileRef[],
+): { name: string; comp_id: string }[] {
+  const ligands = mol.ligands ?? [];
+  // Dedupe by comp_id — multiple instances of the same ligand share a dict.
+  const compIds = Array.from(new Set(ligands.map((l) => l.resName).filter(Boolean)));
+  const out: { name: string; comp_id: string }[] = [];
+
+  for (const comp_id of compIds) {
+    if (STANDARD_MONOMERS.has(comp_id)) continue;
+    let dictText = "";
+    try {
+      dictText = mol.getDict(comp_id) || "";
+    } catch {
+      // getDict may throw for comp_ids without a stored dict — that's
+      // fine, just skip them.
+      continue;
+    }
+    if (!dictText) continue;
+
+    const name = `dict-${molFileName}-${comp_id}`;
+    // Skip if a ref with this name already exists (shouldn't happen but
+    // defensive against pathological dupe-suppression).
+    if (allFiles.some((f) => f.name === name)) continue;
+
+    allFiles.push({
+      name,
+      kind: "dictionary",
+      cifText: dictText,
+    });
+    out.push({ name, comp_id });
+  }
+  return out;
+}
+
+/**
+ * Residue types Coot already knows about — we shouldn't emit dicts for
+ * these because they're built-in. Conservative list: 20 amino acids,
+ * standard nucleotides, water/ions/cofactors that come with the monomer
+ * library. If a structure carries a non-standard variant (e.g. SEP,
+ * PTR) we want to capture *that* dict, so those are intentionally absent.
+ */
+const STANDARD_MONOMERS: ReadonlySet<string> = new Set([
+  // Standard amino acids
+  "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS", "ILE",
+  "LEU", "LYS", "MET", "PHE", "PRO", "SER", "THR", "TRP", "TYR", "VAL",
+  // Standard nucleotides
+  "A", "C", "G", "T", "U", "DA", "DC", "DG", "DT", "DU",
+  // Waters and very common ions/cofactors
+  "HOH", "WAT", "H2O", "OH2",
+]);
+
+/**
+ * Per-file annotations the lifter can produce that don't fit in the
+ * MoorhenScene type itself (e.g. "the loader URL this file came from",
+ * which we want emitted as a YAML comment by the serialiser).
+ *
+ * Returned as a parallel structure keyed by file name. The download-UI
+ * glue passes these to the serialiser; pure parse/serialise flows ignore
+ * them.
+ */
+export interface SceneLiftHints {
+  /** Comments to attach above each `files[i]` entry, keyed by SceneFileRef.name. */
+  fileComments: Record<string, string>;
+}
+
+/**
+ * Same as liftScene, but also returns hints for richer YAML output
+ * (currently: a comment above each file entry naming its uniqueId).
+ */
+export function liftSceneWithHints(ctx: LiftCtx): {
+  scene: MoorhenScene;
+  hints: SceneLiftHints;
+} {
+  const scene = liftScene(ctx);
+  const fileComments: Record<string, string> = {};
+  ctx.molecules.forEach((mol, i) => {
+    const fr = scene.files?.[i];
+    if (fr && mol.uniqueId) {
+      fileComments[fr.name] = `loaded from ${mol.uniqueId}`;
+    }
+  });
+  return { scene, hints: { fileComments } };
+}
+
+/**
+ * Lift a scene AND a parallel asset map suitable for bundling into a
+ * `.scene.zip`. Compared to liftScene/liftSceneWithHints, this:
+ *
+ *  - For each loaded coordinate molecule, asks Moorhen for the current
+ *    coord text via mol.getAtoms() and emits a `bundle:` file ref. The
+ *    bytes go into the asset map under `assets/<safeName>.<ext>`.
+ *  - Already-emitted `cifText:` dictionary refs are moved into bundle
+ *    assets too, because once we have a zip there's no reason to inline
+ *    them in the YAML.
+ *
+ * The returned scene is self-contained: serialised to YAML and zipped
+ * up alongside its asset map, it round-trips on any machine.
+ */
+export async function liftSceneToBundle(ctx: LiftCtx): Promise<{
+  scene: MoorhenScene;
+  hints: SceneLiftHints;
+  assets: Map<string, ArrayBuffer>;
+}> {
+  const { scene, hints } = liftSceneWithHints(ctx);
+  const assets = new Map<string, ArrayBuffer>();
+
+  // 1. Replace each coord file ref with a bundle: ref carrying the
+  //    current coords. Skip refs the lifter wrote as PDB IDs / project
+  //    fileIds — those are already self-resolving and don't need
+  //    inlining.
+  const filesByName = new Map<string, SceneFileRef>();
+  for (const f of scene.files ?? []) filesByName.set(f.name, f);
+
+  for (const mol of ctx.molecules) {
+    const ref = scene.files?.find(
+      (f) => f.name === sanitiseName(mol.name) || f.name === `mol${ctx.molecules.indexOf(mol)}`,
+    );
+    if (!ref) continue;
+    if (ref.kind === "dictionary") continue; // handled below
+    // Only inline coords for refs that aren't already pdb/fileId/url —
+    // those are portable on their own. Bundle is for "this only exists
+    // in memory or on local disk".
+    const alreadyPortable = !!ref.pdb || ref.fileId !== undefined || !!ref.url;
+    if (alreadyPortable) continue;
+
+    try {
+      const coordText = await mol.getAtoms();
+      if (!coordText) continue;
+      const ext = (mol.coordsFormat === "mmcif" || mol.coordsFormat === "mmjson") ? "cif" : "pdb";
+      const assetPath = `assets/${ref.name}.${ext}`;
+      assets.set(assetPath, new TextEncoder().encode(coordText).buffer);
+      // Replace the unresolvable path: form with the portable bundle: form.
+      ref.bundle = assetPath;
+      delete ref.path;
+      // Preserve the original path as a comment so the round-tripped
+      // YAML still records where the user originally pulled this from.
+      if (mol.uniqueId && !hints.fileComments[ref.name]) {
+        hints.fileComments[ref.name] = `originally from ${mol.uniqueId}`;
+      }
+    } catch (err) {
+      console.warn(`[lift] could not bundle coords for ${ref.name}:`, err);
+    }
+  }
+
+  // 2. Move cifText dicts into bundle assets. Cleaner YAML + smaller
+  //    when the same dict appears via multiple scenes.
+  for (const ref of scene.files ?? []) {
+    if (ref.kind !== "dictionary" || !ref.cifText) continue;
+    const assetPath = `assets/${ref.name}.cif`;
+    assets.set(assetPath, new TextEncoder().encode(ref.cifText).buffer);
+    ref.bundle = assetPath;
+    delete ref.cifText;
+  }
+
+  return { scene, hints, assets };
+}
+
+// --------------------------------------------------------------------------
+// Files
+// --------------------------------------------------------------------------
+
+function liftFileRef(mol: moorhen.Molecule, ctx: LiftCtx): SceneFileRef {
+  const name = sanitiseName(mol.name) || `mol${mol.molNo ?? "?"}`;
+
+  // Project-internal: ccp4i2 file id embedded in the loader URL pattern.
+  const fileId = extractFileIdFromUniqueId(mol.uniqueId ?? "");
+  if (fileId !== null && ctx.projectId) {
+    return {
+      name,
+      projectId: ctx.projectId,
+      projectName: ctx.projectName,
+      fileId,
+    };
+  }
+
+  // Plain URL fallback for non-ccp4i2 loaders (e.g. PDBe direct fetches).
+  if (mol.uniqueId && /^https?:\/\//.test(mol.uniqueId)) {
+    return { name, url: mol.uniqueId };
+  }
+
+  // Path fallback for local fetches that don't look like URLs.
+  if (mol.uniqueId) {
+    return { name, path: mol.uniqueId };
+  }
+
+  // Last resort: a placeholder url that the user will edit.
+  return { name, url: "TODO: source URL for this molecule" };
+}
+
+// --------------------------------------------------------------------------
+// View
+// --------------------------------------------------------------------------
+
+function liftView(glRef: LiftCtx["glRef"]): SceneView | undefined {
+  if (!glRef) return undefined;
+  // glRef.origin / glRef.quat can be Float32Array — coerce to arrays so
+  // they JSON/YAML-stringify as sequences not as objects.
+  const origin = toArray3(glRef.origin);
+  const quat = toArray4(glRef.quat);
+  const view: SceneView = {};
+  if (origin) view.origin = origin;
+  if (quat) view.quat = quat;
+  if (typeof glRef.zoom === "number") view.zoom = round(glRef.zoom, 4);
+  // clip/fog: only include if set; the apply path will use Moorhen
+  // defaults for anything omitted.
+  if (typeof glRef.clipStart === "number") view.clipStart = glRef.clipStart;
+  if (typeof glRef.clipEnd === "number") view.clipEnd = glRef.clipEnd;
+  if (typeof glRef.fogStart === "number") view.fogStart = glRef.fogStart;
+  if (typeof glRef.fogEnd === "number") view.fogEnd = glRef.fogEnd;
+  return Object.keys(view).length > 0 ? view : undefined;
+}
+
+// --------------------------------------------------------------------------
+// Elements + representations
+// --------------------------------------------------------------------------
+
+function liftElement(mol: moorhen.Molecule, fileName: string): SceneElement | null {
+  const reps = (mol.representations ?? []).filter((r) => r && r.style);
+  // Only lift visible reps; hidden ones are usually leftovers the user
+  // wouldn't expect in a captured scene.
+  const visible = reps.filter((r) => r.visible !== false);
+  if (visible.length === 0) return null;
+
+  const out: SceneRepresentation[] = visible.map(liftRepresentation);
+  return { file: fileName, representations: out };
+}
+
+function liftRepresentation(rep: moorhen.MoleculeRepresentation): SceneRepresentation {
+  const out: SceneRepresentation = { style: rep.style };
+  if (rep.cid && rep.cid !== "/*/*/*/*") out.selection = rep.cid;
+
+  const colour = liftColour(rep.colourRules ?? []);
+  if (colour !== undefined) out.colour = colour;
+
+  return out;
+}
+
+// --------------------------------------------------------------------------
+// Colours — the only bit that does pattern matching
+// --------------------------------------------------------------------------
+
+const NAMED_MULTI_RULES = new Set([
+  "b-factor",
+  "b-factor-norm",
+  "af2-plddt",
+  "secondary-structure",
+  "jones-rainbow",
+  "mol-symm",
+]);
+
+function liftColour(rules: moorhen.ColourRule[]): SceneColour | undefined {
+  if (rules.length === 0) return undefined;
+
+  // We only attempt to lift the *first* rule. Multiple rules per
+  // representation is rare in normal Moorhen UI flows; if we see it,
+  // the safer thing is to emit the first one and drop the rest rather
+  // than invent some lossy merge. (A future v2 could lift a sequence.)
+  const r = rules[0];
+
+  // 1. Named multi-rule scheme (b-factor, etc.).
+  if (NAMED_MULTI_RULES.has(r.ruleType)) {
+    return r.ruleType as SceneColour;
+  }
+
+  // 2. Single-colour rule with a hex colour (Moorhen's "molecule" ruleType
+  //    or anything with isMultiColourRule=false).
+  if (!r.isMultiColourRule && typeof r.color === "string" && /^#[0-9a-fA-F]{6}$/.test(r.color)) {
+    return r.color;
+  }
+
+  // 3. by-domain shape: a single multi-rule whose args[0] is a string
+  //    of `//chain/start-end^#rrggbb|...` segments. Recognise and emit
+  //    as `by-domain` (the calling code can reconstitute domains from
+  //    the top-level domains: block; we don't try to lift those here
+  //    because we don't know what the segments *mean*).
+  if (
+    r.isMultiColourRule &&
+    typeof r.args?.[0] === "string" &&
+    /^\/\/[^/]+\/-?\d+--?\d+\^#[0-9a-fA-F]{6}(\|\/\/[^/]+\/-?\d+--?\d+\^#[0-9a-fA-F]{6})*$/.test(
+      r.args[0] as string,
+    )
+  ) {
+    return "by-domain";
+  }
+
+  // 4. Escape hatch: keep the rule verbatim. Lossless, ugly.
+  return {
+    raw: {
+      ruleType: r.ruleType,
+      args: r.args ?? [],
+      isMultiColourRule: r.isMultiColourRule,
+      applyColourToNonCarbonAtoms: r.applyColourToNonCarbonAtoms,
+    },
+  };
+}
+
+// --------------------------------------------------------------------------
+// Small utilities
+// --------------------------------------------------------------------------
+
+function sanitiseName(name?: string): string {
+  if (!name) return "";
+  // Strip URL-ish punctuation; YAML keys are happier with quiet identifiers.
+  return name.replace(/[^A-Za-z0-9_.-]+/g, "_");
+}
+
+function toArray3(v: number[] | Float32Array | undefined): [number, number, number] | undefined {
+  if (!v || v.length < 3) return undefined;
+  return [round(v[0], 3), round(v[1], 3), round(v[2], 3)];
+}
+
+function toArray4(
+  v: number[] | Float32Array | undefined,
+): [number, number, number, number] | undefined {
+  if (!v || v.length < 4) return undefined;
+  return [round(v[0], 4), round(v[1], 4), round(v[2], 4), round(v[3], 4)];
+}
+
+function round(n: number, dp: number): number {
+  const f = Math.pow(10, dp);
+  return Math.round(n * f) / f;
+}
+
+function hasAnyValue(o: Record<string, unknown>): boolean {
+  return Object.values(o).some((v) => v !== undefined);
+}

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -656,12 +656,16 @@ function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] 
   if (!rep.colour) return [];
 
   if (isSceneHexColour(rep.colour)) {
+    // libcoot's add_colour_rule reads cid+colour from args, not from
+    // this.cid/this.color (which are only consulted by the bond-style
+    // shim_set_bond_colours path). Without [cid, colour] in args,
+    // ribbons / MolecularSurface / etc. silently no-op.
     return [
       {
         ruleType: "molecule",
         cid: defaultCid,
         color: rep.colour,
-        args: [],
+        args: [defaultCid, rep.colour],
         isMultiColourRule: false,
       },
     ];

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -1,0 +1,882 @@
+/**
+ * Moorhen Scene resolver.
+ *
+ * Takes a parsed MoorhenScene plus the molecules currently loaded in
+ * Moorhen and applies the scene: clears existing representations on each
+ * targeted molecule, adds new ones per the scene, with colour rules
+ * compiled from the scene's domain definitions.
+ *
+ * v0 scope: only the simplest path. Files in the scene must match
+ * structures already loaded in Moorhen (matched by file id extracted
+ * from the molecule's uniqueId). Fetching new structures from `files:`
+ * entries (url/path/job+param) is deferred — drop the file on Moorhen
+ * first, then apply the scene.
+ *
+ * Camera (view block) is applied by dispatching the same Redux actions
+ * the existing PasteViewLinkField uses.
+ */
+
+import type { Dispatch } from "redux";
+import {
+  setOrigin,
+  setQuat,
+  setZoom,
+  setClipStart,
+  setClipEnd,
+  setFogStart,
+  setFogEnd,
+  setBackgroundColor,
+  setRequestDrawScene,
+  addCustomRepresentation,
+  removeCustomRepresentation,
+} from "moorhen";
+import type { moorhen } from "moorhen/types/moorhen";
+
+// We deliberately don't import MoorhenColourRule from "moorhen". Although
+// the class is exported in Moorhen's source, the installed package's
+// bundled moorhen.js does not re-expose it on the package export object
+// (runtime "is not a constructor"). Instead, we add colour rules via
+// MoleculeRepresentation.addColourRule, which constructs the rule
+// internally with the right commandCentre + parent molecule wiring.
+
+import { extractFileIdFromUniqueId } from "./moorhen-view-state";
+import {
+  MoorhenScene,
+  SceneColour,
+  SceneDomain,
+  SceneFileRef,
+  SceneRepresentation,
+  SceneLsqMatch,
+  SceneSuperpose,
+  isSceneHexColour,
+  isSceneNamedColour,
+  isSceneRawColour,
+} from "../types/moorhen-scene";
+
+// --------------------------------------------------------------------------
+// Result + log entries
+// --------------------------------------------------------------------------
+
+/** One modification noted by the clamp-and-log resolver policy. */
+export interface SceneResolveLogEntry {
+  file: string;            // SceneFileRef.name
+  domain: string;          // SceneDomain.name
+  message: string;         // human-readable
+}
+
+export interface SceneResolveResult {
+  /** Files in the scene that couldn't be matched to a loaded molecule. */
+  unresolvedFiles: string[];
+  /** Modifications made by clamp-and-log (or anything else worth noting). */
+  log: SceneResolveLogEntry[];
+  /** Per-file representation counts actually applied. */
+  applied: { file: string; molNo: number; representations: number }[];
+}
+
+// --------------------------------------------------------------------------
+// Entry point
+// --------------------------------------------------------------------------
+
+/**
+ * Loads a structure described by a SceneFileRef and returns the
+ * MoorhenMolecule that ends up in the store, or null if the ref is not
+ * fetchable on its own (e.g. a bare `path:` with no matching loaded mol).
+ *
+ * The resolver doesn't know how to talk to Coot or the store directly —
+ * it just calls this. The wrapper provides the implementation in terms
+ * of its existing fetchMolecule / fetchFile / apiText machinery.
+ */
+export type SceneFileFetcher = (
+  ref: SceneFileRef,
+) => Promise<moorhen.Molecule | null>;
+
+/**
+ * Fetches the raw text of a dictionary CIF and returns it. The resolver
+ * is then responsible for loading it into Coot (globally and/or scoped
+ * to specific molecule molNos). A single dictionary file may contain
+ * multiple `data_comp_*` blocks — Coot loads them all in one call, so
+ * the resolver doesn't need to split.
+ */
+export type SceneDictionaryFetcher = (
+  ref: SceneFileRef,
+) => Promise<string | null>;
+
+/**
+ * Loads a dictionary CIF string into Coot's dictionary store for a
+ * specific molecule (or globally, when molNo is -999999). Mirrors the
+ * existing wrapper pattern: load globally first so coords containing the
+ * monomers parse, then re-associate per-molecule so structures using
+ * differently-defined ligands with the same residue name don't collide.
+ */
+export type SceneDictionaryLoader = (
+  dictText: string,
+  molNo: number,
+) => Promise<void>;
+
+interface ResolveCtx {
+  scene: MoorhenScene;
+  molecules: moorhen.Molecule[];
+  dispatch: Dispatch;
+  /** Optional. When provided, the resolver fetches structures that aren't
+   *  already loaded but whose file ref carries enough info (pdb, url,
+   *  fileId+projectId). Without it, unmatched files just go to
+   *  unresolvedFiles. */
+  fetcher?: SceneFileFetcher;
+  /** Optional. When provided alongside `dictionaryLoader`, dict file
+   *  refs (`kind: dictionary`) are fetched into raw CIF text. */
+  dictionaryFetcher?: SceneDictionaryFetcher;
+  /** Optional. Required for any dictionary scoping to take effect. The
+   *  resolver calls this once per (dict, molecule) pair. */
+  dictionaryLoader?: SceneDictionaryLoader;
+}
+
+/**
+ * Apply a scene to the currently-loaded molecules.
+ *
+ * Returns a SceneResolveResult describing what was applied and what
+ * couldn't be resolved. Throws only on programmer errors; missing
+ * structures and domain clamping are reported in the result, not raised.
+ */
+export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
+  const { scene, molecules, dispatch, fetcher, dictionaryFetcher, dictionaryLoader } = ctx;
+  const result: SceneResolveResult = {
+    unresolvedFiles: [],
+    log: [],
+    applied: [],
+  };
+
+  const policy = scene.resolver?.onMissingResidues ?? "clamp-and-log";
+
+  // Split file refs by kind. Dictionaries are fetched and loaded
+  // GLOBALLY first, so coords containing those monomers parse correctly
+  // when they're loaded immediately after. Per-element re-association
+  // (the scoping step) happens later, once coord molNos are known.
+  const allFiles = scene.files ?? [];
+  const dictRefs = allFiles.filter((f) => f.kind === "dictionary");
+  const coordRefs = allFiles.filter((f) => f.kind !== "dictionary");
+
+  // 1a. Fetch and globally-load dictionary text. Keep the raw text
+  //     keyed by name so we can re-load per-molecule later.
+  const dictTexts = new Map<string, string>();
+  for (const fr of dictRefs) {
+    if (!dictionaryFetcher || !dictionaryLoader) {
+      result.unresolvedFiles.push(fr.name);
+      continue;
+    }
+    if (!isFetchable(fr)) {
+      result.unresolvedFiles.push(fr.name);
+      continue;
+    }
+    try {
+      const text = await dictionaryFetcher(fr);
+      if (!text) {
+        result.unresolvedFiles.push(fr.name);
+        continue;
+      }
+      dictTexts.set(fr.name, text);
+      // Global association: imol = -999999 (Coot's "any" sentinel).
+      // Coots parses every `data_comp_*` block in a single call, so
+      // multi-comp dicts are handled in one shot.
+      await dictionaryLoader(text, -999999);
+    } catch (e) {
+      console.warn(`[scene] dictionary fetch failed for ${fr.name}:`, e);
+      result.unresolvedFiles.push(fr.name);
+    }
+  }
+
+  // 1b. Match coord scene files to loaded molecules. For any file that
+  //     doesn't match, fall back to the fetcher (if provided + ref is
+  //     fetchable). Newly-fetched molecules are accumulated into a
+  //     local list so later files can also bind against them.
+  const livePool: moorhen.Molecule[] = [...molecules];
+  const fileBindings = new Map<string, moorhen.Molecule>();
+  for (const fr of coordRefs) {
+    const existing = matchOneFile(fr, livePool);
+    if (existing) {
+      fileBindings.set(fr.name, existing);
+      continue;
+    }
+    if (fetcher && isFetchable(fr)) {
+      try {
+        const fetched = await fetcher(fr);
+        if (fetched) {
+          livePool.push(fetched);
+          fileBindings.set(fr.name, fetched);
+          continue;
+        }
+      } catch (e) {
+        console.warn(`[scene] fetch failed for ${fr.name}:`, e);
+      }
+    }
+    result.unresolvedFiles.push(fr.name);
+  }
+
+  // 1c. Scope dictionaries to specific molecules. Re-association overrides
+  //     the earlier global load for the named molecule, so two molecules
+  //     with same-named ligands can carry different chemistry. Order:
+  //     globalDictionaries first (apply to every coord molecule), then
+  //     per-element dictionaries (which take precedence on their molecule
+  //     because they're loaded last).
+  if (dictionaryLoader) {
+    const globalDictNames = scene.globalDictionaries ?? [];
+    for (const dictName of globalDictNames) {
+      const text = dictTexts.get(dictName);
+      if (!text) continue; // unresolved noted above
+      for (const mol of fileBindings.values()) {
+        if (mol.molNo === undefined || mol.molNo === null) continue;
+        try {
+          await dictionaryLoader(text, mol.molNo);
+        } catch (e) {
+          console.warn(`[scene] global dict ${dictName} failed on molNo ${mol.molNo}:`, e);
+        }
+      }
+    }
+    const moleculesNeedingRedraw = new Set<moorhen.Molecule>();
+    for (const element of scene.elements ?? []) {
+      const elDicts = element.dictionaries ?? [];
+      if (elDicts.length === 0) continue;
+      const mol = fileBindings.get(element.file);
+      if (!mol || mol.molNo === undefined || mol.molNo === null) continue;
+      for (const dictName of elDicts) {
+        const text = dictTexts.get(dictName);
+        if (!text) continue;
+        try {
+          await dictionaryLoader(text, mol.molNo);
+          moleculesNeedingRedraw.add(mol);
+        } catch (e) {
+          console.warn(`[scene] dict ${dictName} failed on ${element.file}:`, e);
+        }
+      }
+    }
+    // Redraw molecules that got per-element dict re-associations, so
+    // bond rendering picks up the new geometry before reps are applied.
+    for (const mol of moleculesNeedingRedraw) {
+      try {
+        mol.setAtomsDirty(true);
+        await mol.redraw();
+      } catch (e) {
+        console.warn(`[scene] redraw after dict scope failed on ${mol.name}:`, e);
+      }
+    }
+  }
+
+  // 2. Run superpositions before rendering. The view's camera is meaningless
+  //    against un-aligned coords, so any saved quaternion expects this
+  //    step to have happened. Each entry mutates the *moving* molecule's
+  //    display transform in place; the reference is untouched.
+  for (const sp of scene.superpose ?? []) {
+    const mov = fileBindings.get(sp.move);
+    const ref = fileBindings.get(sp.onto);
+    if (!mov || !ref) {
+      const missing = !mov ? sp.move : sp.onto;
+      result.log.push({
+        file: missing,
+        domain: `superpose ${sp.move}→${sp.onto}`,
+        message: `cannot superpose: file "${missing}" not bound`,
+      });
+      continue;
+    }
+    if (ref.molNo === undefined || ref.molNo === null) {
+      result.log.push({
+        file: sp.onto,
+        domain: `superpose ${sp.move}→${sp.onto}`,
+        message: `reference molecule has no molNo yet; skipped`,
+      });
+      continue;
+    }
+    try {
+      await runSuperpose(sp, mov, ref);
+    } catch (e) {
+      console.warn(
+        `[scene] superpose failed (${sp.method} ${sp.move}→${sp.onto}):`,
+        e,
+      );
+      result.log.push({
+        file: sp.move,
+        domain: `superpose ${sp.move}→${sp.onto}`,
+        message: `${sp.method} superpose failed: ${e instanceof Error ? e.message : "unknown error"}`,
+      });
+    }
+  }
+
+  // 3. Apply each element to its bound molecule.
+  for (const element of scene.elements ?? []) {
+    const mol = fileBindings.get(element.file);
+    if (!mol) continue; // already noted in unresolvedFiles
+
+    // Clear all existing custom representations on this molecule so the
+    // scene fully controls the look. Built-in style toggles aren't custom
+    // reps so this is non-destructive for things like default ribbons
+    // added by the loader. Symmetrically tell the Redux store so the
+    // Moorhen Models drawer drops them from its "Custom representations"
+    // list.
+    try {
+      for (const rep of mol.representations ?? []) {
+        if (rep.isCustom) {
+          await mol.removeRepresentation(rep.uniqueId);
+          dispatch(removeCustomRepresentation(rep));
+        }
+      }
+    } catch (e) {
+      console.warn(`[scene] failed to clear representations on ${mol.name}:`, e);
+    }
+
+    const reps = element.representations ?? [];
+
+    // The scene fully owns the look of any molecule it touches: hide
+    // every loader-default (non-custom) representation so only what the
+    // scene asks for is drawn. Without this, every molecule that has a
+    // scene element but no CRs/MolecularSurface in it (e.g. a fragment
+    // showing only `style: ligands`) keeps its loader-default ribbon
+    // visible — producing one ghost ribbon per loaded molecule.
+    //
+    // We hide rather than remove so the panel's built-in B/R/S toggles
+    // can bring them back if the user wants.
+    try {
+      for (const rep of mol.representations ?? []) {
+        if (!rep.isCustom && rep.visible) {
+          rep.hide();
+        }
+      }
+    } catch (e) {
+      console.warn(`[scene] failed to hide overshadowed defaults on ${mol.name}:`, e);
+    }
+
+    let added = 0;
+    for (const rep of reps) {
+      const ok = await applyRepresentation({
+        molecule: mol,
+        rep,
+        domains: scene.domains ?? [],
+        fileName: element.file,
+        log: result.log,
+        policy,
+        dispatch,
+      });
+      if (ok) added++;
+    }
+    result.applied.push({
+      file: element.file,
+      molNo: mol.molNo ?? -1,
+      representations: added,
+    });
+  }
+
+  // 3. Camera. Mirror PasteViewLinkField exactly so behaviour matches.
+  if (scene.view) {
+    if (scene.view.origin) dispatch(setOrigin(scene.view.origin));
+    if (scene.view.quat) dispatch(setQuat(scene.view.quat));
+    if (scene.view.zoom !== undefined) dispatch(setZoom(scene.view.zoom));
+    if (scene.view.clipStart !== undefined) dispatch(setClipStart(scene.view.clipStart));
+    if (scene.view.clipEnd !== undefined) dispatch(setClipEnd(scene.view.clipEnd));
+    if (scene.view.fogStart !== undefined) dispatch(setFogStart(scene.view.fogStart));
+    if (scene.view.fogEnd !== undefined) dispatch(setFogEnd(scene.view.fogEnd));
+    if (scene.view.background) {
+      const rgba = hexToRgba01(scene.view.background);
+      if (rgba) dispatch(setBackgroundColor(rgba));
+    }
+  }
+  dispatch(setRequestDrawScene(true));
+
+  return result;
+}
+
+// --------------------------------------------------------------------------
+// File matching
+// --------------------------------------------------------------------------
+
+/**
+ * True iff the resolver could ask the fetcher to load this ref on its
+ * own — i.e. the ref carries enough info to know where to fetch from.
+ * `path:` alone is not fetchable (we don't read arbitrary local paths
+ * from the browser); `job+param` would need an extra ccp4i2 API lookup
+ * we haven't built yet, so for now it's also not fetchable.
+ */
+export function isFetchable(fr: SceneFileRef): boolean {
+  if (fr.pdb) return true;
+  if (fr.url) return true;
+  if (fr.fileId !== undefined && fr.projectId) return true;
+  // Inline dict text: trivially "fetchable" — the fetcher just returns
+  // the text. Only valid on dictionary refs (validator enforces this).
+  if (fr.cifText && fr.kind === "dictionary") return true;
+  // Bundle ref: fetcher looks up bytes/text in an in-memory asset map.
+  // Always considered fetchable; if the map doesn't have the key the
+  // fetcher returns null and the resolver records it as unresolved.
+  if (fr.bundle) return true;
+  return false;
+}
+
+/** Match a file ref against the currently-loaded molecules. */
+function matchOneFile(
+  fr: SceneFileRef,
+  molecules: moorhen.Molecule[],
+): moorhen.Molecule | null {
+  // 1. Match by ccp4i2 fileId extracted from uniqueId.
+  if (fr.fileId !== undefined) {
+    for (const mol of molecules) {
+      const fid = extractFileIdFromUniqueId(mol.uniqueId || "");
+      if (fid === fr.fileId) return mol;
+    }
+  }
+
+  // 2. Match by PDB id embedded in the proxied download URL.
+  //    Fetched PDB structures get uniqueId =
+  //    /api/proxy/pdbe/entry-files/download/<pdbid>.cif
+  if (fr.pdb) {
+    const pdbLower = fr.pdb.toLowerCase();
+    for (const mol of molecules) {
+      const u = (mol.uniqueId || "").toLowerCase();
+      if (u.includes(`/pdbe/entry-files/download/${pdbLower}`)) return mol;
+    }
+  }
+
+  // 3. Match a previously-fetched bundle ref. The wrapper sets the
+  //    molecule's uniqueId to `bundle:<assetPath>` so re-applying the
+  //    same scene against the same loaded bundle skips the re-fetch.
+  if (fr.bundle) {
+    const sentinel = `bundle:${fr.bundle}`;
+    for (const mol of molecules) {
+      if (mol.uniqueId === sentinel) return mol;
+    }
+  }
+
+  // 4. Match by URL or path (uniqueId is set to the loader's URL/path).
+  const candidates = [fr.url, fr.path].filter(Boolean) as string[];
+  for (const c of candidates) {
+    for (const mol of molecules) {
+      if (mol.uniqueId === c) return mol;
+    }
+  }
+
+  return null;
+}
+
+// --------------------------------------------------------------------------
+// Superposition
+// --------------------------------------------------------------------------
+
+/**
+ * Apply one SceneSuperpose entry to a pair of already-loaded molecules.
+ * Mutates `mov` in place; `ref` is untouched. Throws on coot-side
+ * errors so the caller can record them in the resolver log.
+ */
+async function runSuperpose(
+  sp: SceneSuperpose,
+  mov: moorhen.Molecule,
+  ref: moorhen.Molecule,
+): Promise<void> {
+  if (sp.method === "ssm") {
+    await mov.SSMSuperpose(sp.movChain, ref.molNo as number, sp.refChain, true);
+    return;
+  }
+  // LSQ: translate the scene's matches (or chain+range shorthand) into
+  // Moorhen's lskqbResidueRangeMatch shape.
+  const matches = expandLsqMatches(sp);
+  const residueMatches: moorhen.lskqbResidueRangeMatch[] = [];
+  for (const m of matches) {
+    const refMatch = RANGE_RE.exec(m.refRange);
+    const movMatch = RANGE_RE.exec(m.movRange);
+    if (!refMatch || !movMatch) continue; // validator caught it; defensive skip
+    residueMatches.push({
+      refChainId: m.refChain,
+      movChainId: m.movChain,
+      refResidueRange: [parseInt(refMatch[1], 10), parseInt(refMatch[2], 10)],
+      movResidueRange: [parseInt(movMatch[1], 10), parseInt(movMatch[2], 10)],
+    });
+  }
+  const matchTypeMap = { all: 0, main: 1, ca: 2 } as const;
+  const matchType = matchTypeMap[sp.matchType ?? "main"];
+  await mov.lsqkbSuperpose(ref.molNo as number, residueMatches, matchType, true);
+}
+
+/**
+ * Resolve an LSQ entry's matches: if the scene used the `chain`+`range`
+ * shorthand, expand it into a single SceneLsqMatch with the same chain
+ * and range on both sides. Otherwise use the explicit `matches` block.
+ *
+ * Exported for unit testing — the schema validation accepts the
+ * shorthand, but the expansion logic is the bit most likely to drift.
+ */
+export function expandLsqMatches(sp: {
+  matches?: SceneLsqMatch[];
+  chain?: string;
+  range?: string;
+}): SceneLsqMatch[] {
+  if (sp.chain && sp.range) {
+    return [{
+      refChain: sp.chain,
+      movChain: sp.chain,
+      refRange: sp.range,
+      movRange: sp.range,
+    }];
+  }
+  return sp.matches ?? [];
+}
+
+const RANGE_RE = /^(-?\d+)-(-?\d+)$/;
+
+/**
+ * Split a Coot-style multi-CID selection into single CIDs. Coot uses
+ * "||" as the multi-CID separator in some APIs (rigid_body_fit,
+ * copy_fragment_using_cid, etc.) — but MoorhenMoleculeRepresentation
+ * does *not* split them, so the resolver has to do it before calling
+ * addRepresentation, otherwise the whole "||"-joined string is treated
+ * as a single (invalid) CID and silently selects nothing.
+ *
+ * Empty chunks (from leading/trailing/repeated "||") are dropped, and
+ * each chunk is trimmed. A string with no "||" comes back as a single-
+ * element array.
+ */
+export function splitMultiCid(cid: string): string[] {
+  if (!cid.includes("||")) return [cid];
+  return cid
+    .split("||")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// --------------------------------------------------------------------------
+// Representations
+// --------------------------------------------------------------------------
+
+interface ApplyRepCtx {
+  molecule: moorhen.Molecule;
+  rep: SceneRepresentation;
+  domains: SceneDomain[];
+  fileName: string;
+  log: SceneResolveLogEntry[];
+  policy: "clamp-and-log" | "strict";
+  dispatch: Dispatch;
+}
+
+/**
+ * A colour rule expressed as the arguments to MoleculeRepresentation.addColourRule.
+ * Lets us stage the rule independently of how Moorhen wires it together.
+ */
+interface PendingRule {
+  ruleType: string;
+  cid: string;
+  color: string;
+  args: (string | number)[];
+  isMultiColourRule: boolean;
+  applyColourToNonCarbonAtoms?: boolean;
+}
+
+async function applyRepresentation(ctx: ApplyRepCtx): Promise<boolean> {
+  const { molecule, rep, dispatch, fileName, log } = ctx;
+
+  const cid = rep.selection ?? "/*/*/*/*";
+
+  // Coot supports "||"-joined multi-CID strings as a convention in *some*
+  // APIs (copy_fragment, rigid_body_fit), but MoorhenMoleculeRepresentation
+  // does NOT split them — it passes the whole string through as one CID,
+  // which silently selects nothing. We split here and emit one
+  // representation per chunk, all sharing the same style and colour rules.
+  const cids = splitMultiCid(cid);
+
+  const pendingRules = buildPendingRules(ctx, cid);
+
+  let anySucceeded = false;
+  for (const subCid of cids) {
+    try {
+      const created = await molecule.addRepresentation(
+        rep.style as moorhen.RepresentationStyles,
+        subCid,
+        true, // isCustom — keeps it under our control to clear later
+      );
+      if (!created) continue;
+      if (pendingRules.length > 0) {
+        for (const r of pendingRules) {
+          // Colour rule CID stays as authored — the rule's CID and the
+          // representation's CID don't have to match (e.g. by-domain
+          // rules target absolute residue numbers regardless of the
+          // representation's selection).
+          created.addColourRule(
+            r.ruleType,
+            r.cid,
+            r.color,
+            r.args,
+            r.isMultiColourRule,
+            r.applyColourToNonCarbonAtoms ?? false,
+          );
+        }
+        await molecule.redrawRepresentation(created.uniqueId);
+      }
+      dispatch(addCustomRepresentation(created));
+      anySucceeded = true;
+    } catch (e) {
+      const detail = extractRepError(e);
+      console.warn(
+        `[scene] failed to add ${rep.style} on ${molecule.name} (cid=${subCid}):`,
+        e,
+      );
+      // Surface in the result log so the user sees what went wrong
+      // without having to open DevTools. Coot's `Invalid selection
+      // syntax` errors are the most common cause and the most
+      // actionable for the author.
+      log.push({
+        file: fileName,
+        domain: `${rep.style} ${subCid}`,
+        message: detail,
+      });
+    }
+  }
+  return anySucceeded;
+}
+
+/**
+ * Pull a useful one-line message out of whatever Moorhen/Coot threw at
+ * us. The exception shape varies (sometimes a plain Error with stack,
+ * sometimes a Coot-side Exception with an `Array` message), so we
+ * sniff and reach for the most informative string we can find.
+ */
+function extractRepError(e: unknown): string {
+  if (!e) return "unknown error";
+  const anyE = e as { message?: unknown; stack?: unknown };
+  // Coot exceptions surface their message as an array like
+  // ["std::runtime_error", "Invalid selection syntax: //A/115,116"].
+  if (Array.isArray(anyE.message)) {
+    return anyE.message.filter((s) => typeof s === "string").join(": ");
+  }
+  if (typeof anyE.message === "string") return anyE.message;
+  if (typeof anyE.stack === "string") {
+    // Coot's "Error: std::runtime_error,Invalid selection syntax..." pattern.
+    const m = anyE.stack.match(/Error:\s*(.+?)(?:\n|$)/);
+    if (m) return m[1].slice(0, 200);
+  }
+  try {
+    return String(e).slice(0, 200);
+  } catch {
+    return "unknown error";
+  }
+}
+
+function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] {
+  const { molecule, rep, domains, fileName, log, policy } = ctx;
+  if (!rep.colour) return [];
+
+  if (isSceneHexColour(rep.colour)) {
+    return [
+      {
+        ruleType: "molecule",
+        cid: defaultCid,
+        color: rep.colour,
+        args: [],
+        isMultiColourRule: false,
+      },
+    ];
+  }
+
+  if (isSceneNamedColour(rep.colour)) {
+    if (rep.colour === "by-domain") {
+      return buildByDomainPendingRule(molecule, domains, fileName, log, policy);
+    }
+    // Named schemes (b-factor, af2-plddt, etc.) are Moorhen multi-rules
+    // whose args are filled in by Moorhen at apply-time. We pass an empty
+    // args array; Moorhen's internal getMultiColourRuleArgs supplies them.
+    return [
+      {
+        ruleType: rep.colour,
+        cid: defaultCid,
+        color: "#ffffff",
+        args: [],
+        isMultiColourRule: true,
+      },
+    ];
+  }
+
+  if (isSceneRawColour(rep.colour)) {
+    const raw = rep.colour.raw;
+    return [
+      {
+        ruleType: raw.ruleType,
+        cid: defaultCid,
+        color: "#ffffff",
+        args: raw.args,
+        isMultiColourRule: raw.isMultiColourRule ?? true,
+        applyColourToNonCarbonAtoms: raw.applyColourToNonCarbonAtoms,
+      },
+    ];
+  }
+
+  return [];
+}
+
+// --------------------------------------------------------------------------
+// by-domain compilation: clamp ranges, build pipe-delimited args
+// --------------------------------------------------------------------------
+
+function buildByDomainPendingRule(
+  molecule: moorhen.Molecule,
+  domains: SceneDomain[],
+  fileName: string,
+  log: SceneResolveLogEntry[],
+  policy: "clamp-and-log" | "strict",
+): PendingRule[] {
+  if (domains.length === 0) return [];
+
+  // Index present residues per chain from molecule.sequences.
+  const presentByChain = new Map<string, Set<number>>();
+  for (const seq of molecule.sequences ?? []) {
+    const present = new Set<number>();
+    for (const r of seq.sequence) present.add(r.resNum);
+    presentByChain.set(seq.chain, present);
+  }
+
+  const segments: string[] = [];
+  for (const d of domains) {
+    const m = /^(-?\d+)-(-?\d+)$/.exec(d.range);
+    if (!m) continue;
+    const start = parseInt(m[1], 10);
+    const end = parseInt(m[2], 10);
+
+    // Resolve the domain's chain selector into concrete chain ids.
+    // - "*"      → every chain present in the structure
+    // - "A"      → exactly chain A (legacy single-chain form)
+    // - ["A","B"] → exactly those chains
+    const targetChains = resolveChainSelector(d.chain, presentByChain);
+    if (targetChains.length === 0) {
+      log.push({
+        file: fileName,
+        domain: d.name,
+        message:
+          typeof d.chain === "string"
+            ? `chain ${d.chain} not present in molecule; skipped`
+            : `no chains from [${(d.chain as string[]).join(", ")}] present; skipped`,
+      });
+      continue;
+    }
+
+    for (const chainId of targetChains) {
+      const present = presentByChain.get(chainId);
+      if (!present) {
+        // Should only happen with an explicit list naming an absent
+        // chain; "*" already excludes absent ones, single-chain hit the
+        // outer check.
+        log.push({
+          file: fileName,
+          domain: d.name,
+          message: `chain ${chainId} not present in molecule; skipped`,
+        });
+        continue;
+      }
+
+      const subRanges = clampRangeToPresent(start, end, present);
+      if (subRanges.length === 0) {
+        log.push({
+          file: fileName,
+          domain: d.name,
+          message: `range ${start}-${end} has no present residues in chain ${chainId}; skipped`,
+        });
+        continue;
+      }
+      if (subRanges.length > 1 || subRanges[0][0] !== start || subRanges[0][1] !== end) {
+        log.push({
+          file: fileName,
+          domain: d.name,
+          message:
+            `chain ${chainId}: range ${start}-${end} resolved to ${subRanges
+              .map(([s, e]) => `${s}-${e}`)
+              .join(", ")} after clamping to present residues`,
+        });
+      }
+      if (
+        policy === "strict" &&
+        (subRanges.length > 1 || subRanges[0][0] !== start || subRanges[0][1] !== end)
+      ) {
+        throw new Error(
+          `Scene resolver in strict mode: domain "${d.name}" range ${start}-${end} not fully present in chain ${chainId}`,
+        );
+      }
+
+      for (const [s, e] of subRanges) {
+        segments.push(`//${chainId}/${s}-${e}^${d.color}`);
+      }
+    }
+  }
+
+  if (segments.length === 0) return [];
+
+  // One multi-rule, args = pipe-joined segments. Matches Moorhen's own
+  // internal shape for multi-residue colouring (see secondary-structure
+  // colouring in baby-gru/src/utils/utils.ts).
+  return [
+    {
+      ruleType: "by-domain", // label only; not a built-in scheme
+      cid: "/*/*/*/*",
+      color: "#ffffff",
+      args: [segments.join("|")],
+      isMultiColourRule: true,
+    },
+  ];
+}
+
+/**
+ * Resolve a SceneDomain.chain value into a concrete list of chain ids
+ * for the loaded structure.
+ *
+ *   - "*"        → every chain that has at least one residue present
+ *                  (sorted for stable output)
+ *   - "A" etc.   → just ["A"]; the chain might be absent — the caller
+ *                  is responsible for handling that case
+ *   - ["A","B"]  → that list verbatim (in declared order)
+ *
+ * For "*", returns an empty list when no chains are present (e.g. an
+ * un-loaded molecule) so callers can short-circuit with a single log
+ * entry rather than emitting a misleading per-chain error.
+ */
+export function resolveChainSelector(
+  selector: string | string[],
+  presentByChain: Map<string, Set<number>>,
+): string[] {
+  if (typeof selector === "string") {
+    if (selector === "*") {
+      return [...presentByChain.keys()].sort();
+    }
+    return [selector];
+  }
+  return selector;
+}
+
+/**
+ * Given an inclusive range [start, end] and the set of residue numbers
+ * actually present, return one or more sub-ranges that:
+ *   1. Are inside [start, end]
+ *   2. Are contiguous in the present set
+ *   3. Don't include any residues not present
+ *
+ * Sub-ranges are returned in ascending order.
+ */
+export function clampRangeToPresent(
+  start: number,
+  end: number,
+  present: Set<number>,
+): [number, number][] {
+  const out: [number, number][] = [];
+  let runStart: number | null = null;
+  let runEnd: number | null = null;
+  for (let n = start; n <= end; n++) {
+    if (present.has(n)) {
+      if (runStart === null) runStart = n;
+      runEnd = n;
+    } else if (runStart !== null) {
+      out.push([runStart, runEnd!]);
+      runStart = null;
+      runEnd = null;
+    }
+  }
+  if (runStart !== null) out.push([runStart, runEnd!]);
+  return out;
+}
+
+// --------------------------------------------------------------------------
+// Small utilities
+// --------------------------------------------------------------------------
+
+function hexToRgba01(hex: string): [number, number, number, number] | null {
+  if (!/^#[0-9a-fA-F]{6}$/.test(hex)) return null;
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  return [r, g, b, 1];
+}

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -29,6 +29,16 @@ import {
   setRequestDrawScene,
   addCustomRepresentation,
   removeCustomRepresentation,
+  setContourLevel,
+  setMapRadius,
+  setMapAlpha,
+  setMapStyle,
+  setMapColours,
+  setPositiveMapColours,
+  setNegativeMapColours,
+  showMap,
+  hideMap,
+  setActiveMap,
 } from "moorhen";
 import type { moorhen } from "moorhen/types/moorhen";
 
@@ -45,6 +55,7 @@ import {
   SceneColour,
   SceneDomain,
   SceneFileRef,
+  SceneMap,
   SceneRepresentation,
   SceneLsqMatch,
   SceneSuperpose,
@@ -113,9 +124,26 @@ export type SceneDictionaryLoader = (
   molNo: number,
 ) => Promise<void>;
 
+/**
+ * Fetch an MTZ file ref's bytes and load it into Coot as a Moorhen map
+ * with the given column spec. Owned by the wrapper because it
+ * instantiates MoorhenMap and dispatches addMap — neither of which
+ * belong in the resolver.
+ *
+ * Returns the resulting moorhen.Map (so the resolver can pick up its
+ * molNo for redux state updates), or null on fetch / parse failure.
+ */
+export type SceneMapFetcher = (
+  ref: SceneFileRef,
+  sceneMap: SceneMap,
+) => Promise<moorhen.Map | null>;
+
 interface ResolveCtx {
   scene: MoorhenScene;
   molecules: moorhen.Molecule[];
+  /** Maps currently loaded in Moorhen. Used to match scene.maps entries
+   *  to existing maps before falling back to mapFetcher. */
+  maps?: moorhen.Map[];
   dispatch: Dispatch;
   /** Optional. When provided, the resolver fetches structures that aren't
    *  already loaded but whose file ref carries enough info (pdb, url,
@@ -128,6 +156,9 @@ interface ResolveCtx {
   /** Optional. Required for any dictionary scoping to take effect. The
    *  resolver calls this once per (dict, molecule) pair. */
   dictionaryLoader?: SceneDictionaryLoader;
+  /** Optional. Required for scene.maps[] to be applied. Without it,
+   *  map entries are dropped with a log entry. */
+  mapFetcher?: SceneMapFetcher;
 }
 
 /**
@@ -138,7 +169,8 @@ interface ResolveCtx {
  * structures and domain clamping are reported in the result, not raised.
  */
 export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
-  const { scene, molecules, dispatch, fetcher, dictionaryFetcher, dictionaryLoader } = ctx;
+  const { scene, molecules, dispatch, fetcher, dictionaryFetcher, dictionaryLoader, mapFetcher } = ctx;
+  const maps = ctx.maps ?? [];
   const result: SceneResolveResult = {
     unresolvedFiles: [],
     log: [],
@@ -362,6 +394,63 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
     });
   }
 
+  // 2.5 Maps. For each scene.maps entry: bind to a loaded map if one
+  //     matches the file ref; otherwise fetch+load via mapFetcher.
+  //     Then dispatch contour/colour/style/visibility updates, and
+  //     promote the named activeMap (if any).
+  const liveMapPool: moorhen.Map[] = [...maps];
+  const mapBindings = new Map<string, moorhen.Map>();
+  for (const sceneMap of scene.maps ?? []) {
+    const fileRef = (scene.files ?? []).find((f) => f.name === sceneMap.file);
+    if (!fileRef) {
+      result.log.push({
+        file: sceneMap.file,
+        domain: `map ${sceneMap.name}`,
+        message: `map references unknown file "${sceneMap.file}"`,
+      });
+      continue;
+    }
+    const existing = matchOneMap(fileRef, liveMapPool);
+    let map: moorhen.Map | null = existing;
+    if (!map && mapFetcher && isFetchable(fileRef)) {
+      try {
+        map = await mapFetcher(fileRef, sceneMap);
+        if (map) liveMapPool.push(map);
+      } catch (e) {
+        result.log.push({
+          file: sceneMap.file,
+          domain: `map ${sceneMap.name}`,
+          message: `MTZ fetch failed: ${e instanceof Error ? e.message : "unknown"}`,
+        });
+        continue;
+      }
+    }
+    if (!map) {
+      result.log.push({
+        file: sceneMap.file,
+        domain: `map ${sceneMap.name}`,
+        message: mapFetcher
+          ? "no matching loaded map and ref is not fetchable"
+          : "no matching loaded map (no mapFetcher provided)",
+      });
+      continue;
+    }
+    mapBindings.set(sceneMap.name, map);
+    applyMapState(map, sceneMap, dispatch);
+  }
+  if (scene.activeMap) {
+    const active = mapBindings.get(scene.activeMap);
+    if (active) {
+      dispatch(setActiveMap(active));
+    } else {
+      result.log.push({
+        file: "",
+        domain: `activeMap ${scene.activeMap}`,
+        message: `activeMap "${scene.activeMap}" not bound to any loaded map`,
+      });
+    }
+  }
+
   // 3. Camera. Mirror PasteViewLinkField exactly so behaviour matches.
   if (scene.view) {
     if (scene.view.origin) dispatch(setOrigin(scene.view.origin));
@@ -449,6 +538,91 @@ function matchOneFile(
   }
 
   return null;
+}
+
+/**
+ * Same shape as matchOneFile but for maps. Maps are keyed by molNo via
+ * extractFileIdFromUniqueId (when loaded from a ccp4i2 file), by URL,
+ * or by the bundle: sentinel for re-applied bundle scenes.
+ */
+function matchOneMap(fr: SceneFileRef, maps: moorhen.Map[]): moorhen.Map | null {
+  if (fr.fileId !== undefined) {
+    for (const m of maps) {
+      const fid = extractFileIdFromUniqueId(m.uniqueId || "");
+      if (fid === fr.fileId) return m;
+    }
+  }
+  if (fr.bundle) {
+    const sentinel = `bundle:${fr.bundle}`;
+    for (const m of maps) {
+      if (m.uniqueId === sentinel) return m;
+    }
+  }
+  const candidates = [fr.url, fr.path].filter(Boolean) as string[];
+  for (const c of candidates) {
+    for (const m of maps) {
+      if (m.uniqueId === c) return m;
+    }
+  }
+  return null;
+}
+
+/**
+ * Apply a SceneMap's render state to a loaded map by dispatching the
+ * relevant Moorhen actions. Difference maps split colour into positive
+ * + negative lobes; non-difference use the single mapColours slot.
+ *
+ * No-op when a field is undefined — Moorhen defaults stand.
+ */
+function applyMapState(
+  map: moorhen.Map,
+  sceneMap: SceneMap,
+  dispatch: Dispatch,
+): void {
+  const molNo = map.molNo;
+  if (sceneMap.contourLevel !== undefined) {
+    // setContourLevel's typings have drifted across Moorhen versions;
+    // cast keeps the resolver compatible with the installed shape.
+    dispatch(setContourLevel({ molNo, contourLevel: sceneMap.contourLevel } as never));
+  }
+  if (sceneMap.radius !== undefined) {
+    dispatch(setMapRadius({ molNo, radius: sceneMap.radius } as never));
+  }
+  if (sceneMap.alpha !== undefined) {
+    dispatch(setMapAlpha({ molNo, alpha: sceneMap.alpha } as never));
+  }
+  if (sceneMap.style) {
+    dispatch(setMapStyle({ molNo, style: sceneMap.style } as never));
+  }
+  if (sceneMap.isDifference) {
+    if (sceneMap.positiveColour) {
+      const rgb = hexToRgb01(sceneMap.positiveColour);
+      if (rgb) dispatch(setPositiveMapColours({ molNo, rgb } as never));
+    }
+    if (sceneMap.negativeColour) {
+      const rgb = hexToRgb01(sceneMap.negativeColour);
+      if (rgb) dispatch(setNegativeMapColours({ molNo, rgb } as never));
+    }
+  } else if (sceneMap.colour) {
+    const rgb = hexToRgb01(sceneMap.colour);
+    if (rgb) dispatch(setMapColours({ molNo, rgb } as never));
+  }
+  if (sceneMap.visible === false) {
+    dispatch(hideMap(map as never));
+  } else if (sceneMap.visible === true) {
+    dispatch(showMap(map as never));
+  }
+}
+
+/** Parse #rrggbb / #rrggbbaa into the {r,g,b} 0-1 shape Moorhen wants. */
+function hexToRgb01(hex: string): { r: number; g: number; b: number } | null {
+  const m = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})(?:[0-9a-fA-F]{2})?$/.exec(hex);
+  if (!m) return null;
+  return {
+    r: parseInt(m[1], 16) / 255,
+    g: parseInt(m[2], 16) / 255,
+    b: parseInt(m[3], 16) / 255,
+  };
 }
 
 // --------------------------------------------------------------------------

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -1,0 +1,986 @@
+/**
+ * Moorhen Scene parse/serialise/validate.
+ *
+ * Pure functions over the MoorhenScene type. No DOM, no Moorhen runtime,
+ * no React — that keeps this trivially testable and reusable in Node
+ * (e.g. CLI scene linter) as well as in the renderer.
+ *
+ * The lifter (Moorhen state → Scene) and the resolver (Scene → Moorhen
+ * backupSession) live in separate files because they have very different
+ * dependencies. This file is just the format itself.
+ */
+
+import * as YAML from "yaml";
+
+import {
+  MoorhenScene,
+  SCENE_SCHEMA_VERSION,
+  SceneDomain,
+  SceneFileRef,
+  SceneElement,
+  SceneLsqMatch,
+  SceneRepresentation,
+  SceneColour,
+  SceneSuperpose,
+  isSceneHexColour,
+  isSceneNamedColour,
+  isSceneRawColour,
+} from "../types/moorhen-scene";
+
+// --------------------------------------------------------------------------
+// Errors
+// --------------------------------------------------------------------------
+
+/** A single validation problem, located by JSON-pointer-ish path. */
+export interface SceneValidationError {
+  /** Dotted path to the offending field, e.g. "files[1].fileId". */
+  path: string;
+  message: string;
+}
+
+export class SceneParseError extends Error {
+  constructor(public readonly errors: SceneValidationError[]) {
+    super(
+      `Invalid Moorhen scene: ${errors.length} error(s)\n` +
+        errors.map((e) => `  - ${e.path}: ${e.message}`).join("\n"),
+    );
+    this.name = "SceneParseError";
+  }
+}
+
+// --------------------------------------------------------------------------
+// Parse: YAML string → MoorhenScene
+// --------------------------------------------------------------------------
+
+/**
+ * Parse a YAML scene document into a typed MoorhenScene.
+ * Throws SceneParseError if validation fails.
+ */
+export function parseScene(yamlText: string): MoorhenScene {
+  let raw: unknown;
+  try {
+    raw = YAML.parse(yamlText);
+  } catch (e) {
+    throw new SceneParseError([
+      { path: "", message: `YAML parse error: ${(e as Error).message}` },
+    ]);
+  }
+  const { scene, errors } = validateScene(raw);
+  if (errors.length > 0) throw new SceneParseError(errors);
+  return scene;
+}
+
+/**
+ * Validate a parsed JS value against the scene schema.
+ * Returns the (possibly partially-constructed) scene plus a list of errors.
+ * Callers that need exceptions should use parseScene().
+ */
+export function validateScene(raw: unknown): {
+  scene: MoorhenScene;
+  errors: SceneValidationError[];
+} {
+  const errors: SceneValidationError[] = [];
+
+  if (!isObject(raw)) {
+    errors.push({ path: "", message: "scene must be a YAML mapping" });
+    return { scene: { scene: "", version: SCENE_SCHEMA_VERSION }, errors };
+  }
+
+  const sceneName = strField(raw, "scene", "", errors);
+  const version = numField(raw, "version", SCENE_SCHEMA_VERSION, errors);
+  if (version !== SCENE_SCHEMA_VERSION) {
+    errors.push({
+      path: "version",
+      message: `unsupported scene version ${version}; this reader handles version ${SCENE_SCHEMA_VERSION}`,
+    });
+  }
+
+  const out: MoorhenScene = { scene: sceneName, version };
+
+  if ("authoredIn" in raw) {
+    const a = (raw as Record<string, unknown>).authoredIn;
+    if (isObject(a)) {
+      out.authoredIn = {
+        projectId: optStr(a, "projectId", "authoredIn.projectId", errors),
+        projectName: optStr(a, "projectName", "authoredIn.projectName", errors),
+        createdAt: optStr(a, "createdAt", "authoredIn.createdAt", errors),
+        createdBy: optStr(a, "createdBy", "authoredIn.createdBy", errors),
+        ccp4i2Version: optStr(a, "ccp4i2Version", "authoredIn.ccp4i2Version", errors),
+      };
+    } else {
+      errors.push({ path: "authoredIn", message: "must be a mapping" });
+    }
+  }
+
+  if ("files" in raw) {
+    out.files = validateFiles((raw as Record<string, unknown>).files, errors);
+  }
+
+  if ("superpose" in raw) {
+    out.superpose = validateSuperpose(
+      (raw as Record<string, unknown>).superpose,
+      out.files ?? [],
+      errors,
+    );
+  }
+
+  if ("globalDictionaries" in raw) {
+    out.globalDictionaries = validateDictionaryNameList(
+      (raw as Record<string, unknown>).globalDictionaries,
+      out.files ?? [],
+      "globalDictionaries",
+      errors,
+    );
+  }
+
+  if ("domains" in raw) {
+    out.domains = validateDomains((raw as Record<string, unknown>).domains, errors);
+  }
+
+  if ("elements" in raw) {
+    out.elements = validateElements(
+      (raw as Record<string, unknown>).elements,
+      out.files ?? [],
+      errors,
+    );
+  }
+
+  if ("view" in raw) {
+    const v = (raw as Record<string, unknown>).view;
+    if (isObject(v)) {
+      out.view = {
+        origin: tupleField<3>(v, "origin", 3, "view.origin", errors),
+        quat: tupleField<4>(v, "quat", 4, "view.quat", errors),
+        zoom: optNum(v, "zoom", "view.zoom", errors),
+        clipStart: optNum(v, "clipStart", "view.clipStart", errors),
+        clipEnd: optNum(v, "clipEnd", "view.clipEnd", errors),
+        fogStart: optNum(v, "fogStart", "view.fogStart", errors),
+        fogEnd: optNum(v, "fogEnd", "view.fogEnd", errors),
+        background: optStr(v, "background", "view.background", errors),
+      };
+    } else {
+      errors.push({ path: "view", message: "must be a mapping" });
+    }
+  }
+
+  if ("resolver" in raw) {
+    const r = (raw as Record<string, unknown>).resolver;
+    if (isObject(r)) {
+      const policy = optStr(r, "onMissingResidues", "resolver.onMissingResidues", errors);
+      if (policy && policy !== "clamp-and-log" && policy !== "strict") {
+        errors.push({
+          path: "resolver.onMissingResidues",
+          message: `must be "clamp-and-log" or "strict", got "${policy}"`,
+        });
+      } else if (policy) {
+        out.resolver = { onMissingResidues: policy as "clamp-and-log" | "strict" };
+      }
+    } else {
+      errors.push({ path: "resolver", message: "must be a mapping" });
+    }
+  }
+
+  return { scene: out, errors };
+}
+
+// --------------------------------------------------------------------------
+// Validation helpers for sub-objects
+// --------------------------------------------------------------------------
+
+function validateFiles(
+  raw: unknown,
+  errors: SceneValidationError[],
+): SceneFileRef[] | undefined {
+  if (!Array.isArray(raw)) {
+    errors.push({ path: "files", message: "must be a sequence" });
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const out: SceneFileRef[] = [];
+  raw.forEach((entry, i) => {
+    const p = `files[${i}]`;
+    if (!isObject(entry)) {
+      errors.push({ path: p, message: "must be a mapping" });
+      return;
+    }
+    const name = strField(entry, "name", "", errors, p);
+    if (!name) {
+      errors.push({ path: `${p}.name`, message: "required" });
+    } else if (seen.has(name)) {
+      errors.push({ path: `${p}.name`, message: `duplicate file name "${name}"` });
+    } else {
+      seen.add(name);
+    }
+
+    const ref: SceneFileRef = { name };
+    if ("kind" in entry) {
+      const kind = optStr(entry, "kind", `${p}.kind`, errors);
+      if (kind && kind !== "coordinates" && kind !== "dictionary") {
+        errors.push({
+          path: `${p}.kind`,
+          message: `must be "coordinates" or "dictionary", got "${kind}"`,
+        });
+      } else if (kind === "coordinates" || kind === "dictionary") {
+        ref.kind = kind;
+      }
+    }
+    if ("pdb" in entry) ref.pdb = optStr(entry, "pdb", `${p}.pdb`, errors);
+    if ("cifText" in entry) ref.cifText = optStr(entry, "cifText", `${p}.cifText`, errors);
+    if ("bundle" in entry) ref.bundle = optStr(entry, "bundle", `${p}.bundle`, errors);
+    if ("url" in entry) ref.url = optStr(entry, "url", `${p}.url`, errors);
+    if ("path" in entry) ref.path = optStr(entry, "path", `${p}.path`, errors);
+    if ("projectId" in entry) ref.projectId = optStr(entry, "projectId", `${p}.projectId`, errors);
+    if ("projectName" in entry) ref.projectName = optStr(entry, "projectName", `${p}.projectName`, errors);
+    if ("fileId" in entry) ref.fileId = optNum(entry, "fileId", `${p}.fileId`, errors);
+    if ("job" in entry) ref.job = optNum(entry, "job", `${p}.job`, errors);
+    if ("param" in entry) ref.param = optStr(entry, "param", `${p}.param`, errors);
+
+    // pdb id sanity check (4 char or extended 8 char). Keep it permissive
+    // but flag obvious nonsense.
+    if (ref.pdb && !/^[0-9A-Za-z]{4}$|^pdb_[0-9a-z]{8}$/.test(ref.pdb)) {
+      errors.push({
+        path: `${p}.pdb`,
+        message: `does not look like a PDB ID (got "${ref.pdb}")`,
+      });
+    }
+
+    // PDB IDs only make sense for coordinate refs.
+    if (ref.pdb && ref.kind === "dictionary") {
+      errors.push({
+        path: `${p}.pdb`,
+        message: "pdb: is only valid for coordinate refs, not dictionaries",
+      });
+    }
+
+    // cifText only makes sense for dictionary refs (it's the inline-dict
+    // shape the lifter writes when a loaded dict has no recoverable URL).
+    if (ref.cifText && ref.kind !== "dictionary") {
+      errors.push({
+        path: `${p}.cifText`,
+        message: "cifText: is only valid for dictionary refs (kind: dictionary)",
+      });
+    }
+
+    // At least one resolvable reference must be set.
+    const hasPdb = !!ref.pdb;
+    const hasCifText = !!ref.cifText;
+    const hasBundle = !!ref.bundle;
+    const hasUrl = !!ref.url;
+    const hasPath = !!ref.path;
+    const hasFileId = ref.fileId !== undefined;
+    const hasJobParam = ref.job !== undefined && !!ref.param;
+    if (!hasPdb && !hasCifText && !hasBundle && !hasUrl && !hasPath && !hasFileId && !hasJobParam) {
+      errors.push({
+        path: p,
+        message: "must set one of: pdb, url, path, bundle, fileId (+projectId), job+param (+projectId), or cifText (for dictionaries)",
+      });
+    }
+    // Project-internal forms need a projectId.
+    if ((hasFileId || hasJobParam) && !ref.projectId) {
+      errors.push({
+        path: `${p}.projectId`,
+        message: "required when fileId or job+param is set",
+      });
+    }
+    // job and param are paired.
+    if ((ref.job !== undefined) !== !!ref.param) {
+      errors.push({
+        path: p,
+        message: "job and param must be set together",
+      });
+    }
+
+    out.push(ref);
+  });
+  return out;
+}
+
+const RANGE_RE = /^(-?\d+)-(-?\d+)$/;
+
+function validateSuperpose(
+  raw: unknown,
+  files: SceneFileRef[],
+  errors: SceneValidationError[],
+): SceneSuperpose[] | undefined {
+  if (!Array.isArray(raw)) {
+    errors.push({ path: "superpose", message: "must be a sequence" });
+    return undefined;
+  }
+  const fileNames = new Set(files.map((f) => f.name));
+  const out: SceneSuperpose[] = [];
+
+  raw.forEach((entry, i) => {
+    const p = `superpose[${i}]`;
+    if (!isObject(entry)) {
+      errors.push({ path: p, message: "must be a mapping" });
+      return;
+    }
+    const method = strField(entry, "method", "", errors, p);
+    const move = strField(entry, "move", "", errors, p);
+    const onto = strField(entry, "onto", "", errors, p);
+    if (!method) {
+      errors.push({ path: `${p}.method`, message: 'required ("ssm" or "lsq")' });
+    } else if (method !== "ssm" && method !== "lsq") {
+      errors.push({
+        path: `${p}.method`,
+        message: `must be "ssm" or "lsq", got "${method}"`,
+      });
+    }
+    if (!move) errors.push({ path: `${p}.move`, message: "required" });
+    if (!onto) errors.push({ path: `${p}.onto`, message: "required" });
+
+    // Cross-reference the files block — surfaces typos early.
+    if (move && files.length > 0 && !fileNames.has(move)) {
+      errors.push({
+        path: `${p}.move`,
+        message: `unknown file "${move}" (not in top-level files block)`,
+      });
+    }
+    if (onto && files.length > 0 && !fileNames.has(onto)) {
+      errors.push({
+        path: `${p}.onto`,
+        message: `unknown file "${onto}" (not in top-level files block)`,
+      });
+    }
+    if (move && onto && move === onto) {
+      errors.push({
+        path: p,
+        message: `cannot superpose a file onto itself ("${move}")`,
+      });
+    }
+
+    if (method === "ssm") {
+      const movChain = strField(entry, "movChain", "", errors, p);
+      const refChain = strField(entry, "refChain", "", errors, p);
+      if (!movChain) errors.push({ path: `${p}.movChain`, message: "required for ssm" });
+      if (!refChain) errors.push({ path: `${p}.refChain`, message: "required for ssm" });
+      out.push({ method: "ssm", move, onto, movChain, refChain });
+      return;
+    }
+
+    if (method === "lsq") {
+      const hasMatches = "matches" in entry;
+      const chain = optStr(entry, "chain", `${p}.chain`, errors);
+      const range = rangeField(entry, "range", errors, p);
+      const hasShorthand = !!chain || !!range;
+
+      // Mutually exclusive — having both invites silent precedence bugs.
+      if (hasMatches && hasShorthand) {
+        errors.push({
+          path: p,
+          message: 'use either `matches` or the `chain`+`range` shorthand, not both',
+        });
+      }
+
+      let matches: SceneLsqMatch[] = [];
+
+      if (hasShorthand) {
+        // chain + range together; both required.
+        if (!chain) {
+          errors.push({ path: `${p}.chain`, message: "required when range is set" });
+        }
+        if (!range) {
+          errors.push({ path: `${p}.range`, message: "required when chain is set" });
+        } else if (!RANGE_RE.test(range)) {
+          errors.push({
+            path: `${p}.range`,
+            message: `must be "start-end", got "${range}"`,
+          });
+        } else {
+          const m = RANGE_RE.exec(range)!;
+          const s = parseInt(m[1], 10);
+          const e = parseInt(m[2], 10);
+          if (e < s) {
+            errors.push({
+              path: `${p}.range`,
+              message: `end (${e}) must be >= start (${s})`,
+            });
+          }
+        }
+        // Even without `matches`, this is a valid LSQ entry — the resolver
+        // expands the shorthand at apply-time.
+      } else {
+        const matchesRaw = (entry as Record<string, unknown>).matches;
+        if (!Array.isArray(matchesRaw)) {
+          errors.push({
+            path: `${p}.matches`,
+            message:
+              "required for lsq (must be a sequence of range matches) — or use the `chain`+`range` shorthand",
+          });
+        } else if (matchesRaw.length === 0) {
+          errors.push({
+            path: `${p}.matches`,
+            message: "must contain at least one match entry",
+          });
+        } else {
+          matches = matchesRaw
+            .map((m, j) => validateLsqMatch(m, `${p}.matches[${j}]`, errors))
+            .filter((m): m is SceneLsqMatch => m !== null);
+        }
+      }
+
+      const matchType = optStr(entry, "matchType", `${p}.matchType`, errors);
+      if (matchType && matchType !== "all" && matchType !== "main" && matchType !== "ca") {
+        errors.push({
+          path: `${p}.matchType`,
+          message: `must be "all", "main" or "ca", got "${matchType}"`,
+        });
+      }
+      out.push({
+        method: "lsq",
+        move,
+        onto,
+        ...(hasShorthand ? { chain, range } : { matches }),
+        matchType: (matchType as "all" | "main" | "ca" | undefined) ?? undefined,
+      });
+      return;
+    }
+
+    // Unknown method already errored above; skip emission.
+  });
+
+  return out;
+}
+
+function validateLsqMatch(
+  raw: unknown,
+  path: string,
+  errors: SceneValidationError[],
+): SceneLsqMatch | null {
+  if (!isObject(raw)) {
+    errors.push({ path, message: "must be a mapping" });
+    return null;
+  }
+  const refChain = strField(raw, "refChain", "", errors, path);
+  const refRange = rangeField(raw, "refRange", errors, path) ?? "";
+  const movChain = strField(raw, "movChain", "", errors, path);
+  const movRange = rangeField(raw, "movRange", errors, path) ?? "";
+  if (!refChain) errors.push({ path: `${path}.refChain`, message: "required" });
+  if (!movChain) errors.push({ path: `${path}.movChain`, message: "required" });
+  for (const [field, val] of [["refRange", refRange], ["movRange", movRange]] as const) {
+    if (!val) {
+      errors.push({ path: `${path}.${field}`, message: "required" });
+    } else if (!RANGE_RE.test(val)) {
+      errors.push({
+        path: `${path}.${field}`,
+        message: `must be "start-end", got "${val}"`,
+      });
+    } else {
+      const m = RANGE_RE.exec(val)!;
+      const s = parseInt(m[1], 10);
+      const e = parseInt(m[2], 10);
+      if (e < s) {
+        errors.push({
+          path: `${path}.${field}`,
+          message: `end (${e}) must be >= start (${s})`,
+        });
+      }
+    }
+  }
+  return { refChain, refRange, movChain, movRange };
+}
+
+/**
+ * Validate a list of dictionary file-name references — used for both
+ * the top-level `globalDictionaries:` block and per-element
+ * `dictionaries:` lists. Each entry must be a string that names an
+ * existing file ref in the `files:` block, and that ref must have
+ * `kind: dictionary`.
+ */
+function validateDictionaryNameList(
+  raw: unknown,
+  files: SceneFileRef[],
+  path: string,
+  errors: SceneValidationError[],
+): string[] | undefined {
+  if (!Array.isArray(raw)) {
+    errors.push({ path, message: "must be a sequence of file names" });
+    return undefined;
+  }
+  const dictNames = new Set(
+    files.filter((f) => f.kind === "dictionary").map((f) => f.name),
+  );
+  const knownNames = new Set(files.map((f) => f.name));
+  const out: string[] = [];
+  raw.forEach((entry, i) => {
+    const p = `${path}[${i}]`;
+    if (typeof entry !== "string") {
+      errors.push({ path: p, message: `must be a string, got ${typeof entry}` });
+      return;
+    }
+    if (files.length === 0) {
+      // No files block at all; can't cross-check. Leave as-is.
+      out.push(entry);
+      return;
+    }
+    if (!knownNames.has(entry)) {
+      errors.push({
+        path: p,
+        message: `unknown file "${entry}" (not in top-level files block)`,
+      });
+      return;
+    }
+    if (!dictNames.has(entry)) {
+      errors.push({
+        path: p,
+        message: `file "${entry}" is not a dictionary (missing \`kind: dictionary\`)`,
+      });
+      return;
+    }
+    out.push(entry);
+  });
+  return out;
+}
+
+function validateDomains(
+  raw: unknown,
+  errors: SceneValidationError[],
+): SceneDomain[] | undefined {
+  if (!Array.isArray(raw)) {
+    errors.push({ path: "domains", message: "must be a sequence" });
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const out: SceneDomain[] = [];
+  raw.forEach((entry, i) => {
+    const p = `domains[${i}]`;
+    if (!isObject(entry)) {
+      errors.push({ path: p, message: "must be a mapping" });
+      return;
+    }
+    const name = strField(entry, "name", "", errors, p);
+    const chain = parseChainField(entry, `${p}.chain`, errors);
+    const range = rangeField(entry, "range", errors, p) ?? "";
+    const color = strField(entry, "color", "", errors, p);
+    if (!name) errors.push({ path: `${p}.name`, message: "required" });
+    if (chain === undefined) errors.push({ path: `${p}.chain`, message: "required" });
+    if (!range) {
+      errors.push({ path: `${p}.range`, message: "required" });
+    } else if (!RANGE_RE.test(range)) {
+      errors.push({
+        path: `${p}.range`,
+        message: `must be "start-end", got "${range}"`,
+      });
+    } else {
+      const m = RANGE_RE.exec(range)!;
+      const start = parseInt(m[1], 10);
+      const end = parseInt(m[2], 10);
+      if (end < start) {
+        errors.push({
+          path: `${p}.range`,
+          message: `end (${end}) must be >= start (${start})`,
+        });
+      }
+    }
+    if (!color) {
+      errors.push({ path: `${p}.color`, message: "required" });
+    } else if (!isHexColor(color)) {
+      errors.push({
+        path: `${p}.color`,
+        message: `must be hex like "#rrggbb", got "${color}"`,
+      });
+    }
+    if (name) {
+      if (seen.has(name)) {
+        errors.push({ path: `${p}.name`, message: `duplicate domain name "${name}"` });
+      }
+      seen.add(name);
+    }
+    out.push({ name, chain: chain ?? "", range, color });
+  });
+  return out;
+}
+
+function validateElements(
+  raw: unknown,
+  files: SceneFileRef[],
+  errors: SceneValidationError[],
+): SceneElement[] | undefined {
+  if (!Array.isArray(raw)) {
+    errors.push({ path: "elements", message: "must be a sequence" });
+    return undefined;
+  }
+  const fileNames = new Set(files.map((f) => f.name));
+  const out: SceneElement[] = [];
+  raw.forEach((entry, i) => {
+    const p = `elements[${i}]`;
+    if (!isObject(entry)) {
+      errors.push({ path: p, message: "must be a mapping" });
+      return;
+    }
+    const file = strField(entry, "file", "", errors, p);
+    if (!file) {
+      errors.push({ path: `${p}.file`, message: "required" });
+    } else if (files.length > 0 && !fileNames.has(file)) {
+      errors.push({
+        path: `${p}.file`,
+        message: `unknown file "${file}" (not in top-level files block)`,
+      });
+    }
+
+    const el: SceneElement = { file };
+    if ("dictionaries" in entry) {
+      const dicts = validateDictionaryNameList(
+        (entry as Record<string, unknown>).dictionaries,
+        files,
+        `${p}.dictionaries`,
+        errors,
+      );
+      if (dicts) el.dictionaries = dicts;
+    }
+    if ("representations" in entry) {
+      const reps = (entry as Record<string, unknown>).representations;
+      if (!Array.isArray(reps)) {
+        errors.push({ path: `${p}.representations`, message: "must be a sequence" });
+      } else {
+        el.representations = reps
+          .map((r, j) => validateRepresentation(r, `${p}.representations[${j}]`, errors))
+          .filter((r): r is SceneRepresentation => r !== null);
+      }
+    }
+    out.push(el);
+  });
+  return out;
+}
+
+function validateRepresentation(
+  raw: unknown,
+  path: string,
+  errors: SceneValidationError[],
+): SceneRepresentation | null {
+  if (!isObject(raw)) {
+    errors.push({ path, message: "must be a mapping" });
+    return null;
+  }
+  const style = strField(raw, "style", "", errors, path);
+  if (!style) {
+    errors.push({ path: `${path}.style`, message: "required" });
+  }
+  const rep: SceneRepresentation = { style };
+  if ("selection" in raw) {
+    rep.selection = optStr(raw, "selection", `${path}.selection`, errors);
+  }
+  if ("colour" in raw) {
+    const c = (raw as Record<string, unknown>).colour;
+    rep.colour = validateColour(c, `${path}.colour`, errors) ?? undefined;
+  }
+  return rep;
+}
+
+function validateColour(
+  raw: unknown,
+  path: string,
+  errors: SceneValidationError[],
+): SceneColour | null {
+  if (typeof raw === "string") {
+    if (isHexColor(raw)) return raw;
+    if (isSceneNamedColour(raw as SceneColour)) return raw as SceneColour;
+    errors.push({
+      path,
+      message: `unknown colour "${raw}" — expected hex (#rrggbb) or named scheme`,
+    });
+    return null;
+  }
+  if (isObject(raw) && "raw" in raw) {
+    const r = (raw as { raw: unknown }).raw;
+    if (!isObject(r)) {
+      errors.push({ path: `${path}.raw`, message: "must be a mapping" });
+      return null;
+    }
+    const ruleType = strField(r, "ruleType", "", errors, `${path}.raw`);
+    const args = (r as Record<string, unknown>).args;
+    if (!ruleType) {
+      errors.push({ path: `${path}.raw.ruleType`, message: "required" });
+    }
+    if (!Array.isArray(args)) {
+      errors.push({ path: `${path}.raw.args`, message: "must be a sequence" });
+      return null;
+    }
+    return {
+      raw: {
+        ruleType,
+        args: args as (string | number)[],
+        isMultiColourRule: optBool(r, "isMultiColourRule", `${path}.raw.isMultiColourRule`, errors),
+        applyColourToNonCarbonAtoms: optBool(
+          r,
+          "applyColourToNonCarbonAtoms",
+          `${path}.raw.applyColourToNonCarbonAtoms`,
+          errors,
+        ),
+      },
+    };
+  }
+  errors.push({ path, message: "must be a hex string, named scheme, or { raw: ... }" });
+  return null;
+}
+
+// --------------------------------------------------------------------------
+// Serialise: MoorhenScene → YAML string
+// --------------------------------------------------------------------------
+
+/**
+ * Serialise a scene back to YAML. Field order is canonical (top-level
+ * keys appear in the order declared in the type), and empty/undefined
+ * fields are omitted so round-trip is stable.
+ */
+export function serialiseScene(scene: MoorhenScene): string {
+  return YAML.stringify(buildOrderedScene(scene), { lineWidth: 0 });
+}
+
+/**
+ * Like serialiseScene, but attaches per-file comments above each entry
+ * in the files: sequence. Used by the lifter to record source URLs
+ * without polluting the schema.
+ *
+ * fileComments is keyed by SceneFileRef.name; missing entries produce
+ * no comment.
+ */
+export function serialiseSceneWithComments(
+  scene: MoorhenScene,
+  fileComments: Record<string, string> = {},
+): string {
+  const ordered = buildOrderedScene(scene);
+  const doc = new YAML.Document(ordered);
+
+  if (scene.files && scene.files.length > 0) {
+    const filesNode = doc.get("files") as YAML.YAMLSeq | undefined;
+    if (filesNode && Array.isArray(filesNode.items)) {
+      scene.files.forEach((f, i) => {
+        const comment = fileComments[f.name];
+        const item = filesNode.items[i];
+        if (comment && item && typeof item === "object") {
+          (item as { commentBefore?: string }).commentBefore = ` ${comment}`;
+        }
+      });
+    }
+  }
+
+  return doc.toString({ lineWidth: 0 });
+}
+
+function buildOrderedScene(scene: MoorhenScene): Record<string, unknown> {
+  const ordered: Record<string, unknown> = {};
+  ordered.scene = scene.scene;
+  ordered.version = scene.version;
+  if (scene.authoredIn && hasAnyValue(scene.authoredIn)) {
+    ordered.authoredIn = stripUndefined(scene.authoredIn);
+  }
+  if (scene.files && scene.files.length > 0) {
+    ordered.files = scene.files.map((f) => stripUndefined(f));
+  }
+  if (scene.superpose && scene.superpose.length > 0) {
+    ordered.superpose = scene.superpose.map((sp) => stripUndefined(sp));
+  }
+  if (scene.globalDictionaries && scene.globalDictionaries.length > 0) {
+    ordered.globalDictionaries = scene.globalDictionaries;
+  }
+  if (scene.domains && scene.domains.length > 0) {
+    ordered.domains = scene.domains;
+  }
+  if (scene.elements && scene.elements.length > 0) {
+    ordered.elements = scene.elements.map((el) => {
+      const out: Record<string, unknown> = { file: el.file };
+      if (el.dictionaries && el.dictionaries.length > 0) {
+        out.dictionaries = el.dictionaries;
+      }
+      if (el.representations && el.representations.length > 0) {
+        out.representations = el.representations.map((r) => stripUndefined(r));
+      }
+      return out;
+    });
+  }
+  if (scene.view && hasAnyValue(scene.view)) {
+    ordered.view = stripUndefined(scene.view);
+  }
+  if (scene.resolver && scene.resolver.onMissingResidues) {
+    ordered.resolver = { onMissingResidues: scene.resolver.onMissingResidues };
+  }
+  return ordered;
+}
+
+// --------------------------------------------------------------------------
+// Small utilities
+// --------------------------------------------------------------------------
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function isHexColor(s: string): boolean {
+  return /^#[0-9a-fA-F]{6}$/.test(s);
+}
+
+function hasAnyValue(o: object): boolean {
+  return Object.values(o as Record<string, unknown>).some((v) => v !== undefined);
+}
+
+function stripUndefined<T extends object>(o: T): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(o as Record<string, unknown>)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as Partial<T>;
+}
+
+function strField(
+  obj: Record<string, unknown>,
+  key: string,
+  fallback: string,
+  errors: SceneValidationError[],
+  parent = "",
+): string {
+  const v = obj[key];
+  if (v === undefined) return fallback;
+  if (typeof v !== "string") {
+    errors.push({
+      path: parent ? `${parent}.${key}` : key,
+      message: `must be a string, got ${typeof v}`,
+    });
+    return fallback;
+  }
+  return v;
+}
+
+/**
+ * Read a residue-range field. Accepts either a "start-end" string or a
+ * bare integer (treated as the single-residue range "N-N"). Returns the
+ * normalised string form so downstream code only sees one shape. Pushes
+ * an error and returns "" if the field is present but the wrong type.
+ */
+function rangeField(
+  obj: Record<string, unknown>,
+  key: string,
+  errors: SceneValidationError[],
+  parent = "",
+): string | undefined {
+  const v = obj[key];
+  if (v === undefined) return undefined;
+  if (typeof v === "number" && Number.isFinite(v) && Number.isInteger(v)) {
+    return `${v}-${v}`;
+  }
+  if (typeof v === "string") return v;
+  errors.push({
+    path: parent ? `${parent}.${key}` : key,
+    message: `must be a string or integer, got ${typeof v}`,
+  });
+  return undefined;
+}
+
+function numField(
+  obj: Record<string, unknown>,
+  key: string,
+  fallback: number,
+  errors: SceneValidationError[],
+  parent = "",
+): number {
+  const v = obj[key];
+  if (v === undefined) return fallback;
+  if (typeof v !== "number") {
+    errors.push({
+      path: parent ? `${parent}.${key}` : key,
+      message: `must be a number, got ${typeof v}`,
+    });
+    return fallback;
+  }
+  return v;
+}
+
+function optStr(
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: SceneValidationError[],
+): string | undefined {
+  const v = obj[key];
+  if (v === undefined) return undefined;
+  if (typeof v !== "string") {
+    errors.push({ path, message: `must be a string, got ${typeof v}` });
+    return undefined;
+  }
+  return v;
+}
+
+function optNum(
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: SceneValidationError[],
+): number | undefined {
+  const v = obj[key];
+  if (v === undefined) return undefined;
+  if (typeof v !== "number") {
+    errors.push({ path, message: `must be a number, got ${typeof v}` });
+    return undefined;
+  }
+  return v;
+}
+
+function optBool(
+  obj: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: SceneValidationError[],
+): boolean | undefined {
+  const v = obj[key];
+  if (v === undefined) return undefined;
+  if (typeof v !== "boolean") {
+    errors.push({ path, message: `must be a boolean, got ${typeof v}` });
+    return undefined;
+  }
+  return v;
+}
+
+function tupleField<N extends number>(
+  obj: Record<string, unknown>,
+  key: string,
+  length: N,
+  path: string,
+  errors: SceneValidationError[],
+): (N extends 3 ? [number, number, number] : [number, number, number, number]) | undefined {
+  const v = obj[key];
+  if (v === undefined) return undefined;
+  if (!Array.isArray(v) || v.length !== length) {
+    errors.push({ path, message: `must be an array of ${length} numbers` });
+    return undefined;
+  }
+  if (!v.every((x) => typeof x === "number")) {
+    errors.push({ path, message: `all elements must be numbers` });
+    return undefined;
+  }
+  return v as never;
+}
+
+/**
+ * Parse a `chain:` field accepting either a string (single chain id or
+ * the "*" wildcard) or a sequence of strings.
+ *
+ * Returns `undefined` only when the field is missing — that lets the
+ * caller emit its own "required" error so error messages don't double
+ * up. Returns an empty string for typed-but-empty values, so the
+ * required-check still fires uniformly.
+ */
+function parseChainField(
+  obj: Record<string, unknown>,
+  path: string,
+  errors: SceneValidationError[],
+): string | string[] | undefined {
+  const v = obj["chain"];
+  if (v === undefined) return undefined;
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) {
+    if (v.length === 0) {
+      errors.push({ path, message: "chain list must not be empty" });
+      return "";
+    }
+    if (!v.every((x): x is string => typeof x === "string")) {
+      errors.push({ path, message: "chain list entries must all be strings" });
+      return "";
+    }
+    return v;
+  }
+  errors.push({ path, message: `must be a string or sequence of strings, got ${typeof v}` });
+  return "";
+}
+
+// Re-export the guards so callers don't need two imports.
+export { isSceneHexColour, isSceneNamedColour, isSceneRawColour };

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -577,7 +577,7 @@ function validateDomains(
     } else if (!isHexColor(color)) {
       errors.push({
         path: `${p}.color`,
-        message: `must be hex like "#rrggbb", got "${color}"`,
+        message: `must be hex like "#rrggbb" or "#rrggbbaa", got "${color}"`,
       });
     }
     if (name) {
@@ -677,7 +677,7 @@ function validateColour(
     if (isSceneNamedColour(raw as SceneColour)) return raw as SceneColour;
     errors.push({
       path,
-      message: `unknown colour "${raw}" — expected hex (#rrggbb) or named scheme`,
+      message: `unknown colour "${raw}" — expected hex (#rrggbb or #rrggbbaa) or named scheme`,
     });
     return null;
   }
@@ -807,7 +807,11 @@ function isObject(x: unknown): x is Record<string, unknown> {
 }
 
 function isHexColor(s: string): boolean {
-  return /^#[0-9a-fA-F]{6}$/.test(s);
+  // 6-hex (#rrggbb) or 8-hex with alpha (#rrggbbaa). Moorhen's own
+  // MoorhenColourRule.parseHexToRgba accepts both, and Moorhen's
+  // default per-chain colour rules come out as 8-hex, so the scene
+  // format mirrors that.
+  return /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(s);
 }
 
 function hasAnyValue(o: object): boolean {

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -19,6 +19,8 @@ import {
   SceneFileRef,
   SceneElement,
   SceneLsqMatch,
+  SceneMap,
+  SceneMapColumns,
   SceneRepresentation,
   SceneColour,
   SceneSuperpose,
@@ -145,6 +147,31 @@ export function validateScene(raw: unknown): {
     );
   }
 
+  if ("maps" in raw) {
+    out.maps = validateMaps(
+      (raw as Record<string, unknown>).maps,
+      out.files ?? [],
+      errors,
+    );
+  }
+
+  if ("activeMap" in raw) {
+    const am = optStr(raw, "activeMap", "activeMap", errors);
+    if (am) {
+      // Validate cross-reference against the maps block. The maps block
+      // is optional, so we accept any string here when it isn't present
+      // (the resolver will warn at apply time).
+      if (out.maps && !out.maps.some((m) => m.name === am)) {
+        errors.push({
+          path: "activeMap",
+          message: `"${am}" does not name any entry in maps:`,
+        });
+      } else {
+        out.activeMap = am;
+      }
+    }
+  }
+
   if ("view" in raw) {
     const v = (raw as Record<string, unknown>).view;
     if (isObject(v)) {
@@ -215,12 +242,12 @@ function validateFiles(
     const ref: SceneFileRef = { name };
     if ("kind" in entry) {
       const kind = optStr(entry, "kind", `${p}.kind`, errors);
-      if (kind && kind !== "coordinates" && kind !== "dictionary") {
+      if (kind && kind !== "coordinates" && kind !== "dictionary" && kind !== "mtz") {
         errors.push({
           path: `${p}.kind`,
-          message: `must be "coordinates" or "dictionary", got "${kind}"`,
+          message: `must be "coordinates", "dictionary", or "mtz", got "${kind}"`,
         });
-      } else if (kind === "coordinates" || kind === "dictionary") {
+      } else if (kind === "coordinates" || kind === "dictionary" || kind === "mtz") {
         ref.kind = kind;
       }
     }
@@ -643,6 +670,130 @@ function validateElements(
   return out;
 }
 
+function validateMaps(
+  raw: unknown,
+  files: SceneFileRef[],
+  errors: SceneValidationError[],
+): SceneMap[] | undefined {
+  if (!Array.isArray(raw)) {
+    errors.push({ path: "maps", message: "must be a sequence" });
+    return undefined;
+  }
+  const fileNames = new Set(files.map((f) => f.name));
+  const mtzFileNames = new Set(
+    files.filter((f) => f.kind === "mtz").map((f) => f.name),
+  );
+  const seen = new Set<string>();
+  const out: SceneMap[] = [];
+  raw.forEach((entry, i) => {
+    const p = `maps[${i}]`;
+    if (!isObject(entry)) {
+      errors.push({ path: p, message: "must be a mapping" });
+      return;
+    }
+    const name = strField(entry, "name", "", errors, p);
+    if (!name) {
+      errors.push({ path: `${p}.name`, message: "required" });
+    } else if (seen.has(name)) {
+      errors.push({ path: `${p}.name`, message: `duplicate map name "${name}"` });
+    } else {
+      seen.add(name);
+    }
+
+    const file = strField(entry, "file", "", errors, p);
+    if (!file) {
+      errors.push({ path: `${p}.file`, message: "required" });
+    } else if (files.length > 0 && !fileNames.has(file)) {
+      errors.push({
+        path: `${p}.file`,
+        message: `unknown file "${file}" (not in top-level files block)`,
+      });
+    } else if (fileNames.has(file) && !mtzFileNames.has(file)) {
+      errors.push({
+        path: `${p}.file`,
+        message: `"${file}" must be a file with kind: "mtz"`,
+      });
+    }
+
+    const columnsRaw = (entry as Record<string, unknown>).columns;
+    let columns: SceneMapColumns = {};
+    if (!isObject(columnsRaw)) {
+      errors.push({ path: `${p}.columns`, message: "required mapping (F + PHI minimum)" });
+    } else {
+      columns = {
+        F: optStr(columnsRaw, "F", `${p}.columns.F`, errors),
+        PHI: optStr(columnsRaw, "PHI", `${p}.columns.PHI`, errors),
+        Fobs: optStr(columnsRaw, "Fobs", `${p}.columns.Fobs`, errors),
+        SigFobs: optStr(columnsRaw, "SigFobs", `${p}.columns.SigFobs`, errors),
+        FreeR: optStr(columnsRaw, "FreeR", `${p}.columns.FreeR`, errors),
+        useWeight: optBool(columnsRaw, "useWeight", `${p}.columns.useWeight`, errors),
+        calcStructFact: optBool(columnsRaw, "calcStructFact", `${p}.columns.calcStructFact`, errors),
+      };
+      // Drop undefined fields so the round-trip stays clean.
+      (Object.keys(columns) as (keyof SceneMapColumns)[]).forEach((k) => {
+        if (columns[k] === undefined) delete columns[k];
+      });
+      // Need F + PHI unless calcStructFact (then Moorhen computes them
+      // from Fobs/SigFobs/FreeR).
+      const haveFP = !!columns.F && !!columns.PHI;
+      const haveCalc = columns.calcStructFact && !!columns.Fobs && !!columns.SigFobs;
+      if (!haveFP && !haveCalc) {
+        errors.push({
+          path: `${p}.columns`,
+          message: "must set F + PHI (or calcStructFact + Fobs + SigFobs)",
+        });
+      }
+    }
+
+    const map: SceneMap = { name, file, columns };
+
+    if ("isDifference" in entry) {
+      map.isDifference = optBool(entry, "isDifference", `${p}.isDifference`, errors);
+    }
+    if ("contourLevel" in entry) {
+      map.contourLevel = optNum(entry, "contourLevel", `${p}.contourLevel`, errors);
+    }
+    if ("radius" in entry) {
+      map.radius = optNum(entry, "radius", `${p}.radius`, errors);
+    }
+    if ("alpha" in entry) {
+      map.alpha = optNum(entry, "alpha", `${p}.alpha`, errors);
+    }
+    if ("style" in entry) {
+      const s = optStr(entry, "style", `${p}.style`, errors);
+      if (s && s !== "lines" && s !== "solid" && s !== "lit-lines") {
+        errors.push({
+          path: `${p}.style`,
+          message: `must be "lines", "solid", or "lit-lines", got "${s}"`,
+        });
+      } else if (s) {
+        map.style = s as SceneMap["style"];
+      }
+    }
+    for (const k of ["colour", "positiveColour", "negativeColour"] as const) {
+      if (k in entry) {
+        const c = optStr(entry, k, `${p}.${k}`, errors);
+        if (c) {
+          if (!isHexColor(c)) {
+            errors.push({
+              path: `${p}.${k}`,
+              message: `must be hex like "#rrggbb" or "#rrggbbaa", got "${c}"`,
+            });
+          } else {
+            map[k] = c;
+          }
+        }
+      }
+    }
+    if ("visible" in entry) {
+      map.visible = optBool(entry, "visible", `${p}.visible`, errors);
+    }
+
+    out.push(map);
+  });
+  return out;
+}
+
 function validateRepresentation(
   raw: unknown,
   path: string,
@@ -788,6 +939,28 @@ function buildOrderedScene(scene: MoorhenScene): Record<string, unknown> {
       }
       return out;
     });
+  }
+  if (scene.maps && scene.maps.length > 0) {
+    ordered.maps = scene.maps.map((m) => {
+      const out: Record<string, unknown> = {
+        name: m.name,
+        file: m.file,
+        columns: stripUndefined(m.columns),
+      };
+      // Optional render-state fields: emit only the ones the lifter
+      // (or hand-author) set, so the YAML stays small.
+      const optional: (keyof SceneMap)[] = [
+        "isDifference", "contourLevel", "radius", "alpha", "style",
+        "colour", "positiveColour", "negativeColour", "visible",
+      ];
+      for (const k of optional) {
+        if (m[k] !== undefined) out[k] = m[k];
+      }
+      return out;
+    });
+  }
+  if (scene.activeMap) {
+    ordered.activeMap = scene.activeMap;
   }
   if (scene.view && hasAnyValue(scene.view)) {
     ordered.view = stripUndefined(scene.view);

--- a/client/renderer/middleware.ts
+++ b/client/renderer/middleware.ts
@@ -35,21 +35,30 @@ const AUTH_EXEMPT_PATHS = [
                         // probes need to reach it without an auth-session cookie.
 ];
 
-// Paths that accept Bearer token authentication (for CLI tools like i2remote)
-// These paths handle their own auth validation in the route handler
+// Paths that accept Bearer token authentication (for CLI tools like i2remote).
+// These paths handle their own auth validation in the route handler downstream.
+//
+// IMPORTANT: list each prefix WITHOUT a trailing slash. Next.js's default
+// `trailingSlash: false` canonicalizer strips trailing slashes from incoming
+// URLs before middleware sees them -- so a request to `/api/proxy/pandda/runs/`
+// arrives here as `/api/proxy/pandda/runs`, and a rule of
+// `/api/proxy/pandda/runs/` would never match via `startsWith()`. The bug
+// manifests as CLI POSTs (no auth cookie) silently redirecting to /auth/login.
+// Listing the no-slash prefix matches both `/runs` and `/runs/2` (or any
+// deeper sub-path), which is what we want.
 const BEARER_AUTH_PATHS = [
-  "/api/proxy/ccp4i2/", // CCP4i2 API proxy - validates Bearer token in route handler
-  "/api/proxy/compounds/", // Compounds API proxy - validates Bearer token in route handler
-  "/api/proxy/pandda/runs/", // PanDDA run-lifecycle proxy (POST trigger, GET poll, cancel).
-                             // The route handler forwards the user's Authorization header
-                             // to Reinspect; Reinspect's ccp4i2-api middleware validates
-                             // the AAD JWT and stamps Run.triggered_by_oid.
-  "/reinspect/", // Reinspect SPA + asset + API proxy. Browser navigation reaches it
-                 // with an auth-session cookie (cookie-or-Bearer suffices for the
-                 // middleware); programmatic /api/v1/* calls from the SPA include
-                 // a Bearer token via MSAL. Reinspect's middleware then validates
-                 // the AAD JWT downstream (auth at the edge here is just gating
-                 // unknown traffic; the real check is on Reinspect's side).
+  "/api/proxy/ccp4i2", // CCP4i2 API proxy - validates Bearer token in route handler
+  "/api/proxy/compounds", // Compounds API proxy - validates Bearer token in route handler
+  "/api/proxy/pandda/runs", // PanDDA run-lifecycle proxy (POST trigger, GET poll, cancel).
+                            // The route handler forwards the user's Authorization header
+                            // to Reinspect; Reinspect's ccp4i2-api middleware validates
+                            // the AAD JWT and stamps Run.triggered_by_oid.
+  "/reinspect", // Reinspect SPA + asset + API proxy. Browser navigation reaches it
+                // with an auth-session cookie (cookie-or-Bearer suffices for the
+                // middleware); programmatic /api/v1/* calls from the SPA include
+                // a Bearer token via MSAL. Reinspect's middleware then validates
+                // the AAD JWT downstream (auth at the edge here is just gating
+                // unknown traffic; the real check is on Reinspect's side).
 ];
 
 // Check if path is exempt from authentication

--- a/client/renderer/next.config.ts
+++ b/client/renderer/next.config.ts
@@ -210,6 +210,19 @@ const nextConfig: NextConfig = {
           source: "/ccp4i2/moorhen-page/:path*",
           headers: [...devCommonHeaders, ...webAssemblyHeaders],
         },
+        // Reinspect SPA is path-mounted at /reinspect/* and instantiates
+        // Moorhen for event review; same COOP/COEP requirement as
+        // /ccp4i2/moorhen-page above. Mirror it here so dev-mode parity
+        // with production is maintained. See production block for full
+        // rationale.
+        {
+          source: "/reinspect",
+          headers: [...devCommonHeaders, ...webAssemblyHeaders],
+        },
+        {
+          source: "/reinspect/:path*",
+          headers: [...devCommonHeaders, ...webAssemblyHeaders],
+        },
         // All other routes
         {
           source: "/:path*",
@@ -310,6 +323,26 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/ccp4i2/moorhen-page/:path*",
+        headers: [...commonHeaders, ...webAssemblyHeaders],
+      },
+      // Reinspect SPA is path-mounted at /reinspect/* and instantiates Moorhen
+      // (via CootWorker.js) when it shows event review pages. The SPA page
+      // therefore needs the same cross-origin-isolation pair (COOP same-origin
+      // + COEP require-corp) that /ccp4i2/moorhen-page gets, so the browser
+      // accepts SharedArrayBuffer and Worker construction. The Reinspect
+      // upstream sets these too (CLOUD_DEPLOYMENT.md "Cross-Origin headers")
+      // and our /reinspect/* proxy preserves them, but emitting them at the
+      // Materia edge as well guarantees consistency across the redirect chain
+      // (the SPA index.html, the Reinspect API responses, asset 404 / error
+      // pages, ...) -- without this, the WASM Worker load was blocked with
+      // "Refused to load worker because of Cross-Origin-Embedder-Policy"
+      // (BAZ2B smoke, 2026-06-07).
+      {
+        source: "/reinspect",
+        headers: [...commonHeaders, ...webAssemblyHeaders],
+      },
+      {
+        source: "/reinspect/:path*",
         headers: [...commonHeaders, ...webAssemblyHeaders],
       },
       // All other routes - no cross-origin isolation, allows Teams embedding

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -1,0 +1,597 @@
+# Moorhen Scene format — v1
+
+A **scene** is a portable, human-editable YAML description of how to
+render one or more structures in Moorhen. It captures *intent*
+(domains, colour rules, representations, superpositions, camera)
+separately from any specific PDB file, so the same visual treatment
+can be re-applied across different structures of the same protein.
+
+This document is the authoring reference — written for a person (or a
+script) building a scene from outside Moorhen. The TypeScript types
+live in [`moorhen-scene.ts`](./moorhen-scene.ts); parse/serialise
+logic lives in [`../lib/moorhen-scene.ts`](../lib/moorhen-scene.ts).
+
+## File extensions
+
+| Suffix             | Purpose                                                              |
+| ------------------ | -------------------------------------------------------------------- |
+| `*.scene.yaml`     | The scene as a plain YAML file. Use when all file refs are portable. |
+| `*.scene.zip`      | Bundle: `scene.yaml` at root + `assets/` directory of attached data. |
+| `*.session.json`   | Moorhen-native cache, regenerable. Not for hand-authoring.           |
+
+The bundle is the right shape when the scene references local files
+(coords or dictionaries) that aren't otherwise reachable by URL or PDB
+ID. The yaml inside uses `bundle: <relpath>` to point at zipped
+assets. Both forms parse identically — the yaml is the source of truth.
+
+## Top-level grammar
+
+```yaml
+scene: <string>                      # required: human-readable identifier
+version: 1                           # required: schema version
+
+authoredIn:                          # optional: provenance (never resolved)
+  projectId: <uuid>                  # optional
+  projectName: <name>                # optional
+  createdAt: <iso-8601>              # optional
+  createdBy: <author>                # optional
+  ccp4i2Version: <string>            # optional
+
+files: [ ... ]                       # optional: named coord + dict refs
+superpose: [ ... ]                   # optional: alignments, applied in order
+globalDictionaries: [ <name>, ... ]  # optional: dicts loaded on every molecule
+domains: [ ... ]                     # optional: reusable named residue blocks
+elements: [ ... ]                    # optional: per-file rendering instructions
+view: { ... }                        # optional: camera, clip, fog, background
+
+resolver:                            # optional: apply-time policy
+  onMissingResidues: clamp-and-log   # | strict
+```
+
+Order of evaluation at apply-time:
+
+1. **Fetch dictionaries** (load each globally, so coords parse).
+2. **Fetch coordinates** (in declared order).
+3. **Scope dictionaries** per element (re-associate to that molecule's molNo).
+4. **Run superpositions** (mutate moving structures' transforms).
+5. **Apply representations** per element.
+6. **Set camera**.
+
+## `files`
+
+A list of named file references. The name (e.g. `protein`, `apo`,
+`x0034`) is what other parts of the scene refer to; it's local to this
+file and doesn't have to mean anything outside.
+
+Each entry has:
+
+- `name`: **required**, unique within the block.
+- `kind`: optional, `"coordinates"` (default) or `"dictionary"`.
+- Exactly one resolution method:
+
+  | Field                              | Use when                                                                                                                 |
+  | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+  | `pdb: <id>`                        | Deposited structure. Fetched via PDBe. Most portable. Coordinates only.                                                  |
+  | `url: <https://...>`               | Coord or dict published at a CORS-friendly URL.                                                                          |
+  | `fileId: <int>` + `projectId: <uuid>` | Project-internal ref to a ccp4i2 file.                                                                                |
+  | `job: <int>` + `param: <str>` + `projectId` | Project-internal ref to a job's output parameter.                                                              |
+  | `bundle: <relpath>`                | Asset packaged inside a `.scene.zip` (e.g. `assets/coords/x0034.cif`).                                                   |
+  | `cifText: \|<inline cif>`          | Dictionary text inlined directly. Only valid for `kind: dictionary`.                                                     |
+  | `path: <abspath>`                  | Local-only. Won't resolve on another machine. Mostly used as a marker.                                                   |
+
+### Examples
+
+```yaml
+files:
+  # A deposited structure — most portable.
+  - { name: ref, pdb: 1m17 }
+
+  # Project-internal ccp4i2 file.
+  - name: refined
+    projectId: 3f8a-aaaa-bbbb-cccc-uuid
+    fileId: 482
+
+  # Multiple coord files via a single bundle.
+  - { name: x0034, bundle: assets/coords/x0034.cif }
+  - { name: x0092, bundle: assets/coords/x0092.cif }
+
+  # A scoped dictionary, bundled alongside its coords.
+  - { name: lig-A, kind: dictionary, bundle: assets/dict/lig-A.cif }
+
+  # Inline dict (cifText) — verbose but always works on any machine.
+  - name: minimal-dict
+    kind: dictionary
+    cifText: |
+      data_comp_LIG
+      _chem_comp.id LIG
+      ...
+```
+
+## `domains`
+
+Reusable named residue blocks, referenced from `colour: by-domain`
+inside an element. Hoisted to the top level so a multi-structure scene
+doesn't duplicate them per element.
+
+```yaml
+domains:
+  - { name: CARD, chain: A, range: 1-92,    color: "#4b8bbe" }
+  - { name: NBD,  chain: A, range: 104-260, color: "#2ecc71" }
+  - { name: HD1,  chain: A, range: 261-330, color: "#9b59b6" }
+```
+
+Fields:
+
+- `name`: required.
+- `chain`: required. Three forms:
+  - `"A"` — a single chain.
+  - `"*"` — every chain present in the structure (useful for symmetric
+    assemblies like the apoptosome heptamer).
+  - `["A", "B", "C"]` — explicit list, applied to each chain in turn.
+- `range`: required. Two forms:
+  - `"start-end"` (string) — inclusive range, e.g. `"100-200"`.
+  - `<integer>` (bare int) — single residue; the validator normalises
+    `115` to `"115-115"` so downstream code only sees one shape.
+- `color`: required hex `#rrggbb`.
+
+The resolver clamps each range to the residues actually present in the
+loaded structure (see `resolver.onMissingResidues`).
+
+## `elements`
+
+Per-file rendering instructions: which representations to draw, with
+what colour, on which selection.
+
+```yaml
+elements:
+  - file: protein                        # name from the files: block
+    dictionaries: [lig-A, cofactor]      # optional: per-molecule dict scoping
+    representations:
+      - { style: CRs,      selection: "//A",       colour: by-domain }
+      - { style: ligands,  selection: "//*/(LIG)", colour: "#2ecc71" }
+      # Multi-residue highlight: || joins single-residue / range CIDs.
+      - { style: CBs,      selection: "//A/115||//A/116||//A/121-122", colour: "#e74c3c" }
+```
+
+### `style`
+
+Any [Moorhen representation
+style](https://github.com/moorhen-coot/Moorhen/) (27 supported as of
+v1). The common ones:
+
+| Style              | What it draws                       |
+| ------------------ | ----------------------------------- |
+| `CRs`              | Cartoon ribbons.                    |
+| `CBs`              | All-atom sticks (carbon bonds).     |
+| `CAs`              | Cα-only trace.                      |
+| `MolecularSurface` | Smooth molecular surface.           |
+| `VdwSpheres`       | Van-der-Waals spheres.              |
+| `ligands`          | Stick representation of HET atoms.  |
+| `DishyBases`       | Cartoon-style nucleotide bases.     |
+| `allHBonds`        | Hydrogen bonds.                     |
+
+### `selection`
+
+A Coot CID string (gemmi-parsed selection syntax). Format:
+`/<model>/<chain>/<residue>/<atom>`. Wildcards: `*` matches any one
+component; omitting trailing components defaults them to `*`.
+
+The residue field accepts **either a single residue number, or a
+single `start-end` range** — *not* a comma-separated list. Comma lists
+ARE valid for residue *names* (`(ALA,GLY,SER)`) and *elements*
+(`[N,O,S]`), but not for residue numbers.
+
+| Pattern                    | Meaning                                            |
+| -------------------------- | -------------------------------------------------- |
+| `/*/*/*/*`                 | Every atom (the default if `selection` is omitted) |
+| `//A`                      | Chain A, all residues                              |
+| `//A/115`                  | Residue 115 of chain A                             |
+| `//A/115-200`              | Residues 115–200 inclusive                         |
+| `//*/(LIG)`                | Every chain, residue name LIG (parens are required)|
+| `//A/(ALA,GLY)`            | Chain A, residue name ALA or GLY                   |
+| `//A/115/CA[C]`            | The Cα atom of residue 115, element carbon         |
+
+**Comma-separated residue numbers are NOT valid.** Coot's parser
+rejects `//A/115,116,121` with `Invalid selection syntax`.
+
+### Multiple disjoint residues: `||`-joined multi-CID
+
+To select several non-contiguous residues on the same chain (a common
+need for highlighting catalytic / binding / mutation hotspots), join
+single-residue or single-range CIDs with `||`:
+
+```yaml
+# Correct: || is the only way to express "these N disjoint residues"
+- style: CBs
+  selection: "//A/115||//A/122||//A/155||//A/210||//A/221||//A/233-234||//A/246"
+  colour: "#e74c3c"
+```
+
+The resolver splits on `||` and emits **one representation per chunk**,
+each sharing the same style and colour. This is correct, but every
+chunk becomes a row in Moorhen's Models drawer. For seven highlights
+you get seven rows; for fifty, fifty.
+
+**There is currently no compact form that produces one row.** The
+mmdb/gemmi CID grammar simply doesn't have one. If panel-row count
+matters for you, group highlights into contiguous ranges where you
+can, and accept the row-per-chunk cost where you can't. Improving
+this needs a Moorhen API change — see the upstream issue tracker.
+
+## Common authoring pitfalls
+
+A small set of CID and rep-shape mistakes account for almost every
+"why isn't anything rendering?" problem. If you're writing a converter
+that produces scenes from another tool (PyMOL `.pse`, ChimeraX
+session, etc.), check these first.
+
+### Never emit `selection: //`
+
+`//` is **not** a valid CID. Coot reads it as "model nothing, chain
+nothing" and the selection comes back empty, so the representation
+renders no atoms. The viewer will look broken or near-empty.
+
+To mean "the whole molecule", do one of:
+
+```yaml
+# Best: omit `selection:` entirely. The resolver defaults to /*/*/*/*.
+- { style: CRs, colour: by-domain }
+
+# Equivalent: explicit wildcard.
+- { style: CRs, selection: "/*/*/*/*", colour: by-domain }
+
+# Single chain.
+- { style: CRs, selection: "//A", colour: by-domain }
+```
+
+**Never** emit `selection: //`, `selection: ""`, `selection: "/"`, or
+any partially-empty CID. They all evaluate to "select nothing" and the
+rep silently draws nothing.
+
+### `style: ligands` — always emit an explicit selection
+
+Moorhen's `ligands` style does its own non-polymer atom-discovery
+inside Coot, which depends on entity types and parsing quirks of the
+loaded cif. In practice this misbehaves on cifs from many sources:
+it can pick up amino-acid residues (especially glycines) as
+"ligands", miss the actual fragment ligand entirely, or — worst —
+share an auto-discovered list across all molecules in a multi-load
+session, so every fragment in a campaign renders the *same* ligand
+neighbourhood instead of its own.
+
+**Always specify the ligand explicitly** by residue name. The CID
+form is `//*/(COMPID)`:
+
+```yaml
+- file: x0682
+  dictionaries: [x0682_LIG]
+  representations:
+    - style: ligands
+      selection: "//*/(LIG)"          # only LIG, by residue name
+```
+
+`//*/(LIG)` reads as: any chain, any residue with name `LIG`. The
+parentheses are required — they tell the gemmi CID parser this is a
+residue-name selector, not a sequence number.
+
+If the fragment comp_id varies per structure (typical in a fragment
+campaign — each soaked compound has its own three-letter code), the
+converter should read the comp_id out of the dict file's
+`data_comp_<X>` line and emit the right name per element. **The
+converter knows what the ligand is — there's a dict for it.** Anything
+the converter knows should be expressed explicitly; don't trust
+Moorhen's auto-discovery for anything load-bearing.
+
+For multiple distinct ligands on one molecule, `||`-join them as
+usual:
+
+```yaml
+- style: ligands
+  selection: "//*/(LIG)||//*/(ADP)"
+```
+
+**Why the doc previously said the opposite:** earlier versions of this
+file recommended bare `style: ligands` with no selection, relying on
+Moorhen's auto-discovery. That advice produced wrong renderings on
+real cifs and has been retracted.
+
+### Don't lift `view.clipStart` / `clipEnd` from PyMOL
+
+PyMOL's view state uses massive clip-plane values (often ±10000+ Å)
+because PyMOL works in a much larger conceptual volume than Moorhen.
+Importing those verbatim into a scene's `view:` block will push
+Moorhen's depth-test out so far that fog culling / depth buffer
+precision break down and the structure may render as a blank canvas
+or with severe z-fighting.
+
+**Either omit `clipStart` / `clipEnd` entirely** (the resolver leaves
+Moorhen's defaults of 0 / 1000) **or clamp at author time** to
+Moorhen-sensible values. The same applies to `fogStart` / `fogEnd`.
+
+```yaml
+# Good: omit, let Moorhen pick defaults
+view:
+  origin: [2.5, 16.6, -8.6]
+  quat: [0.64, 0.67, -0.01, 0.37]
+  zoom: 2.5
+
+# Bad: PyMOL-derived values that don't translate
+view:
+  clipStart: -12586.35       # nope
+  clipEnd: 13099.16          # nope
+```
+
+`origin`, `quat`, `zoom`, and `background` translate cleanly between
+viewers and are safe to copy verbatim.
+
+### Highlights produce one drawer row per CID chunk
+
+The Coot CID grammar does not have a compact form for "these N
+disjoint residue numbers" — comma lists of residue numbers are
+rejected. The only way to express disjoint residues is a `||`-joined
+multi-CID, and the resolver renders each chunk as a separate
+representation, each of which becomes a row in Moorhen's Models drawer.
+
+There's nothing the author can do to collapse N highlights into one
+row today. The practical advice:
+
+- Group highlights into contiguous ranges where you can.
+  `//A/115-117` is one rep / one row; `//A/115||//A/116||//A/117`
+  is three.
+- Accept the row-count cost otherwise. Twelve catalytic residues
+  produce twelve rows.
+- If you want a *single* colour applied across a whole multi-highlight
+  set, all the chunks share the same colour anyway — the picture
+  reads as one logical thing even if the drawer has many rows.
+
+### `colour`
+
+Four forms:
+
+```yaml
+colour: "#4b8bbe"             # 1. Hex literal
+colour: by-domain             # 2. Compile from the domains: block
+colour: b-factor              # 3. Named Moorhen scheme
+colour:                       # 4. Raw escape hatch (lossless, ugly)
+  raw:
+    ruleType: <string>
+    args: [...]
+    isMultiColourRule: <bool>
+```
+
+Named schemes available out of the box:
+`by-domain`, `b-factor`, `b-factor-norm`, `af2-plddt`,
+`secondary-structure`, `jones-rainbow`, `mol-symm`.
+
+`by-domain` compiles to a single multi-residue colour rule built from
+the top-level `domains:` block. So one element with `colour: by-domain`
+on a ribbon gives you the whole domain-coloured protein in one rep.
+
+### `dictionaries`
+
+A list of dictionary file names (from `files:` with `kind: dictionary`).
+The resolver loads each globally first (so the coord parses), then
+re-associates with the specific molecule's molNo. This is the key
+mechanism for fragment-campaign work: two molecules with same-named
+ligands can carry different chemistry because each gets its own scoped
+dictionary.
+
+```yaml
+elements:
+  - file: x0034
+    dictionaries: [x0034_LIG, x0034_ADP]      # scoped to this molecule only
+    representations: [ ... ]
+```
+
+For dictionaries that should apply to *every* molecule (cofactors,
+common ions), use the top-level `globalDictionaries:` block instead.
+
+## `superpose`
+
+Alignments to apply after fetching but before rendering. Each entry
+mutates the *moving* structure's display transform in place; the
+reference is untouched.
+
+```yaml
+superpose:
+  # SSM — secondary-structure matching. Cheapest default; needs one
+  # chain id on each side. Good for homologues / different conformations
+  # of the same chain.
+  - { method: ssm, move: holo, onto: apo, movChain: A, refChain: A }
+
+  # LSQ on explicit residue ranges. Use when you know correspondences
+  # or want to control which region drives the fit (e.g. align on a
+  # binding-site loop only).
+  - method: lsq
+    move: nod-x
+    onto: closed
+    matches:
+      - { refChain: A, refRange: 104-260, movChain: A, movRange: 104-260 }
+      - { refChain: B, refRange: 50-150,  movChain: B, movRange: 60-160 }
+    matchType: main      # one of: all | main | ca   (default: main)
+
+  # LSQ convenience shorthand for the common "same chain + same range
+  # on both sides" case. Mutually exclusive with `matches`.
+  - { method: lsq, move: holo, onto: apo, chain: A, range: 104-260 }
+```
+
+The LSQ `matchType` controls which atoms are fitted:
+
+- `all` — every atom in the named residue ranges.
+- `main` — main-chain atoms only (default; usually what you want).
+- `ca` — Cα atoms only (fastest, most tolerant of side-chain differences).
+
+`gesamt` is not currently supported because the Moorhen build doesn't
+expose it; the schema may grow to include it in a later version.
+
+## `view`
+
+The portable subset of Moorhen's view state. Anything you omit is left
+alone at apply-time.
+
+```yaml
+view:
+  origin: [10.5, 20.0, -5.25]            # camera origin
+  quat:   [0, 0, 0, -1]                  # camera quaternion
+  zoom:   1.5
+  clipStart: 0
+  clipEnd:   1000
+  fogStart:  250
+  fogEnd:    1250
+  background: "#ffffff"                  # hex
+```
+
+## `resolver`
+
+Apply-time policy. Currently one option:
+
+```yaml
+resolver:
+  onMissingResidues: clamp-and-log   # default
+  # onMissingResidues: strict        # fail loudly instead of silently clamping
+```
+
+`clamp-and-log` is the right default. The resolver clamps domain
+ranges to the residues actually present in the loaded structure, splits
+across internal gaps, and writes a sidecar log noting what was modified.
+`strict` raises an error when any clamping or splitting would happen
+— useful when you're authoring against a structure you know exactly.
+
+## Authoring tips
+
+### Keep the model panel manageable
+
+Every representation entry — and every `||`-split chunk inside one —
+becomes a row in Moorhen's Models drawer. For a scene with many
+molecules each carrying many highlighted residues, the drawer can
+become unwieldy. To keep it tractable:
+
+- **Group highlights into ranges where you can.** `//A/115-117` is
+  one chunk / one row; `//A/115||//A/116||//A/117` is three.
+- **Use `by-domain` colouring instead of one rep per coloured block.**
+  A ribbon with `colour: by-domain` is one row that colours the whole
+  protein by the domain map; doing the same with N hex-coloured reps
+  produces N rows.
+- For repeated patterns across molecules (a fragment campaign), the
+  same selection on N molecules costs N rows total, not N×M; you only
+  pay for repeats *within* a single molecule.
+
+### Naming bundle assets
+
+Inside the `bundle:` value, use a sensible directory structure:
+
+```
+my-scene.scene.zip
+├── scene.yaml
+└── assets/
+    ├── coords/
+    │   ├── x0034.cif
+    │   ├── x0092.cif
+    │   └── ...
+    └── dict/
+        ├── x0034_LIG.cif
+        ├── x0092_LIG.cif
+        └── ...
+```
+
+The path inside `bundle:` matches the path inside the zip — pick
+something stable and human-readable. `assets/` is convention; the
+schema doesn't enforce it.
+
+### Multi-comp dictionaries
+
+A single `.cif` file can declare several `data_comp_*` blocks. Coot's
+`read_dictionary_string` parses all of them in one call, so the
+resolver doesn't need to split. One file ref = all blocks loaded.
+
+### Bare-int ranges
+
+Use bare integers for single residues. `range: 115` is more readable
+than `range: "115-115"`, and parses to the same internal form. Same
+applies inside LSQ matches:
+
+```yaml
+domains:
+  - { name: catalytic, chain: A, range: 245, color: "#e74c3c" }   # bare int
+  - { name: helix-A,   chain: A, range: 100-130, color: "#4b8bbe" }  # range
+```
+
+### Disjoint residues on one chain need `||`
+
+The Coot CID grammar does **not** accept comma-separated residue
+numbers — `//A/115,116,121` is a parse error. The only valid form for
+disjoint residues is `||`-joined single-residue or single-range CIDs:
+
+```yaml
+# Correct: || joins single-residue / single-range CIDs
+- style: CBs
+  selection: "//A/115||//A/116||//A/121-122||//A/146||//A/155||//A/192||//A/198||//A/201||//A/204-205||//A/208||//A/213"
+  colour: "#e74c3c"
+```
+
+Each `||` chunk becomes its own row in the Models drawer (the
+resolver splits and emits one rep per chunk). Group adjacent
+residues into ranges where you can to keep the count down.
+
+### Multi-structure scenes share the same domains and view
+
+When you're comparing 25 fragment-soak structures, write the domains
+block *once* and one element per molecule that references it:
+
+```yaml
+domains:
+  - { name: NBD, chain: A, range: 104-260, color: "#2ecc71" }
+  - { name: HD1, chain: A, range: 261-330, color: "#9b59b6" }
+  ...
+
+elements:
+  - file: x0034
+    representations:
+      - { style: CRs, selection: "//A", colour: by-domain }
+  - file: x0092
+    representations:
+      - { style: CRs, selection: "//A", colour: by-domain }
+  ...
+```
+
+For comparing conformations, add a `superpose:` block so the camera
+stays meaningful across all of them.
+
+## Worked example
+
+A minimal scene that fetches two PDB entries, aligns them on the NBD,
+and renders both with domain colouring:
+
+```yaml
+scene: apaf1-nod-aligned
+version: 1
+
+files:
+  - { name: closed, pdb: 1z6t }
+  - { name: nod-x,  pdb: 3sfz }
+
+superpose:
+  - { method: lsq, move: nod-x, onto: closed, chain: A, range: 104-260 }
+
+domains:
+  - { name: CARD, chain: A, range: 1-92,    color: "#4b8bbe" }
+  - { name: NBD,  chain: A, range: 104-260, color: "#2ecc71" }
+  - { name: HD1,  chain: A, range: 261-330, color: "#9b59b6" }
+  - { name: WHD,  chain: A, range: 331-415, color: "#f1c40f" }
+  - { name: HD2,  chain: A, range: 416-586, color: "#e67e22" }
+
+elements:
+  - file: closed
+    representations:
+      - { style: CRs, selection: "//A", colour: by-domain }
+  - file: nod-x
+    representations:
+      - { style: CRs, selection: "//A", colour: by-domain }
+
+resolver:
+  onMissingResidues: clamp-and-log
+```
+
+Drop that into the Scenes editor, click Apply, and you have two
+APAF-1 structures aligned on their NBDs with matching colour schemes
+— ready to compare conformations.

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -1,0 +1,373 @@
+/**
+ * Moorhen Scene types.
+ *
+ * A Scene is a portable, human-editable description of how to render one
+ * or more structures in Moorhen: which files to load, what domains to
+ * recognise, what representations and colour rules to apply, and where the
+ * camera should sit.
+ *
+ * Scenes are designed to be re-applied across different PDB files of the
+ * same protein. Residue ranges in domain definitions are resolved against
+ * the actual residues present in each loaded structure at apply-time, with
+ * the resolver policy controlled by the `resolver` block.
+ *
+ * Two related artefacts:
+ *   - `*.scene.yaml`  — this format; the only file a human writes/edits.
+ *   - `*.session.json` — Moorhen-native backupSession, regenerable from
+ *                       (scene, structure). Disposable cache.
+ *
+ * See `moorhen-scene.md` for the full grammar and worked examples.
+ */
+
+// --------------------------------------------------------------------------
+// Top-level Scene
+// --------------------------------------------------------------------------
+
+/** Current schema version. Bump on breaking changes; readers may refuse
+ *  to load scenes with a higher major version than they support. */
+export const SCENE_SCHEMA_VERSION = 1 as const;
+
+export interface MoorhenScene {
+  /** Human-readable identifier for the scene. Free text. */
+  scene: string;
+
+  /** Schema version. Must equal SCENE_SCHEMA_VERSION for v1 readers. */
+  version: number;
+
+  /** Provenance: where this scene was authored. Never consulted by the
+   *  resolver — only shown to humans and surfaced in bug reports. */
+  authoredIn?: SceneProvenance;
+
+  /** Files to load, named so that elements can reference them. */
+  files?: SceneFileRef[];
+
+  /** Superpositions to apply after fetching but before rendering. Each
+   *  entry aligns one file (`move`) onto another (`onto`). Applied in
+   *  declared order. */
+  superpose?: SceneSuperpose[];
+
+  /** Dictionary file names (from the `files:` block, with kind:
+   *  dictionary) loaded globally — visible to every coordinate molecule
+   *  in the scene. Use for cofactors, common buffer components, etc.
+   *  Loaded before any coordinate molecules so coords containing those
+   *  monomers parse correctly. */
+  globalDictionaries?: string[];
+
+  /** Reusable domain definitions, referenced by `colour: by-domain`
+   *  inside elements. Hoisted to the top level so a multi-structure
+   *  scene doesn't duplicate them per element. */
+  domains?: SceneDomain[];
+
+  /** Per-file rendering instructions: representations and colour rules. */
+  elements?: SceneElement[];
+
+  /** Camera, clip, fog, background. Portable subset of Moorhen's
+   *  viewDataSession; lighting/SSAO/shadow params intentionally omitted. */
+  view?: SceneView;
+
+  /** Apply-time policy. */
+  resolver?: SceneResolverOptions;
+}
+
+// --------------------------------------------------------------------------
+// Provenance
+// --------------------------------------------------------------------------
+
+export interface SceneProvenance {
+  projectId?: string;       // UUID of the authoring project
+  projectName?: string;     // human-readable name (advisory)
+  createdAt?: string;       // ISO-8601 timestamp
+  createdBy?: string;       // email or username
+  ccp4i2Version?: string;   // for debugging
+}
+
+// --------------------------------------------------------------------------
+// File references
+// --------------------------------------------------------------------------
+
+/**
+ * A named file reference. Exactly one of {pdb, url, fileId+project,
+ * job+param+project, path} should be set. The resolver first looks for an
+ * already-loaded molecule that matches; failing that (and when the ref
+ * carries enough info), the resolver fetches the coords and registers a
+ * new molecule before binding.
+ */
+export interface SceneFileRef {
+  /** Local name used by elements (e.g. "protein", "apo", "ref"). Unique
+   *  within the files block. */
+  name: string;
+
+  /** What kind of file this ref points at. Defaults to "coordinates".
+   *  "dictionary" refs are CIF monomer dicts (refmac/coot format) that
+   *  the resolver loads into Coot's dictionary store rather than as
+   *  separate molecules; they're then scoped to specific molecules via
+   *  the per-element `dictionaries:` list. */
+  kind?: "coordinates" | "dictionary";
+
+  /** PDB ID (4-letter or extended). Fetched via the PDBe proxy on apply
+   *  if not already loaded. The most portable, share-friendly form for
+   *  deposited structures. Only meaningful for `kind: coordinates`. */
+  pdb?: string;
+
+  /** Inline CIF text — only valid on `kind: dictionary` refs. Used by
+   *  the lifter for dicts loaded from job outputs (no stable URL). The
+   *  resolver hands the text straight to Coot's `read_dictionary_string`
+   *  without any network round-trip. Multi-block dicts work in one shot
+   *  because Coot parses every `data_comp_*` block in the input. */
+  cifText?: string;
+
+  /** Asset path inside a scene bundle (`.scene.zip`). Resolved against
+   *  the in-memory asset map the editor populates when a .zip is opened.
+   *  The portable shape for sharing scenes with their data attached —
+   *  works for both coord and dictionary refs, and round-trips across
+   *  machines without needing local filesystem access. */
+  bundle?: string;
+
+  /** Fully qualified URL — most portable across machines for non-PDB
+   *  structures (refined coords on a shared server, e.g.). */
+  url?: string;
+
+  /** Absolute path on the local filesystem. Not portable. */
+  path?: string;
+
+  // -- ccp4i2 project-internal references --------------------------------
+
+  /** UUID of the project containing the file. Required for `fileId` or
+   *  `job`+`param` references. */
+  projectId?: string;
+
+  /** Project name (advisory; for human inspection only). */
+  projectName?: string;
+
+  /** Stable file id within the project. */
+  fileId?: number;
+
+  /** Job number within the project. Pair with `param`. */
+  job?: number;
+
+  /** Job parameter name, e.g. "XYZOUT". Pair with `job`. */
+  param?: string;
+}
+
+// --------------------------------------------------------------------------
+// Domains
+// --------------------------------------------------------------------------
+
+export interface SceneDomain {
+  /** Free-text name used in `colour: by-domain` and in the resolver log. */
+  name: string;
+
+  /** Chain selector. Three forms:
+   *
+   *   - `"A"` (or any non-`*` string) — single chain.
+   *   - `"*"` — every chain present in the structure (useful for symmetric
+   *     assemblies like the apoptosome heptamer).
+   *   - `["A", "B", "C"]` — explicit list, applied to each chain in turn.
+   *
+   *  At apply-time the resolver fans the domain out across the resolved
+   *  chain list and clamps the range per-chain. */
+  chain: string | string[];
+
+  /** Inclusive residue range "start-end", e.g. "1-120". The resolver
+   *  clamps this to the residues actually present in each loaded
+   *  structure (see SceneResolverOptions.onMissingResidues). */
+  range: string;
+
+  /** Hex colour, e.g. "#4b8bbe". */
+  color: string;
+}
+
+// --------------------------------------------------------------------------
+// Superpose
+// --------------------------------------------------------------------------
+
+/**
+ * Align one loaded structure onto another. Run after fetch, before
+ * representations/camera, so the saved view's quaternion is meaningful
+ * against the aligned coords. Mutates the moving structure's display
+ * transform in place; does not write to disk.
+ *
+ * Two methods, mirroring Moorhen's own API:
+ *
+ *   - `ssm`: secondary-structure matching. Cheap default; needs one
+ *     chain id per side. Use for homologues or different conformations
+ *     of the same chain.
+ *
+ *   - `lsq`: least-squares on explicit residue ranges. Use when you
+ *     know the correspondences (e.g. matching specific binding-site
+ *     residues across distantly related structures).
+ */
+export type SceneSuperpose = SceneSuperposeSsm | SceneSuperposeLsq;
+
+export interface SceneSuperposeSsm {
+  method: "ssm";
+  /** File name (from the `files:` block) being transformed. */
+  move: string;
+  /** File name being aligned to (reference; unchanged). */
+  onto: string;
+  /** Chain id in the moving structure to use for the alignment. */
+  movChain: string;
+  /** Chain id in the reference structure to use for the alignment. */
+  refChain: string;
+}
+
+export interface SceneSuperposeLsq {
+  method: "lsq";
+  move: string;
+  onto: string;
+  /** Per-range correspondences. Each entry pairs a residue range in the
+   *  reference with one in the moving structure. Omit when using the
+   *  `chain`+`range` shorthand below. */
+  matches?: SceneLsqMatch[];
+  /** Shorthand chain id, applied to both reference and moving structures.
+   *  Use with `range:` when the simple "same chain, same residue numbers
+   *  on both sides" case applies — saves writing a single-entry `matches`
+   *  block. Mutually exclusive with `matches`. */
+  chain?: string;
+  /** Shorthand residue range "start-end", applied to both sides. Paired
+   *  with `chain:`. */
+  range?: string;
+  /** Which atoms to fit:
+   *   - `"all"`   — all atoms in the residue ranges
+   *   - `"main"`  — main-chain atoms only (default; usually what you want)
+   *   - `"ca"`    — Cα atoms only (fastest, most tolerant of differences) */
+  matchType?: "all" | "main" | "ca";
+}
+
+export interface SceneLsqMatch {
+  refChain: string;
+  /** Inclusive residue range "start-end" in the reference. */
+  refRange: string;
+  movChain: string;
+  /** Inclusive residue range "start-end" in the moving structure. */
+  movRange: string;
+}
+
+// --------------------------------------------------------------------------
+// Elements
+// --------------------------------------------------------------------------
+
+export interface SceneElement {
+  /** Name of a file from the top-level `files:` block. */
+  file: string;
+
+  /** Dictionary file names (with `kind: dictionary`) to associate with
+   *  this molecule specifically. Loaded globally first (so the coord
+   *  parses) then re-associated with this molecule's molNo. This is the
+   *  pattern that lets two molecules both call their ligand "LIG" with
+   *  different chemistry — each gets its own scoped dictionary. */
+  dictionaries?: string[];
+
+  /** Representations to draw on this file. */
+  representations?: SceneRepresentation[];
+}
+
+export interface SceneRepresentation {
+  /** Moorhen RepresentationStyle, e.g. "CRs" (ribbons), "CBs" (sticks),
+   *  "MolecularSurface", "ligands". See moorhen.RepresentationStyles
+   *  for the full set of 27 styles. */
+  style: string;
+
+  /** CID selection, e.g. "//A" (chain A), "//STAR/LIG" (all ligands
+   *  named LIG, where STAR is the wildcard). Default is the all-atoms
+   *  wildcard CID. */
+  selection?: string;
+
+  /** Colour specification — see SceneColour for the variants. */
+  colour?: SceneColour;
+}
+
+/**
+ * Colour specification. Three v0 shapes:
+ *
+ *   1. Hex literal:        colour: "#4b8bbe"
+ *   2. Named scheme:       colour: by-domain | b-factor | af2-plddt | ...
+ *   3. Raw escape hatch:   colour: { raw: { ruleType, args } }
+ *
+ * `by-domain` compiles to a single multi-rule built from the top-level
+ * `domains:` block. Named schemes map 1:1 to Moorhen's existing multi-rule
+ * ruleTypes. The raw form preserves anything we can't lift to a higher
+ * abstraction (lossless but ugly).
+ */
+export type SceneColour = string | SceneNamedColour | SceneRawColour;
+
+export type SceneNamedColour =
+  | "by-domain"
+  | "b-factor"
+  | "b-factor-norm"
+  | "af2-plddt"
+  | "secondary-structure"
+  | "jones-rainbow"
+  | "mol-symm";
+
+export interface SceneRawColour {
+  raw: {
+    ruleType: string;
+    args: (string | number)[];
+    isMultiColourRule?: boolean;
+    applyColourToNonCarbonAtoms?: boolean;
+  };
+}
+
+// --------------------------------------------------------------------------
+// View
+// --------------------------------------------------------------------------
+
+export interface SceneView {
+  origin?: [number, number, number];
+  quat?: [number, number, number, number];
+  zoom?: number;
+  clipStart?: number;
+  clipEnd?: number;
+  fogStart?: number;
+  fogEnd?: number;
+  background?: string;        // hex
+}
+
+// --------------------------------------------------------------------------
+// Resolver options
+// --------------------------------------------------------------------------
+
+export interface SceneResolverOptions {
+  /**
+   * Policy when a domain's residue range references residues that aren't
+   * present in the loaded structure.
+   *
+   *   "clamp-and-log"  — clamp endpoints inward to the nearest present
+   *                      residue, split across internal gaps, write a
+   *                      sidecar log entry. Render silently. (Default.)
+   *   "strict"         — fail to apply the scene; surface an error.
+   */
+  onMissingResidues?: "clamp-and-log" | "strict";
+}
+
+// --------------------------------------------------------------------------
+// Type guards
+// --------------------------------------------------------------------------
+
+const NAMED_COLOURS: ReadonlySet<string> = new Set([
+  "by-domain",
+  "b-factor",
+  "b-factor-norm",
+  "af2-plddt",
+  "secondary-structure",
+  "jones-rainbow",
+  "mol-symm",
+]);
+
+export function isSceneHexColour(c: SceneColour): c is string {
+  return typeof c === "string" && c.startsWith("#");
+}
+
+export function isSceneNamedColour(c: SceneColour): c is SceneNamedColour {
+  return typeof c === "string" && NAMED_COLOURS.has(c);
+}
+
+export function isSceneRawColour(c: SceneColour): c is SceneRawColour {
+  return (
+    typeof c === "object" &&
+    c !== null &&
+    "raw" in c &&
+    typeof (c as SceneRawColour).raw === "object"
+  );
+}

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -61,6 +61,17 @@ export interface MoorhenScene {
   /** Per-file rendering instructions: representations and colour rules. */
   elements?: SceneElement[];
 
+  /** Map instances to render, each referencing an MTZ file from the
+   *  `files:` block (kind: "mtz") with a column-label spec and optional
+   *  contour/colour/style. v1 supports MTZ refs only — pre-computed
+   *  CCP4 map files and PDB-fetched maps will land in a later version. */
+  maps?: SceneMap[];
+
+  /** Name of the map (from `maps:`) that should be Moorhen's active
+   *  map after apply. Moorhen refines against the active map, so this
+   *  is normally the best/calculated map (not a difference map). */
+  activeMap?: string;
+
   /** Camera, clip, fog, background. Portable subset of Moorhen's
    *  viewDataSession; lighting/SSAO/shadow params intentionally omitted. */
   view?: SceneView;
@@ -101,8 +112,10 @@ export interface SceneFileRef {
    *  "dictionary" refs are CIF monomer dicts (refmac/coot format) that
    *  the resolver loads into Coot's dictionary store rather than as
    *  separate molecules; they're then scoped to specific molecules via
-   *  the per-element `dictionaries:` list. */
-  kind?: "coordinates" | "dictionary";
+   *  the per-element `dictionaries:` list. "mtz" refs are reflection
+   *  data — referenced by entries in the `maps:` block which carry the
+   *  column-label spec and contour/colour settings. */
+  kind?: "coordinates" | "dictionary" | "mtz";
 
   /** PDB ID (4-letter or extended). Fetched via the PDBe proxy on apply
    *  if not already loaded. The most portable, share-friendly form for
@@ -307,6 +320,85 @@ export interface SceneRawColour {
     isMultiColourRule?: boolean;
     applyColourToNonCarbonAtoms?: boolean;
   };
+}
+
+// --------------------------------------------------------------------------
+// Maps
+// --------------------------------------------------------------------------
+
+/**
+ * Column-label spec for reading an MTZ. Mirrors moorhen.selectedMtzColumns
+ * but kept as a scene-local type so the YAML grammar isn't tied to the
+ * installed Moorhen version. F + PHI are the minimum for a coefficient
+ * map; Fobs/SigFobs/FreeR appear when the caller wants Moorhen to do its
+ * own coefficient calculation (calcStructFact).
+ */
+export interface SceneMapColumns {
+  /** Structure-factor label (e.g. "FWT", "F"). */
+  F?: string;
+  /** Phase label (e.g. "PHWT", "PHI"). */
+  PHI?: string;
+  /** Observed structure factor (when calcStructFact = true). */
+  Fobs?: string;
+  /** Sigma of observed F (when calcStructFact = true). */
+  SigFobs?: string;
+  /** Free-R flag column (when calcStructFact = true). */
+  FreeR?: string;
+  /** Weight column (FOM). */
+  useWeight?: boolean;
+  /** True iff Moorhen should compute coefficients on the fly
+   *  rather than reading FWT/PHWT directly. */
+  calcStructFact?: boolean;
+}
+
+/**
+ * One Moorhen map. References an MTZ file from the `files:` block and
+ * carries the column-label spec plus optional render state.
+ *
+ * Render-state fields are all optional — any omitted, Moorhen's
+ * defaults apply at load time. The lifter only emits a field when its
+ * captured value differs from those defaults, so the YAML stays small.
+ */
+export interface SceneMap {
+  /** Local name, unique within the maps block. Used by `activeMap:` at
+   *  the scene root and as a join key for the lifter/promoter. */
+  name: string;
+
+  /** Name of an entry in `files:` (must have `kind: "mtz"`). */
+  file: string;
+
+  /** Column-label spec for reading the referenced MTZ. */
+  columns: SceneMapColumns;
+
+  /** Difference-map flag. Maps with this set render both positive and
+   *  negative contour lobes using `positiveColour` / `negativeColour`. */
+  isDifference?: boolean;
+
+  /** Contour level (rmsd-relative for Moorhen). */
+  contourLevel?: number;
+
+  /** Map radius (Å) — sphere around the camera origin to contour. */
+  radius?: number;
+
+  /** Opacity (0–1). */
+  alpha?: number;
+
+  /** Render style. "lit-lines" is Moorhen's prettier default for
+   *  workstation-class GPUs. */
+  style?: "lines" | "solid" | "lit-lines";
+
+  /** Hex colour (#rrggbb or #rrggbbaa). For non-difference maps only;
+   *  difference maps use `positiveColour` + `negativeColour`. */
+  colour?: string;
+
+  /** Hex colour for the positive contour lobe of a difference map. */
+  positiveColour?: string;
+
+  /** Hex colour for the negative contour lobe of a difference map. */
+  negativeColour?: string;
+
+  /** Whether the map is visible. Defaults to true. */
+  visible?: boolean;
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Brings the **Moorhen scenes** feature into `django` as a focused, self-contained set of commits cherry-picked from the long-lived `moorhen-scenes` branch — deliberately *excluding* the PANDDA-export work and the ccp4i2-api release churn that also accumulated there. PANDDA export will follow in its own branch/PR.

## Commits (7, cherry-picked in chronological order, zero conflicts)

**Scenes feature (4)**
- `moorhen-scenes: portable YAML scene format for Moorhen viewer`
- `moorhen-scenes: wire scene callbacks into the Moorhen wrapper`
- `moorhen-scenes: hex-alpha colours, ATP-class dict skip, self-contained export`
- `moorhen-scenes: MTZ maps in capture / apply / self-contained export`

**Infra (3) — required for the Moorhen viewer/worker**
- `fetch-file-for-param: route EBI/PDBe fetches through local proxy`
- `middleware: drop trailing slashes from BEARER_AUTH_PATHS` (Next.js canonicalizer strips trailing slashes before middleware sees the URL, so the prefixes must be listed without one)
- `next.config: emit COOP/COEP for /reinspect/* (Moorhen Worker isolation)`

## Surface

21 files, +7607/−37. New, self-contained modules: `lib/moorhen-scene{,-lifter,-resolver}.ts`, `types/moorhen-scene.ts`, `components/moorhen/moorhen-scenes-panel.tsx`, `moorhen-ccp4i2-tabbed-panel.tsx`, a `/api/proxy/pdbe/[...path]` route, docs, and tests. Existing files touched only lightly: `moorhen-wrapper.tsx`, `moorhen-control-panel.tsx`, `ccp4i2-menu.ts`, `middleware.ts`, `next.config.ts`, `fetch-file-for-param.tsx`.

New deps: `jszip ^3.10.1`, `yaml ^2.9.0` (lockfile included).

## Verification

- Cherry-pick onto `django`: **zero conflicts**
- `npx tsc --noEmit -p renderer/tsconfig.json`: **clean**
- `npx vitest run moorhen-scene`: **122/122 tests pass** (scene, scene-lifter, scene-resolver)

## Not included (intentional)

PANDDA export (5 commits) and the ccp4i2-api 0.3.x release/CI commits — the latter are already equivalent in `django` via #163. PANDDA export lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)