### PR TITLE
Fix mac/win CI: stop rebuilding native deps the app doesn't use

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,8 +24,8 @@
     "electron-postinstall": "electron-builder install-app-deps",
     "build": "npm run build:electron",
     "start": "npm run start:electron",
-    "build:electron": "npm run electron-postinstall && cross-env BUILD_TARGET=electron npm run copy-assets && next build renderer && vite build --config vite.electron.config.ts && vite build --config vite.preload.config.ts",
-    "start:electron": "npm run electron-postinstall && cross-env BUILD_TARGET=electron npm run copy-assets && vite build --config vite.electron.config.ts && vite build --config vite.preload.config.ts && electron dist/main.js",
+    "build:electron": "cross-env BUILD_TARGET=electron npm run copy-assets && next build renderer && vite build --config vite.electron.config.ts && vite build --config vite.preload.config.ts",
+    "start:electron": "cross-env BUILD_TARGET=electron npm run copy-assets && vite build --config vite.electron.config.ts && vite build --config vite.preload.config.ts && electron dist/main.js",
     "build:web": "cross-env BUILD_TARGET=web npm run copy-assets && cd renderer && next build",
     "start:web": "cross-env BUILD_TARGET=web npm run copy-assets && cd renderer && next dev",
     "export:web": "cross-env BUILD_TARGET=web npm run build:web && cd renderer && next export",
@@ -119,6 +119,7 @@
     "appId": "com.ccp4.ccp4i2-django",
     "productName": "ccp4i2-django",
     "electronVersion": "33.4.11",
+    "npmRebuild": false,
     "icon": "assets/ccp4i2.png",
     "files": [
       "dist/**",


### PR DESCRIPTION
## Problem
The Electron multiplatform build has been failing on **macOS** and **Windows** (linux passes) in the `electron-builder install-app-deps` step, run via `electron-postinstall` inside `build:electron`:
- **Windows**: `Error: Could not find any Visual Studio installation to use` (node-gyp can't compile)
- **macOS**: node-gyp network flake fetching node headers

Both occur while rebuilding the native module **`@parcel/watcher`** for the Electron ABI.

## Why it's safe to stop
`@parcel/watcher` is a transitive, optional dependency of **`sass`** (a build-time tool) and is **never shipped** in the packaged app — `build.files` only ships the JS/Next bundles + `detect-port`. Every production dependency is JS/React/WASM (`@rdkit/rdkit`, `moorhen` are WASM), and the Electron `main/` process requires no native module. The packaged app contains **no native node addon**, so rebuilding native modules for Electron is wasted work that only breaks where the C++ toolchain is absent.

## Change
- Drop `electron-postinstall` (`install-app-deps`) from `build:electron` and `start:electron` (script kept for manual use if a native dep is ever added).
- Set electron-builder `"npmRebuild": false` so the final packaging step also skips the native rebuild.

No runtime behaviour change — the packaged app contains the same files. **The proof is this PR's own CI**: build-win, build-mac and build-linux should all go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)