### PR TITLE
Declare ccp4i2-api as a server dependency

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">=3.9"
 dependencies = [
     "autopep8",
     "biopython>=1.80",     # used by adding_stats_to_mmcif (sequence alignment)
+    "ccp4i2-api>=0.3.4",   # auth middleware + DRF auth classes (config/settings.py)
     "django-cors-headers",
     "django-filter",
     "djangorestframework",


### PR DESCRIPTION
## Summary

`server/ccp4i2/config/settings.py` imports `ccp4i2_api` at runtime — auth middleware (`ccp4i2_api.middleware.*`) and the DRF `DEFAULT_AUTHENTICATION_CLASSES` entry `ccp4i2_api.drf.AzureADAuthentication` — but `ccp4i2-api` was not in `[project.dependencies]`. So a fresh `pip install -e server/` omitted it and the app crashed at startup:

```
ModuleNotFoundError: No module named 'ccp4i2_api'
```

This adds `ccp4i2-api>=0.3.4` to the server dependencies (published on PyPI; source also lives in `packages/ccp4i2-api/`), so every editable install and deployment build pulls it in a consistent way.

## Notes
- `ccp4i2-api` requires `PyJWT[crypto]`, which upgrades the bundled `cryptography` (2.8, from 2019) — expected and required for Azure AD JWT validation. Verified `paramiko` and other consumers still import, and `django check` passes.
- Constraint floor `>=0.3.4` matches the current PyPI release and the monorepo source version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)