### PR TITLE
Self-heal corrupted Electron zoom level; default to actual size

### DIFF
--- a/client/main/ccp4i2-create-window.ts
+++ b/client/main/ccp4i2-create-window.ts
@@ -24,7 +24,17 @@ export const createWindow = async (
     return { action: "deny" }; // Prevent default behavior
   });
   newWindow.webContents.on("did-finish-load", () => {
-    newWindow.webContents.setZoomLevel(store.get("zoomLevel"));
+    // Restore the persisted zoom level, but guard against corrupted/out-of-range
+    // values. A stray accumulated value (e.g. -10.5) renders the whole UI
+    // unusably tiny; and because this runs on *every* load — including dev
+    // hot-reloads — such a value also defeats menu/keyboard zoom, which gets
+    // reset on the next reload. Reset anything outside a sane range back to 0.
+    let zoom = store.get("zoomLevel");
+    if (typeof zoom !== "number" || !Number.isFinite(zoom) || zoom < -3 || zoom > 3) {
+      zoom = 0;
+      store.set("zoomLevel", zoom);
+    }
+    newWindow.webContents.setZoomLevel(zoom);
   });
   // Relay find-in-page results back to renderer
   newWindow.webContents.on("found-in-page", (_event, result) => {

--- a/client/main/ccp4i2-master.ts
+++ b/client/main/ccp4i2-master.ts
@@ -111,7 +111,7 @@ export const store = new Store<StoreSchema>({
     CCP4Dir: getDefaultCCP4Dir(),
     projectRoot: getProjectRoot(), // Computed, not user-configurable
     devMode: false,
-    zoomLevel: -2,
+    zoomLevel: 0,
     CCP4I2_PROJECTS_DIR: getProjectsDir(),
     theme: "dark",
   },


### PR DESCRIPTION
## Summary

The Electron window restored `store.get("zoomLevel")` on every `did-finish-load` with no bounds check, and the store default was `-2`. A persisted value could drift far out of range (observed `-10.5` in the dev `…/Electron/config.json` store), rendering the whole UI **unusably tiny** — and because it re-applied on every load (including dev hot-reloads), it also defeated menu/keyboard zoom, which got reset on the next reload.

- **`ccp4i2-create-window.ts`** — reset any out-of-range / non-finite persisted zoom (outside `[-3, 3]`) back to `0` on load (self-heals a corrupted store).
- **`ccp4i2-master.ts`** — default `zoomLevel` `-2 → 0` (actual size for fresh installs).

## Notes
- Verified fixing a live case (dev store at `-10.5` → tiny UI → normal after restart).
- Related, not fixed here: `app.setName` is never called, so unpackaged dev uses the generic `…/Electron/` store while the packaged app uses `…/ccp4i2-django/`. Unifying them (call `app.setName("ccp4i2-django")` before the module-level `new Store()`) is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)