### PR TITLE
PANDDA export: extract into service module + dataset/FreeR/timeout fixes (from moorhen-scenes)

### DIFF
--- a/client/renderer/components/campaigns/pandda-export-dialog.tsx
+++ b/client/renderer/components/campaigns/pandda-export-dialog.tsx
@@ -89,7 +89,8 @@ export function PanddaExportDialog({
     try {
       const response = await apiFetch(
         `projectgroups/${campaignId}/export_pandda/`,
-        { method: "POST" }
+        { method: "POST" },
+        { timeout: 10 * 60 * 1000 }
       );
 
       // Download the ZIP file

--- a/server/ccp4i2/api/ProjectGroupViewSet.py
+++ b/server/ccp4i2/api/ProjectGroupViewSet.py
@@ -7,11 +7,6 @@ coordinates and FreeR flags, and member projects each represent a dataset
 soaked with a different compound.
 """
 import logging
-import os
-import zipfile
-import tempfile
-from pathlib import Path
-import gemmi
 from django.http import FileResponse
 from django.conf import settings
 from rest_framework.viewsets import ModelViewSet
@@ -23,43 +18,9 @@ from rest_framework import status
 from . import serializers
 from ..db import models
 from ..lib.response import api_success, api_error
+from ..lib import pandda_export
 
 logger = logging.getLogger(f"ccp4i2:{__name__}")
-
-
-PANDDA_FREER_LABELS = ("FREE", "FreeR_flag", "R-free-flags")
-COMMON_FREER_LABELS = (
-    "FREER",
-    "FREE",
-    "FreeR_flag",
-    "FreeRflag",
-    "FreeR",
-    "R-free-flags",
-    "free",
-)
-
-
-def _prepare_mtz_for_pandda(src_path, staging_dir):
-    """Return a path to an MTZ whose FreeR column carries a PANDDA-accepted label.
-
-    PANDDA2 only recognises 'FREE', 'FreeR_flag', or 'R-free-flags'. If the
-    source MTZ already has one of those, the original path is returned (no
-    rewrite). Otherwise the first column matching a common FreeR convention
-    (e.g. CCP4's 'FREER') is renamed to 'FreeR_flag' and the rewritten file
-    is placed in staging_dir. If no FreeR-like column is found at all, the
-    source path is returned unchanged.
-    """
-    mtz = gemmi.read_mtz_file(str(src_path))
-    labels = [col.label for col in mtz.columns]
-    if any(label in PANDDA_FREER_LABELS for label in labels):
-        return src_path
-    for col in mtz.columns:
-        if col.label in COMMON_FREER_LABELS:
-            col.label = "FreeR_flag"
-            out_path = Path(staging_dir) / f"{src_path.stem}_pandda.mtz"
-            mtz.write_to_file(str(out_path))
-            return out_path
-    return src_path
 
 
 class ProjectGroupViewSet(ModelViewSet):
@@ -581,45 +542,18 @@ class ProjectGroupViewSet(ModelViewSet):
         """
         try:
             group = self.get_object()
-            member_memberships = group.memberships.filter(
-                type=models.ProjectGroupMembership.MembershipType.MEMBER
-            ).select_related("project")
-
             datasets = []
-            for membership in member_memberships:
-                project = membership.project
-
-                # Find the most recent finished i2Dimple job
-                dimple_job = (
-                    models.Job.objects.filter(
-                        project=project,
-                        task_name__in=["i2Dimple", "dimple"],
-                        status=models.Job.Status.FINISHED,
-                    )
-                    .order_by("-id")
-                    .first()
-                )
-
-                # Find the most recent finished LidiaAcedrgNew job
-                acedrg_job = (
-                    models.Job.objects.filter(
-                        project=project,
-                        task_name__in=["LidiaAcedrgNew", "acedrg"],
-                        status=models.Job.Status.FINISHED,
-                    )
-                    .order_by("-id")
-                    .first()
-                )
-
-                if dimple_job:
-                    datasets.append({
-                        "project_name": project.name,
-                        "project_id": project.id,
-                        "dimple_job_id": dimple_job.id if dimple_job else None,
-                        "acedrg_job_id": acedrg_job.id if acedrg_job else None,
-                        "has_dimple": dimple_job is not None,
-                        "has_acedrg": acedrg_job is not None,
-                    })
+            for project, dimple_job, acedrg_job in pandda_export.collect_pandda_datasets(group):
+                if not dimple_job:
+                    continue
+                datasets.append({
+                    "project_name": project.name,
+                    "project_id": project.id,
+                    "dimple_job_id": dimple_job.id,
+                    "acedrg_job_id": acedrg_job.id if acedrg_job else None,
+                    "has_dimple": True,
+                    "has_acedrg": acedrg_job is not None,
+                })
 
             return Response({
                 "datasets": datasets,
@@ -652,93 +586,19 @@ class ProjectGroupViewSet(ModelViewSet):
         """
         try:
             group = self.get_object()
-            member_memberships = group.memberships.filter(
-                type=models.ProjectGroupMembership.MembershipType.MEMBER
-            ).select_related("project")
+            result = pandda_export.build_pandda_zip(group)
 
-            # Create temporary directory for ZIP
-            temp_dir = tempfile.mkdtemp(prefix="pandda_export_")
-            zip_path = os.path.join(temp_dir, f"pandda_{group.name}.zip")
-
-            included_count = 0
-
-            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-                for membership in member_memberships:
-                    project = membership.project
-
-                    # Find the most recent finished i2Dimple job
-                    dimple_job = (
-                        models.Job.objects.filter(
-                            project=project,
-                            task_name__in=["i2Dimple", "dimple"],
-                            status=models.Job.Status.FINISHED,
-                        )
-                        .order_by("-id")
-                        .first()
-                    )
-
-                    if not dimple_job:
-                        continue
-
-                    # Dimple job directory
-                    dimple_dir = Path(dimple_job.directory)
-                    final_pdb = dimple_dir / "final.pdb"
-                    final_mtz = dimple_dir / "final.mtz"
-
-                    if not final_pdb.exists() or not final_mtz.exists():
-                        logger.warning(
-                            "Dimple outputs not found for project %s", project.name
-                        )
-                        continue
-
-                    # Add dimple outputs (relabel FreeR for PANDDA if needed)
-                    dataset_path = f"datasets/{project.name}"
-                    try:
-                        mtz_to_write = _prepare_mtz_for_pandda(final_mtz, temp_dir)
-                    except Exception as relabel_err:
-                        logger.warning(
-                            "FreeR relabel failed for %s, using original MTZ: %s",
-                            project.name, relabel_err,
-                        )
-                        mtz_to_write = final_mtz
-                    zf.write(str(final_pdb), f"{dataset_path}/final.pdb")
-                    zf.write(str(mtz_to_write), f"{dataset_path}/final.mtz")
-                    included_count += 1
-
-                    # Find LidiaAcedrgNew job for dictionary
-                    acedrg_job = (
-                        models.Job.objects.filter(
-                            project=project,
-                            task_name__in=["LidiaAcedrgNew", "acedrg"],
-                            status=models.Job.Status.FINISHED,
-                        )
-                        .order_by("-id")
-                        .first()
-                    )
-
-                    if acedrg_job:
-                        acedrg_dir = Path(acedrg_job.directory)
-                        # Check for both possible dictionary names
-                        dict_cif = acedrg_dir / "LIG.cif"
-                        if not dict_cif.exists():
-                            dict_cif = acedrg_dir / "DRG.cif"
-
-                        if dict_cif.exists():
-                            zf.write(str(dict_cif), f"{dataset_path}/dict.cif")
-
-            if included_count == 0:
+            if result.included_count == 0:
                 return api_error(
                     "No datasets with finished Dimple jobs found", status=400
                 )
 
-            # Return the ZIP file
-            response = FileResponse(
-                open(zip_path, "rb"),
+            return FileResponse(
+                open(result.zip_path, "rb"),
                 content_type="application/zip",
                 as_attachment=True,
-                filename=f"pandda_{group.name}.zip",
+                filename=result.zip_path.name,
             )
-            return response
 
         except Exception as e:
             logger.exception(

--- a/server/ccp4i2/api/ProjectGroupViewSet.py
+++ b/server/ccp4i2/api/ProjectGroupViewSet.py
@@ -11,6 +11,7 @@ import os
 import zipfile
 import tempfile
 from pathlib import Path
+import gemmi
 from django.http import FileResponse
 from django.conf import settings
 from rest_framework.viewsets import ModelViewSet
@@ -24,6 +25,41 @@ from ..db import models
 from ..lib.response import api_success, api_error
 
 logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+
+PANDDA_FREER_LABELS = ("FREE", "FreeR_flag", "R-free-flags")
+COMMON_FREER_LABELS = (
+    "FREER",
+    "FREE",
+    "FreeR_flag",
+    "FreeRflag",
+    "FreeR",
+    "R-free-flags",
+    "free",
+)
+
+
+def _prepare_mtz_for_pandda(src_path, staging_dir):
+    """Return a path to an MTZ whose FreeR column carries a PANDDA-accepted label.
+
+    PANDDA2 only recognises 'FREE', 'FreeR_flag', or 'R-free-flags'. If the
+    source MTZ already has one of those, the original path is returned (no
+    rewrite). Otherwise the first column matching a common FreeR convention
+    (e.g. CCP4's 'FREER') is renamed to 'FreeR_flag' and the rewritten file
+    is placed in staging_dir. If no FreeR-like column is found at all, the
+    source path is returned unchanged.
+    """
+    mtz = gemmi.read_mtz_file(str(src_path))
+    labels = [col.label for col in mtz.columns]
+    if any(label in PANDDA_FREER_LABELS for label in labels):
+        return src_path
+    for col in mtz.columns:
+        if col.label in COMMON_FREER_LABELS:
+            col.label = "FreeR_flag"
+            out_path = Path(staging_dir) / f"{src_path.stem}_pandda.mtz"
+            mtz.write_to_file(str(out_path))
+            return out_path
+    return src_path
 
 
 class ProjectGroupViewSet(ModelViewSet):
@@ -655,10 +691,18 @@ class ProjectGroupViewSet(ModelViewSet):
                         )
                         continue
 
-                    # Add dimple outputs
+                    # Add dimple outputs (relabel FreeR for PANDDA if needed)
                     dataset_path = f"datasets/{project.name}"
+                    try:
+                        mtz_to_write = _prepare_mtz_for_pandda(final_mtz, temp_dir)
+                    except Exception as relabel_err:
+                        logger.warning(
+                            "FreeR relabel failed for %s, using original MTZ: %s",
+                            project.name, relabel_err,
+                        )
+                        mtz_to_write = final_mtz
                     zf.write(str(final_pdb), f"{dataset_path}/final.pdb")
-                    zf.write(str(final_mtz), f"{dataset_path}/final.mtz")
+                    zf.write(str(mtz_to_write), f"{dataset_path}/final.mtz")
                     included_count += 1
 
                     # Find LidiaAcedrgNew job for dictionary

--- a/server/ccp4i2/api/ProjectGroupViewSet.py
+++ b/server/ccp4i2/api/ProjectGroupViewSet.py
@@ -645,7 +645,7 @@ class ProjectGroupViewSet(ModelViewSet):
                         continue
 
                     # Dimple job directory
-                    dimple_dir = Path(dimple_job.job_directory)
+                    dimple_dir = Path(dimple_job.directory)
                     final_pdb = dimple_dir / "final.pdb"
                     final_mtz = dimple_dir / "final.mtz"
 
@@ -673,7 +673,7 @@ class ProjectGroupViewSet(ModelViewSet):
                     )
 
                     if acedrg_job:
-                        acedrg_dir = Path(acedrg_job.job_directory)
+                        acedrg_dir = Path(acedrg_job.directory)
                         # Check for both possible dictionary names
                         dict_cif = acedrg_dir / "LIG.cif"
                         if not dict_cif.exists():

--- a/server/ccp4i2/lib/pandda_export.py
+++ b/server/ccp4i2/lib/pandda_export.py
@@ -1,0 +1,172 @@
+"""
+PANDDA export service.
+
+Builds a PANDDA-ready ZIP from a campaign's member projects, collecting
+``final.pdb`` + ``final.mtz`` from each member's most recent finished
+i2Dimple job and (optionally) the dictionary CIF from its most recent
+finished LidiaAcedrgNew job. MTZs whose FreeR column carries a label
+PANDDA2 doesn't recognise are rewritten with an accepted label.
+
+This module is deliberately Django-light: it accepts a
+``ProjectGroup`` instance and reads the related ``Job`` table, but
+contains no request/response handling. That makes it callable from a
+synchronous ViewSet today and from a background worker tomorrow
+without further refactoring.
+"""
+import logging
+import os
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import gemmi
+
+from ..db import models
+
+logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+
+PANDDA_FREER_LABELS = ("FREE", "FreeR_flag", "R-free-flags")
+COMMON_FREER_LABELS = (
+    "FREER",
+    "FREE",
+    "FreeR_flag",
+    "FreeRflag",
+    "FreeR",
+    "R-free-flags",
+    "free",
+)
+
+DIMPLE_TASK_NAMES = ("i2Dimple", "dimple")
+ACEDRG_TASK_NAMES = ("LidiaAcedrgNew", "acedrg")
+DICT_CIF_CANDIDATES = ("LIG.cif", "DRG.cif")
+
+
+@dataclass
+class PanddaExportResult:
+    zip_path: Path
+    temp_dir: Path
+    included_count: int
+
+
+def prepare_mtz_for_pandda(src_path: Path, staging_dir: Path) -> Path:
+    """Return a path to an MTZ whose FreeR column carries a PANDDA-accepted label.
+
+    PANDDA2 only recognises 'FREE', 'FreeR_flag', or 'R-free-flags'. If the
+    source MTZ already has one of those, the original path is returned (no
+    rewrite). Otherwise the first column matching a common FreeR convention
+    (e.g. CCP4's 'FREER') is renamed to 'FreeR_flag' and the rewritten file
+    is placed in ``staging_dir``. If no FreeR-like column is found at all,
+    the source path is returned unchanged.
+    """
+    mtz = gemmi.read_mtz_file(str(src_path))
+    labels = [col.label for col in mtz.columns]
+    if any(label in PANDDA_FREER_LABELS for label in labels):
+        return src_path
+    for col in mtz.columns:
+        if col.label in COMMON_FREER_LABELS:
+            col.label = "FreeR_flag"
+            out_path = Path(staging_dir) / f"{src_path.stem}_pandda.mtz"
+            mtz.write_to_file(str(out_path))
+            return out_path
+    return src_path
+
+
+def _latest_finished_job(project, task_names):
+    return (
+        models.Job.objects.filter(
+            project=project,
+            task_name__in=list(task_names),
+            status=models.Job.Status.FINISHED,
+        )
+        .order_by("-id")
+        .first()
+    )
+
+
+def _find_dictionary_cif(acedrg_job) -> Optional[Path]:
+    if not acedrg_job:
+        return None
+    acedrg_dir = Path(acedrg_job.directory)
+    for name in DICT_CIF_CANDIDATES:
+        candidate = acedrg_dir / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def collect_pandda_datasets(group):
+    """Yield ``(project, dimple_job, acedrg_job)`` for each member project.
+
+    Used by both the export endpoint (to build the ZIP) and the
+    ``pandda_data`` summary endpoint (to report counts to the UI), so
+    the two stay consistent.
+    """
+    member_memberships = group.memberships.filter(
+        type=models.ProjectGroupMembership.MembershipType.MEMBER
+    ).select_related("project")
+    for membership in member_memberships:
+        project = membership.project
+        dimple_job = _latest_finished_job(project, DIMPLE_TASK_NAMES)
+        acedrg_job = _latest_finished_job(project, ACEDRG_TASK_NAMES)
+        yield project, dimple_job, acedrg_job
+
+
+def build_pandda_zip(group, temp_dir: Optional[Path] = None) -> PanddaExportResult:
+    """Build a PANDDA-ready ZIP for ``group`` and return its location.
+
+    Creates ``temp_dir`` if not supplied (using ``tempfile.mkdtemp``).
+    The caller owns cleanup of ``temp_dir`` once the ZIP has been
+    served / persisted. Projects without dimple outputs are skipped
+    with a warning; the returned ``included_count`` may be zero, in
+    which case the caller is expected to surface that to the user.
+    """
+    if temp_dir is None:
+        temp_dir = Path(tempfile.mkdtemp(prefix="pandda_export_"))
+    else:
+        temp_dir = Path(temp_dir)
+        temp_dir.mkdir(parents=True, exist_ok=True)
+
+    zip_path = temp_dir / f"pandda_{group.name}.zip"
+    included_count = 0
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for project, dimple_job, acedrg_job in collect_pandda_datasets(group):
+            if not dimple_job:
+                continue
+
+            dimple_dir = Path(dimple_job.directory)
+            final_pdb = dimple_dir / "final.pdb"
+            final_mtz = dimple_dir / "final.mtz"
+
+            if not final_pdb.exists() or not final_mtz.exists():
+                logger.warning(
+                    "Dimple outputs not found for project %s", project.name
+                )
+                continue
+
+            dataset_path = f"datasets/{project.name}"
+            try:
+                mtz_to_write = prepare_mtz_for_pandda(final_mtz, temp_dir)
+            except Exception as relabel_err:
+                logger.warning(
+                    "FreeR relabel failed for %s, using original MTZ: %s",
+                    project.name, relabel_err,
+                )
+                mtz_to_write = final_mtz
+
+            zf.write(str(final_pdb), f"{dataset_path}/final.pdb")
+            zf.write(str(mtz_to_write), f"{dataset_path}/final.mtz")
+            included_count += 1
+
+            dict_cif = _find_dictionary_cif(acedrg_job)
+            if dict_cif is not None:
+                zf.write(str(dict_cif), f"{dataset_path}/dict.cif")
+
+    return PanddaExportResult(
+        zip_path=zip_path,
+        temp_dir=temp_dir,
+        included_count=included_count,
+    )

--- a/server/ccp4i2/lib/pandda_export.py
+++ b/server/ccp4i2/lib/pandda_export.py
@@ -131,6 +131,12 @@ def build_pandda_zip(group, temp_dir: Optional[Path] = None) -> PanddaExportResu
 
     zip_path = temp_dir / f"pandda_{group.name}.zip"
     included_count = 0
+    # Maps the synthetic ``xtal-NNNN`` directory name (which is what
+    # PANDDA2 reads as the crystal number) back to the original
+    # project name, written out as ``Projects.csv`` at the ZIP root.
+    # The same CSV is consumed by MoorhenPanddaInspect to surface the
+    # original provenance as a subtitle alongside each xtal id.
+    manifest_rows = []
 
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
         for project, dimple_job, acedrg_job in collect_pandda_datasets(group):
@@ -147,7 +153,8 @@ def build_pandda_zip(group, temp_dir: Optional[Path] = None) -> PanddaExportResu
                 )
                 continue
 
-            dataset_path = f"datasets/{project.name}"
+            xtal_name = f"xtal-{included_count:04d}"
+            dataset_path = f"datasets/{xtal_name}"
             try:
                 mtz_to_write = prepare_mtz_for_pandda(final_mtz, temp_dir)
             except Exception as relabel_err:
@@ -159,11 +166,17 @@ def build_pandda_zip(group, temp_dir: Optional[Path] = None) -> PanddaExportResu
 
             zf.write(str(final_pdb), f"{dataset_path}/final.pdb")
             zf.write(str(mtz_to_write), f"{dataset_path}/final.mtz")
+            manifest_rows.append((xtal_name, project.name))
             included_count += 1
 
             dict_cif = _find_dictionary_cif(acedrg_job)
             if dict_cif is not None:
                 zf.write(str(dict_cif), f"{dataset_path}/dict.cif")
+
+        if manifest_rows:
+            csv_lines = ["Dataset, Project"]
+            csv_lines.extend(f"{xtal}, {name}" for xtal, name in manifest_rows)
+            zf.writestr("Projects.csv", "\n".join(csv_lines) + "\n")
 
     return PanddaExportResult(
         zip_path=zip_path,

--- a/server/ccp4i2/tests/inspect_db_results.py
+++ b/server/ccp4i2/tests/inspect_db_results.py
@@ -31,9 +31,9 @@ async def inspect_database(project_uuid: uuid_module.UUID):
     project_data = await sync_to_async(lambda: {
         "UUID": str(project.uuid),
         "Name": project.name,
-        "Title": project.title or "N/A",
+        "Description": project.description or "N/A",
         "Directory": project.directory,
-        "Created": project.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+        "Created": project.creation_time.strftime("%Y-%m-%d %H:%M:%S"),
     })()
     for key, value in project_data.items():
         print(f"  {key:15} : {value}")
@@ -42,7 +42,7 @@ async def inspect_database(project_uuid: uuid_module.UUID):
     print("\n⚙️  JOBS")
     print("-" * 80)
     jobs = await sync_to_async(list)(
-        models.Job.objects.filter(project=project).order_by('created_at')
+        models.Job.objects.filter(project=project).order_by('creation_time')
     )
 
     print(f"{'Job #':<8} {'Task':<15} {'Title':<25} {'Status':<12} {'Started':<10} {'Finished':<10}")
@@ -53,7 +53,7 @@ async def inspect_database(project_uuid: uuid_module.UUID):
             j.task_name,
             (j.title or "N/A")[:24],
             j.get_status_display(),
-            j.created_at.strftime("%H:%M:%S"),
+            j.creation_time.strftime("%H:%M:%S"),
             j.finish_time.strftime("%H:%M:%S") if j.finish_time else "N/A",
         ))()
         print(f"{job_data[0]:<8} {job_data[1]:<15} {job_data[2]:<25} {job_data[3]:<12} {job_data[4]:<10} {job_data[5]:<10}")


### PR DESCRIPTION
## What

Brings the **PANDDA export** work into `django`, cherry-picked from the now-retired `moorhen-scenes` branch (the scenes feature landed separately in #164). Five commits, applied cleanly with zero conflicts.

## Commits (5, chronological order)

- `Fix: field/property names job_directory→directory, created_at→creation_time` — corrects attribute names against the current models
- `Fix: PANDDA export aborts at 30s — extend client timeout to 10 minutes`
- `PANDDA export: relabel FreeR column to a PANDDA-accepted name`
- `Extract PANDDA export into a service module` — moves the logic out of the viewset into `lib/pandda_export.py`
- `PANDDA export: synthesize xtal-NNNN dataset names + write Projects.csv`

## Surface

4 files, +208/−118:
- `server/ccp4i2/lib/pandda_export.py` — **new** service module (+185): `build_pandda_zip`, `collect_pandda_datasets`, `prepare_mtz_for_pandda`, `PanddaExportResult`
- `server/ccp4i2/api/ProjectGroupViewSet.py` — slimmed (−130) to delegate to the service
- `client/renderer/components/campaigns/pandda-export-dialog.tsx` — client timeout bump
- `server/ccp4i2/tests/inspect_db_results.py` — test helper tweak

## Verification

- Cherry-pick onto `django`: **zero conflicts**
- `npx tsc --noEmit -p renderer/tsconfig.json`: **clean**
- `ccp4-python -m py_compile` on all changed server files: **OK**
- Import under Django settings (`django.setup()`): both `lib.pandda_export` and `ProjectGroupViewSet` **import cleanly**

No dedicated unit tests exist for this path (service-extraction refactor + behavior tweaks); end-to-end validation requires a live PANDDA export against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)