### PR TITLE
Fix i2Dimple R-factor scrape and modelcraft test for newer CCP4 tools

### DIFF
--- a/server/ccp4i2/tests/i2run/test_modelcraft.py
+++ b/server/ccp4i2/tests/i2run/test_modelcraft.py
@@ -5,7 +5,7 @@ from .utils import demoData, hasLongLigandName, i2run
 
 
 def _check_output(job: Path, max_rfree):
-    read_structure(str(job / "XYZOUT.pdb"), format=CoorFormat.Mmcif)
+    read_structure(str(job / "XYZOUT.cif"), format=CoorFormat.Mmcif)
     for name in ["ABCD", "DIFFPHI", "FPHI"]:
         read_mtz_file(str(job / f"{name}OUT.mtz"))
     with (job / "modelcraft" / "modelcraft.json").open() as json_file:
@@ -22,7 +22,7 @@ def test_8xfm(cif8xfm, mtz8xfm, seq8xfm):
     args += ["--CYCLES", "2"]
     with i2run(args) as job:
         _check_output(job, max_rfree=0.3)
-        assert hasLongLigandName(job / "XYZOUT.pdb")
+        assert hasLongLigandName(job / "XYZOUT.cif")
 
 
 def test_gamma_ep():

--- a/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.py
+++ b/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.py
@@ -84,15 +84,22 @@ class i2Dimple(CPluginScript):
                     phaserElement = etree.SubElement(xmlStructure,"PHASER")
                     phaserElement.text = configParser.get("phaser","status")
                 refmacCycleArrays = {}
-                #Extract refmac5 jelly cycles output
-                if "refmac5 jelly"  in configParser.sections():
+                #Extract refmac jelly/restr cycle output. Newer dimple renamed
+                #its refinement sections from "refmac5 {jelly,restr}" to
+                #"refmacat {jelly,restr}" (refmacat = the Servalcat-based refmac),
+                #so accept both schemes. Read the sections in the order they
+                #appear in the log so jelly cycles precede restr cycles.
+                refinementSections = [
+                    section for section in configParser.sections()
+                    if len(section.split()) == 2
+                    and section.split()[0] in ("refmac5", "refmacat")
+                    and section.split()[1] in ("jelly", "restr")
+                ]
+                for section in refinementSections:
                     for property in ["iter_overall_r", "iter_free_r", "rmsBOND", "rmsANGL","rmsCHIRAL"]:
-                        perCycleArray = json.loads(configParser.get("refmac5 jelly",property))
-                        refmacCycleArrays[property] = perCycleArray
-                #Extract refmac5 jelly cycles output
-                if "refmac5 restr"  in configParser.sections():
-                    for property in ["iter_overall_r", "iter_free_r", "rmsBOND", "rmsANGL","rmsCHIRAL"]:
-                        perCycleArray = json.loads(configParser.get("refmac5 restr",property))
+                        if not configParser.has_option(section, property):
+                            continue
+                        perCycleArray = json.loads(configParser.get(section,property))
                         if property in refmacCycleArrays: refmacCycleArrays[property] += perCycleArray
                         else: refmacCycleArrays[property] = perCycleArray
                 #Identify if pointless has spotted a better reindexing


### PR DESCRIPTION
## Summary

Two ccp4i2 compatibility fixes surfaced by running the full **i2run** suite against a near-release CCP4 (`ccp4-20260520`) with the Python stack pinned to the baseline (so the only variable is CCP4 itself). Both are caused by **tool output changes**, not ccp4i2 logic.

### 1. i2Dimple R-factor scrape (`wrappers/i2Dimple/script/i2Dimple.py`)
Newer dimple renamed its INI log sections from `[refmac5 jelly]`/`[refmac5 restr]` to `[refmacat jelly]`/`[refmacat restr]` (refmacat = the Servalcat-based refmac). i2Dimple's hardcoded section checks missed them, so no `<r_factor>`/`<r_free>` was written, and `SubstituteLigand`'s result extraction got an empty list (`IndexError`). Now matches both naming schemes in log order, with a `has_option` guard. Backward-compatible.
- Fixes `test_substitute_ligand_no_ligand`, `test_substitute_ligand_with_smiles`.

### 2. modelcraft test extension (`tests/i2run/test_modelcraft.py`)
modelcraft 6.x emits **mmCIF**, so the coordinate output is correctly named `XYZOUT.cif` — and *must* be mmCIF, since the 8xfm model has long ligand names PDB format can't represent (the test itself uses `format=Mmcif` + `hasLongLigandName`). The test read `XYZOUT.pdb`; corrected to `.cif`.
- Fixes `test_8xfm`, `test_gamma_ep`.

## Testing
Both pairs verified green against `ccp4-20260520` (pinned Django 4.2.30 / pytest 8.4.2 baseline stack).

## Context / not in this PR
Running against `ccp4-20260520` also surfaced **CCP4 build-side** issues (not ccp4i2): absent SHELX binaries, a truncated modelcraft package, and ~12 packages with empty metadata. Those are for the CCP4 build team, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)