### PR TITLE
Shared preferences (~/.ccp4i2/preferences.json): settings + PREFERENCES() accessor

### DIFF
--- a/docs/preferences-proposal.md
+++ b/docs/preferences-proposal.md
@@ -1,163 +1,138 @@
-# Preferences Handling: Proposal for Harmonization
+# Preferences Handling: Design
 
-**Status:** Proposal
-**Date:** 2025-03-11
+**Status:** Accepted — supersedes the 2025-03-11 proposal (in git history).
+**Date:** 2026-06-13
 **Authors:** Martin Noble, Claude
 
-## Problem
+This document replaces the earlier *Proposal for Harmonization*. That proposal
+debated database-backed (A) vs file (B) vs hybrid (C) storage and leaned toward A.
+We now have three concrete deployment perspectives in hand — **cloud/container**,
+**desktop Electron app**, and the **`i2`/`i2run` CLI** — and together they collapse
+that debate. The good ideas from the proposal are carried forward below.
 
-Legacy CCP4i2 managed 60+ preferences via a hierarchical XML system:
-site defaults (`<install>/local_setup/`) merged with user overrides (`~/.CCP4I2/configs/`).
-Many of these preferences are *functional* — wrapper code queries them at runtime
-for paths to external programs (Coot, SHELX, BUSTER, DIALS), PDB-REDO credentials,
-diagnostic flags, and more.
+## What the fuller overview settles
 
-The current Electron/Django branch has only 6 preferences (CCP4Dir, projects dir,
-zoom, theme, devMode, projectRoot), all stored in Electron's own config.json.
-The Django backend provides a `_PreferencesStub` that returns `None` for every
-attribute — meaning wrapper code that asks for `PREFERENCES().SHELXDIR` silently
-gets nothing.
+1. **Bootstrap settings cannot be database-backed.** Where the database is, where
+   projects live, and where CCP4 is are needed *before* you can open the database —
+   chicken-and-egg. So they must come from a **file** (or env). This rules out pure
+   Option A for the settings that matter most.
+2. **Cloud doesn't need the file.** Containers set everything via environment
+   variables (including secrets from Key Vault), so as long as **env wins**, the file
+   is inert in cloud. The proposal's main objection to a file ("needs a volume mount
+   in cloud") dissolves. Verified against Materia: it sets `DATABASE_URL` /
+   `CCP4I2_PROJECTS_DIR` in `entrypoint.sh` and ships no `preferences.json`.
+3. **i2run and the GUI must agree, and both boot the same `settings.py`.** A file read
+   during settings load makes the CLI and the control plane coherent for free.
 
-This gap blocks two things:
-1. **Migration** — users cannot bring their settings from legacy to new.
-2. **Functionality** — features that depend on configured paths or tokens are broken.
+**Decision: file-based JSON (the proposal's Option B2), with environment-variable
+override and an optional site-defaults layer.** This is B2 with its two cons —
+"no cloud story" and "no API/CLI" — neutralised by env-precedence and by adding
+accessors over the same file.
 
-## Preferences That Matter
+## The store
 
-Not all 60+ legacy preferences need to survive. Many were Qt GUI concerns
-(toolbar button visibility, font sizes, frame styles) that the new React UI
-handles differently. The preferences that *do* matter fall into two groups:
+| Layer | Location | Holds | Audience |
+|-------|----------|-------|----------|
+| **User preferences** | `~/.ccp4i2/preferences.json` (home overridable via `CCP4I2_HOME`) | bootstrap + functional preferences | GUI + CLI + control plane + worker |
+| **Site defaults** (optional) | `CCP4I2_SITE_PREFERENCES` env, else `$CCP4I2_ROOT/local_setup/site_preferences.json` | institutional defaults | admins |
+| **UI chrome** | Electron `electron-store` (`userData`) | window geometry, zoom, theme | GUI only |
 
-**Functional (consumed by Python wrappers/pipelines):**
-- `SHELXDIR`, `DIALSDIR`, `BUSTERDIR` — external program directories
-- `COOT_EXECUTABLE`, `CCP4MG_EXECUTABLE` — external program paths
-- `EXEPATHLIST` — additional binary search paths
-- `PDB_REDO_TOKEN_ID`, `PDB_REDO_TOKEN_SECRET` — service credentials
-- `RETAIN_DIAGNOSTIC_FILES` — runtime behavior flag
+`~/.ccp4i2` is the modern, lowercase home that already holds the SQLite database and
+the project store — one directory for all per-user state. JSON so the Electron/JS
+side reads and writes it as easily as Python. It is the descendant of classic (Qt)
+CCP4i2's `~/.CCP4I2` XML preferences.
 
-**UI (consumed by the frontend):**
-- `theme`, `zoomLevel`, `devMode` — already handled by electron-store
-- Any new UI preferences the React app needs
+**Why the file (not the DB) for the canonical store:** the bootstrap subset is
+file-resident by necessity (point 1 above); keeping the functional preferences in the
+*same* file avoids two sources of truth, and is human-readable, portable, and
+diff-able. The DB/API is a *projection* for the GUI (see Consumers), not the source.
 
-## Options
+## Resolution precedence (every setting)
 
-### Option A: Database-backed preferences (Django model + CLI + API)
-
-Store functional preferences in the Django database. Provide access via:
-- **REST API** (`GET/PATCH /api/preferences/`) for the frontend
-- **CLI** (`i2 preferences list|get|set|reset|migrate`) for terminal use
-- **Python accessor** (replace `_PreferencesStub` with a real object)
-
-Resolution order: environment variable > user DB value > site defaults file > None.
-
-Electron-only UI preferences (zoom, theme) stay in electron-store where they belong.
-
-**Pros:**
-- Single source of truth accessible from Python, CLI, API, and GUI
-- Works in Docker/cloud deployment (no filesystem assumptions)
-- `i2 preferences set SHELXDIR /opt/shelx` is simple and scriptable
-- Site admins can seed defaults via fixture or `local_setup/site_preferences.json`
-- Natural extension of the existing `i2` CLI and Django REST patterns
-
-**Cons:**
-- Preference values live in SQLite/PostgreSQL, not in a directly editable text file
-- Users cannot simply open a file in a text editor to inspect or change preferences
-- Adds a database migration
-
-### Option B: File-based preferences (XML or JSON on disk)
-
-Keep preferences in a structured file on disk, similar to legacy. Either:
-- **B1: Retain the legacy XML format** (`guipreferences.params.xml`)
-- **B2: Use JSON** (simpler parsing, aligns with Electron conventions)
-
-The file would live at `~/.CCP4I2/configs/preferences.{xml,json}`.
-Site defaults would remain in `<install>/local_setup/`.
-
-Replace `_PreferencesStub` with a file-reading object that loads and merges
-site + user files on startup.
-
-**Pros:**
-- Human-readable and directly editable with any text editor
-- Familiar to legacy users — same location, similar format (if XML)
-- No database dependency
-- Simple to inspect, back up, copy between machines
-
-**Cons:**
-- No API access without additional plumbing (would need a read/write endpoint
-  that proxies the file, with locking/conflict concerns)
-- CLI management still desirable — would need a script that parses and rewrites the file
-- Docker/cloud deployment needs a volume mount or alternative mechanism for the config file
-- Two sources of truth if Electron preferences remain separate
-
-### Option C: Hybrid — file as source of truth, cached in DB
-
-Preferences stored on disk (XML or JSON), but loaded into the database on startup
-and exposed via API. Edits through the API or CLI write back to the file.
-
-**Pros:**
-- Human-readable file *and* API/CLI access
-- File remains the canonical, portable artifact
-
-**Cons:**
-- Complexity of keeping file and DB in sync
-- Race conditions if file is edited externally while app is running
-- More code to maintain for marginal benefit
-
-## CLI Management (applies to all options)
-
-Regardless of storage backend, CLI access to preferences is valuable.
-The `i2` command already handles `projects`, `jobs`, `files`, etc. Adding
-`preferences` as a resource is natural:
-
-```bash
-i2 preferences list                          # show all with current values
-i2 preferences list --category paths         # filter by category
-i2 preferences get SHELXDIR                  # show one preference
-i2 preferences set SHELXDIR /opt/shelx       # set a value
-i2 preferences reset SHELXDIR                # revert to default
-i2 preferences migrate                       # import from legacy XML
+```
+environment variable  >  user preferences.json  >  site defaults  >  built-in default
 ```
 
-For Option A this calls Django management commands. For Option B/C this
-reads/writes the config file directly.
+- **Cloud:** env vars are set for everything → files never consulted → strict no-op.
+- **Desktop:** the user file is the persistence layer; site defaults seed institutions.
 
-## Migration Path (applies to all options)
+## Three preference classes
 
-A one-time import from legacy files:
+1. **Bootstrap / environment** — `ccp4Dir`, `projectsDir`, `database`, `ccp4i2Root`.
+   Consumed by `config/settings.py`. File-resident by necessity. **Implemented.**
+2. **Functional** — consumed by wrappers/pipelines via a `PREFERENCES()` accessor:
+   `SHELXDIR`, `DIALSDIR`, `BUSTERDIR`, `COOT_EXECUTABLE`, `CCP4MG_EXECUTABLE`,
+   `EXEPATHLIST`, `PDB_REDO_TOKEN_ID`, `PDB_REDO_TOKEN_SECRET`,
+   `RETAIN_DIAGNOSTIC_FILES`, … In cloud these are supplied as **env vars / secrets**;
+   on desktop they live in the file.
+3. **UI chrome** — `theme`, `zoomLevel`, `devMode` — stay in `electron-store`; the CLI
+   has no interest in them.
 
-1. Detect `~/.CCP4I2/configs/guipreferences.params.xml`
-2. Parse the XML (reuse existing `CContainer.loadDataFromXml`)
-3. Map legacy keys to new keys (simple dictionary)
-4. Write to the chosen store (DB or file)
+## Schema (`preferences.json`)
 
-This could run automatically on first launch or explicitly via
-`i2 preferences migrate`.
+```json
+{
+  "version": 1,
+  "ccp4Dir":     "/path/to/ccp4",
+  "projectsDir": "/path/to/projects",
+  "database":    "sqlite:////abs/db.sqlite3",   // or postgres://…  (env DATABASE_URL)
+  "ccp4i2Root":  "/path/to/.../ccp4i2",
+  "userPreferences": {                          // functional class (class 2)
+    "SHELXDIR": "/opt/shelx",
+    "PDB_REDO_TOKEN_ID": "…",
+    "RETAIN_DIAGNOSTIC_FILES": false
+  }
+}
+```
 
-## Site-Level Defaults (applies to all options)
+Top-level keys are the bootstrap class (mapped to env vars in `settings.py`);
+`userPreferences` is the functional bag the `PREFERENCES()` accessor exposes.
 
-Institutional deployments need a way for admins to set defaults.
-A file in `<install>/local_setup/` (JSON or XML) serves as the base layer,
-overridden by user-level settings. This preserves the existing admin workflow.
+## Consumers — one store, several readers
 
-## Recommendation
+| # | Consumer | Mechanism | Status |
+|---|----------|-----------|--------|
+| 1 | `config/settings.py` (bootstrap) | `preferences.resolve(key, env, default)` | **Done** |
+| 2 | `PREFERENCES()` accessor (wrappers) | real object over the same file+precedence, replacing the `None`-returning `CPreferencesStub` | Planned |
+| 3 | `i2 preferences get/set/list/reset/migrate` | reads/writes the file | Planned |
+| 4 | `GET/PATCH /api/preferences/` (GUI settings panel) | projects the file over REST | Planned |
+| 5 | Electron main (CCP4-dir / projects pickers) | writes bootstrap keys to the file | Planned (desktop step 3) |
 
-**Option A** (database-backed) is the cleanest fit for the architecture we're
-building — it aligns with how projects, jobs, and files are already managed,
-works across desktop and cloud deployments, and the CLI provides the
-"human interface" that compensates for preferences not being in a plain text file.
+Single store; the API and CLI are interfaces onto it, not separate truths.
 
-However, the readability concern is legitimate: being able to `cat` a config file
-and see what's set, or copy it to another machine, is a real workflow. If this
-is a strong requirement, **Option B2** (JSON file) is the pragmatic choice —
-it's human-readable, simple to parse, and avoids the XML baggage.
+## CLI (carried from the proposal)
 
-**Option C** adds complexity without proportionate benefit and is not recommended.
+```bash
+i2 preferences list                      # all keys + effective values (+ source layer)
+i2 preferences get SHELXDIR
+i2 preferences set SHELXDIR /opt/shelx   # writes user preferences.json
+i2 preferences reset SHELXDIR            # drop user value (fall back to site/default)
+i2 preferences migrate                   # import from legacy ~/.CCP4I2 XML
+```
 
-## Questions for Discussion
+Because storage is the file, these are thin read/modify/write operations (atomic
+write already provided by `config/preferences.save_preferences`).
 
-1. How important is direct text-file editability of preferences in practice?
-   (vs. using `i2 preferences set` or the GUI)
-2. Do we need to support the legacy XML format specifically, or is JSON acceptable?
-3. Should migration from legacy be automatic on first launch, or explicit?
-4. Are there other legacy preferences (beyond the functional ones listed) that
-   need to survive?
+## Migration from legacy (carried from the proposal)
+
+One-time import, on first launch or via `i2 preferences migrate`:
+detect `~/.CCP4I2/configs/guipreferences.params.xml` → parse → map legacy keys to the
+schema above → write `~/.ccp4i2/preferences.json`. Note the case change
+(`.CCP4I2` → `.ccp4i2`); on case-insensitive filesystems they coincide.
+
+## Implementation status
+
+- **Done:** `ccp4i2/config/preferences.py` (load/save/atomic/`resolve`, `CCP4I2_HOME`
+  override) + `config/settings.py` resolving bootstrap settings as
+  `env > preferences.json > default`; unit + end-to-end tests passing on slim CPython
+  and ccp4-python; cloud path verified unaffected.
+- **Next:** site-defaults layer in `resolve()`; the `PREFERENCES()` accessor over the
+  functional class (closes the wrapper gap); Electron write-side; `i2 preferences`
+  CLI; `/api/preferences/`; legacy migration.
+
+## Cloud invariance (new, and load-bearing)
+
+The env-first precedence guarantees containers are unaffected: Materia/cloud sets
+config (and secrets) via env, ships no `preferences.json`, and the file layer returns
+empty. The file is exclusively the desktop persistence layer; functional secrets like
+`PDB_REDO_TOKEN_*` come from env/Key Vault in cloud and from the user file on desktop.

--- a/server/ccp4i2/config/preferences.py
+++ b/server/ccp4i2/config/preferences.py
@@ -1,0 +1,123 @@
+"""
+Shared CCP4i2 user preferences — the single source of truth for desktop config
+that must agree across the GUI, the ``i2``/``i2run`` CLI, and the Django control
+plane.
+
+Location
+--------
+``~/.ccp4i2/preferences.json`` (the existing CCP4i2 user home; override the home
+with the ``CCP4I2_HOME`` environment variable). This sits next to the default
+SQLite database and project store, so one home directory holds all per-user state.
+It is the modern, lowercase, JSON echo of classic (Qt) CCP4i2's ``~/.CCP4i2``
+XML preferences — JSON so the Electron/JS side can read and write it as easily as
+Python.
+
+Resolution precedence (for every setting)
+-----------------------------------------
+``environment variable  >  preferences.json  >  built-in default``
+
+This keeps cloud deployments (which drive everything from env vars) completely
+unaffected — the file is purely the *desktop* persistence layer — while giving the
+GUI and CLI one place to agree.
+
+Schema (``preferences.json``)
+-----------------------------
+All keys are optional; an absent key falls through to the env var then the default.
+::
+
+    {
+      "version":     1,                                   # schema version
+      "ccp4Dir":     "/path/to/ccp4",                     # CCP4 install (for ccp4-python + binaries)
+      "projectsDir": "/path/to/projects",                 # project store      (env CCP4I2_PROJECTS_DIR)
+      "database":    "sqlite:////abs/path/db.sqlite3",    # DB URL, sqlite or postgres (env DATABASE_URL)
+      "ccp4i2Root":  "/path/to/ccp4i2/server/ccp4i2",     # package root       (env CCP4I2_ROOT)
+      "userPreferences": { }                              # open bag for future app/scientific prefs
+    }
+
+Bootstrap note: ``ccp4Dir``/``projectsDir``/``database`` must live in a *file*, not
+the database — you need them to find the database in the first place.
+
+This module is pure stdlib (it is imported while Django settings are still being
+assembled) — it must not import Django or any ccp4i2 package.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+PREFERENCES_VERSION = 1
+
+# Keys that hold filesystem paths (kept here so callers/tests can reason about them).
+PATH_KEYS = ("ccp4Dir", "projectsDir", "ccp4i2Root")
+
+
+def ccp4i2_home() -> Path:
+    """The CCP4i2 user home (``CCP4I2_HOME`` env var, else ``~/.ccp4i2``)."""
+    override = os.environ.get("CCP4I2_HOME")
+    base = Path(override) if override else (Path.home() / ".ccp4i2")
+    return base.expanduser().resolve()
+
+
+def preferences_path() -> Path:
+    """Full path to ``preferences.json`` inside the CCP4i2 user home."""
+    return ccp4i2_home() / "preferences.json"
+
+
+def load_preferences() -> dict:
+    """Load ``preferences.json``; return ``{}`` if absent or unreadable.
+
+    Never raises — a missing or corrupt file must not break settings load or the
+    CLI; callers fall through to env vars / defaults.
+    """
+    path = preferences_path()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (FileNotFoundError, NotADirectoryError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_preferences(prefs: dict) -> Path:
+    """Atomically write ``preferences.json`` (temp file + ``os.replace``).
+
+    Stamps the current schema version. Last writer wins — adequate for a small,
+    rarely-contended config file shared between the GUI and the CLI.
+    """
+    home = ccp4i2_home()
+    home.mkdir(parents=True, exist_ok=True)
+    payload = {"version": PREFERENCES_VERSION, **prefs}
+
+    fd, tmp = tempfile.mkstemp(dir=str(home), prefix=".preferences-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp, preferences_path())
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+    return preferences_path()
+
+
+def resolve(key: str, env: str = None, default=None, prefs: dict = None):
+    """Resolve one setting as ``env var > preferences.json > default``.
+
+    Args:
+        key:     key in ``preferences.json``.
+        env:     environment variable that overrides it (optional).
+        default: value if neither env nor file provides one.
+        prefs:   pre-loaded preferences dict (avoids re-reading the file when
+                 resolving several settings in a row, e.g. from settings.py).
+    """
+    if env:
+        env_val = os.environ.get(env)
+        if env_val not in (None, ""):
+            return env_val
+    if prefs is None:
+        prefs = load_preferences()
+    file_val = prefs.get(key)
+    if file_val not in (None, ""):
+        return file_val
+    return default

--- a/server/ccp4i2/config/preferences.py
+++ b/server/ccp4i2/config/preferences.py
@@ -121,3 +121,20 @@ def resolve(key: str, env: str = None, default=None, prefs: dict = None):
     if file_val not in (None, ""):
         return file_val
     return default
+
+
+def user_preference(name: str, default=None):
+    """Resolve a *functional* preference (from the ``userPreferences`` bag).
+
+    These are the preferences consumed by wrappers/pipelines via the
+    ``PREFERENCES()`` accessor — e.g. ``SHELXDIR``, ``BUSTERDIR``,
+    ``COOT_EXECUTABLE``, ``PDB_REDO_TOKEN_ID``, ``RETAIN_DIAGNOSTIC_FILES``.
+
+    Precedence is the standard ``env var > preferences.json > default``; the
+    environment variable name is the preference name itself, so in cloud these
+    arrive as plain env vars / Key Vault secrets and on desktop from the file's
+    ``userPreferences`` object.
+    """
+    bag = load_preferences().get("userPreferences", {})
+    bag = bag if isinstance(bag, dict) else {}
+    return resolve(name, env=name, default=default, prefs=bag)

--- a/server/ccp4i2/config/settings.py
+++ b/server/ccp4i2/config/settings.py
@@ -161,6 +161,11 @@ if DATABASE_URL:
         # Handle SQLite DATABASE_URL (format: sqlite:///path/to/db.sqlite)
         # The path is everything after sqlite:// (url.path contains the full path)
         db_path = url.path
+        # Windows drive paths arrive as "/C:/..." (urlparse keeps a leading slash
+        # before the drive letter); strip it so SQLite gets "C:/...". POSIX paths
+        # ("/data/...") have no drive letter and are left unchanged.
+        if len(db_path) >= 3 and db_path[0] == "/" and db_path[1].isalpha() and db_path[2] == ":":
+            db_path = db_path[1:]
         DATABASES = {
             "default": {
                 "ENGINE": "django.db.backends.sqlite3",

--- a/server/ccp4i2/config/settings.py
+++ b/server/ccp4i2/config/settings.py
@@ -137,12 +137,20 @@ TEMPLATES = [
 STATIC_URL = "/djangostatic/"
 MEDIA_URL = "/files/"
 
-USER_DIR = Path.home().resolve() / ".ccp4i2"
-USER_DIR.mkdir(exist_ok=True)
+from ccp4i2.config import preferences as _preferences
+
+# Shared user preferences (~/.ccp4i2/preferences.json). Precedence for every
+# setting resolved below is: environment variable > preferences.json > default.
+# Cloud (env-driven) is therefore unaffected; the file is the desktop layer that
+# the GUI and the i2/i2run CLI both read, so they stay coherent.
+_PREFS = _preferences.load_preferences()
+
+USER_DIR = _preferences.ccp4i2_home()
+USER_DIR.mkdir(parents=True, exist_ok=True)
 MEDIA_ROOT = USER_DIR / "files"
 
-# Database configuration with DATABASE_URL support
-DATABASE_URL = os.environ.get("DATABASE_URL")
+# Database configuration (env DATABASE_URL > preferences "database" > SQLite default)
+DATABASE_URL = _preferences.resolve("database", env="DATABASE_URL", prefs=_PREFS)
 
 if DATABASE_URL:
     # Parse the DATABASE_URL
@@ -224,11 +232,14 @@ else:
 TIME_ZONE = "UTC"
 USE_TZ = True
 CCP4I2_PROJECTS_DIR = Path(
-    os.environ.get(
-        "CCP4I2_PROJECTS_DIR", Path.home().resolve() / ".ccp4i2" / "CCP4X_PROJECTS"
+    _preferences.resolve(
+        "projectsDir",
+        env="CCP4I2_PROJECTS_DIR",
+        default=str(USER_DIR / "CCP4X_PROJECTS"),
+        prefs=_PREFS,
     )
 )
-CCP4I2_PROJECTS_DIR.mkdir(exist_ok=True)
+CCP4I2_PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
 
 REST_FRAMEWORK = {
     "DEFAULT_PARSER_CLASSES": (
@@ -260,11 +271,8 @@ STATICFILES_STORAGE = (
 # Defaults to BASE_DIR (the ccp4i2/ package directory) which is correct for all
 # deployment modes: pip-installed, Electron, Docker, Azure.
 # Environment variable override is available for tests or special configurations.
-CCP4I2_ROOT_ENV = os.environ.get("CCP4I2_ROOT")
-if CCP4I2_ROOT_ENV:
-    CCP4I2_ROOT = Path(CCP4I2_ROOT_ENV)
-else:
-    CCP4I2_ROOT = BASE_DIR
+_ccp4i2_root = _preferences.resolve("ccp4i2Root", env="CCP4I2_ROOT", prefs=_PREFS)
+CCP4I2_ROOT = Path(_ccp4i2_root) if _ccp4i2_root else BASE_DIR
 
 # Note: Static files (icons, report assets) are now served by Next.js from public/
 # Django staticfiles is only used for Electron desktop app where Next.js handles statics

--- a/server/ccp4i2/core/CCP4Modules.py
+++ b/server/ccp4i2/core/CCP4Modules.py
@@ -16,33 +16,39 @@ from .CCP4ProcessManager import PROCESSMANAGER
 __all__ = ['PROJECTSMANAGER', 'PROCESSMANAGER', 'PREFERENCES']
 
 
-class _PreferencesStub:
-    """Stub for legacy PREFERENCES object.
+class _Preferences:
+    """Accessor for functional user preferences.
 
-    Legacy code checks for attributes like SHELXDIR on the preferences object.
-    This stub allows attribute access without raising errors.
+    Legacy/wrapper code reads attributes like ``SHELXDIR``, ``BUSTERDIR``,
+    ``COOT_EXECUTABLE``, ``PDB_REDO_TOKEN_ID`` and ``RETAIN_DIAGNOSTIC_FILES`` off
+    the preferences object. Each attribute is resolved from the shared store with
+    precedence ``env var > ~/.ccp4i2/preferences.json (userPreferences) > None``
+    (see ccp4i2.config.preferences). Unknown preferences return None, so attribute
+    access never raises — preserving the previous stub's safety.
     """
-    def __init__(self):
-        pass
 
     def __getattr__(self, name):
-        # Return None for any requested attribute (preferences not set)
-        return None
+        # __getattr__ only fires for attributes not found normally, so this never
+        # shadows real methods. Resolve via the shared preferences store.
+        from ccp4i2.config import preferences
+        return preferences.user_preference(name, default=None)
 
 
 def PREFERENCES():
     """
-    Get the user preferences object (stub for legacy compatibility).
+    Get the user preferences accessor.
 
-    This replaces the legacy CCP4Modules.PREFERENCES() function from classic ccp4i2.
-    Returns a stub object that returns None for any attribute access.
+    Replaces the legacy CCP4Modules.PREFERENCES() from classic ccp4i2. Attribute
+    access (e.g. ``PREFERENCES().SHELXDIR``) resolves from the shared store —
+    ``env var > ~/.ccp4i2/preferences.json (userPreferences) > None`` — so the
+    GUI, the i2/i2run CLI, and job execution all see the same values. Unknown
+    preferences return None.
 
     Returns:
-        _PreferencesStub: A stub preferences object
+        _Preferences: the user preferences accessor
 
     Example:
         >>> from ccp4i2.core import CCP4Modules
-        >>> prefs = CCP4Modules.PREFERENCES()
-        >>> shelx_dir = prefs.SHELXDIR  # Returns None
+        >>> CCP4Modules.PREFERENCES().SHELXDIR   # value from env/file, else None
     """
-    return _PreferencesStub()
+    return _Preferences()

--- a/server/ccp4i2/tests/unit/config/test_preferences.py
+++ b/server/ccp4i2/tests/unit/config/test_preferences.py
@@ -1,0 +1,157 @@
+"""
+Tests for the shared CCP4i2 preferences mechanism
+(``ccp4i2/config/preferences.py``) and its integration into Django settings.
+
+Covers:
+  * the pure-stdlib preferences module (load/save/resolve, home override,
+    robustness to missing/corrupt files);
+  * end-to-end settings precedence (env var > preferences.json > default),
+    verified by importing settings.py in a fresh subprocess so each case picks
+    up its own environment and preferences file.
+
+All of this runs on a slim, CCP4-free interpreter.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ccp4i2.config import preferences
+
+SERVER_ROOT = str(Path(__file__).resolve().parents[4])  # .../server
+
+
+# ---------------------------------------------------------------------------
+# preferences module (pure stdlib)
+# ---------------------------------------------------------------------------
+
+def test_home_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    assert preferences.ccp4i2_home() == tmp_path.resolve()
+    assert preferences.preferences_path() == tmp_path.resolve() / "preferences.json"
+
+
+def test_load_missing_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    assert preferences.load_preferences() == {}
+
+
+def test_corrupt_file_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    preferences.preferences_path().write_text("{ this is not json", encoding="utf-8")
+    assert preferences.load_preferences() == {}
+
+
+def test_save_load_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    preferences.save_preferences({"ccp4Dir": "/opt/ccp4", "projectsDir": "/data/proj"})
+    loaded = preferences.load_preferences()
+    assert loaded["ccp4Dir"] == "/opt/ccp4"
+    assert loaded["projectsDir"] == "/data/proj"
+    # version is stamped, and the file is valid JSON on disk
+    assert loaded["version"] == preferences.PREFERENCES_VERSION
+    json.loads(preferences.preferences_path().read_text(encoding="utf-8"))
+
+
+def test_save_is_atomic_no_temp_left(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    preferences.save_preferences({"ccp4Dir": "/opt/ccp4"})
+    leftovers = list(tmp_path.glob(".preferences-*.tmp"))
+    assert leftovers == []
+
+
+def test_resolve_precedence(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    prefs = {"projectsDir": "/from/file"}
+
+    # default only
+    monkeypatch.delenv("CCP4I2_PROJECTS_DIR", raising=False)
+    assert preferences.resolve("missing", default="/the/default", prefs=prefs) == "/the/default"
+    # file beats default
+    assert preferences.resolve("projectsDir", default="/the/default", prefs=prefs) == "/from/file"
+    # env beats file
+    monkeypatch.setenv("CCP4I2_PROJECTS_DIR", "/from/env")
+    assert (
+        preferences.resolve("projectsDir", env="CCP4I2_PROJECTS_DIR",
+                             default="/the/default", prefs=prefs)
+        == "/from/env"
+    )
+
+
+def test_resolve_ignores_empty_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    monkeypatch.setenv("CCP4I2_PROJECTS_DIR", "")  # empty string must not win
+    prefs = {"projectsDir": "/from/file"}
+    assert (
+        preferences.resolve("projectsDir", env="CCP4I2_PROJECTS_DIR", prefs=prefs)
+        == "/from/file"
+    )
+
+
+# ---------------------------------------------------------------------------
+# settings.py precedence (end-to-end, fresh subprocess per case)
+# ---------------------------------------------------------------------------
+
+_PROBE = (
+    "import json; from ccp4i2.config import settings as s; "
+    "print(json.dumps({"
+    "'projects': str(s.CCP4I2_PROJECTS_DIR), "
+    "'root': str(s.CCP4I2_ROOT), "
+    "'engine': s.DATABASES['default']['ENGINE'], "
+    "'name': str(s.DATABASES['default']['NAME']), "
+    "'host': str(s.DATABASES['default'].get('HOST', '')), "
+    "}))"
+)
+
+
+def _probe_settings(home: Path, prefs: dict, extra_env: dict = None) -> dict:
+    if prefs is not None:
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "preferences.json").write_text(json.dumps(prefs), encoding="utf-8")
+    env = dict(os.environ)
+    env["CCP4I2_HOME"] = str(home)
+    env["PYTHONPATH"] = SERVER_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    # isolate from any ambient overrides
+    for var in ("DATABASE_URL", "CCP4I2_DB_FILE", "CCP4I2_PROJECTS_DIR", "CCP4I2_ROOT"):
+        env.pop(var, None)
+    env.update(extra_env or {})
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE], env=env, capture_output=True, text=True, timeout=120
+    )
+    assert result.returncode == 0, f"probe failed:\n{result.stdout}\n{result.stderr}"
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_settings_reads_preferences(tmp_path):
+    home = tmp_path / "home"
+    out = _probe_settings(home, {
+        "projectsDir": str(tmp_path / "myprojects"),
+        "ccp4i2Root": str(tmp_path / "myroot"),
+        "database": "postgres://u:p@dbhost:5432/mydb",
+    })
+    assert out["projects"] == str(tmp_path / "myprojects")
+    assert out["root"] == str(tmp_path / "myroot")
+    assert out["engine"] == "django.db.backends.postgresql"
+    assert out["name"] == "mydb"
+    assert out["host"] == "dbhost"
+
+
+def test_settings_default_when_no_preferences(tmp_path):
+    home = tmp_path / "home"
+    out = _probe_settings(home, {})  # empty preferences.json
+    assert out["projects"] == str(home.resolve() / "CCP4X_PROJECTS")
+    assert out["engine"] == "django.db.backends.sqlite3"
+
+
+def test_settings_env_overrides_preferences(tmp_path):
+    home = tmp_path / "home"
+    out = _probe_settings(
+        home,
+        {"projectsDir": str(tmp_path / "fromfile")},
+        extra_env={"CCP4I2_PROJECTS_DIR": str(tmp_path / "fromenv")},
+    )
+    assert out["projects"] == str(tmp_path / "fromenv")

--- a/server/ccp4i2/tests/unit/config/test_preferences.py
+++ b/server/ccp4i2/tests/unit/config/test_preferences.py
@@ -155,3 +155,48 @@ def test_settings_env_overrides_preferences(tmp_path):
         extra_env={"CCP4I2_PROJECTS_DIR": str(tmp_path / "fromenv")},
     )
     assert out["projects"] == str(tmp_path / "fromenv")
+
+
+# ---------------------------------------------------------------------------
+# functional preferences (the userPreferences bag) and the PREFERENCES() accessor
+# ---------------------------------------------------------------------------
+
+def test_user_preference_unset_returns_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    monkeypatch.delenv("SHELXDIR", raising=False)
+    assert preferences.user_preference("SHELXDIR") is None
+    assert preferences.user_preference("SHELXDIR", default="/fallback") == "/fallback"
+
+
+def test_user_preference_from_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    monkeypatch.delenv("SHELXDIR", raising=False)
+    preferences.save_preferences({"userPreferences": {"SHELXDIR": "/opt/shelx"}})
+    assert preferences.user_preference("SHELXDIR") == "/opt/shelx"
+
+
+def test_user_preference_env_overrides_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    preferences.save_preferences({"userPreferences": {"SHELXDIR": "/from/file"}})
+    monkeypatch.setenv("SHELXDIR", "/from/env")
+    assert preferences.user_preference("SHELXDIR") == "/from/env"
+
+
+def test_user_preference_preserves_json_bool(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    monkeypatch.delenv("RETAIN_DIAGNOSTIC_FILES", raising=False)
+    preferences.save_preferences({"userPreferences": {"RETAIN_DIAGNOSTIC_FILES": False}})
+    # a real JSON bool comes back as a bool (not the truthy string "False")
+    assert preferences.user_preference("RETAIN_DIAGNOSTIC_FILES") is False
+
+
+def test_PREFERENCES_accessor(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    monkeypatch.delenv("SHELXDIR", raising=False)
+    monkeypatch.delenv("BUSTERDIR", raising=False)
+    preferences.save_preferences({"userPreferences": {"SHELXDIR": "/opt/shelx"}})
+
+    from ccp4i2.core import CCP4Modules
+    prefs = CCP4Modules.PREFERENCES()
+    assert prefs.SHELXDIR == "/opt/shelx"      # from file
+    assert prefs.BUSTERDIR is None             # unset -> None, never raises

--- a/server/ccp4i2/tests/unit/config/test_preferences.py
+++ b/server/ccp4i2/tests/unit/config/test_preferences.py
@@ -200,3 +200,23 @@ def test_PREFERENCES_accessor(monkeypatch, tmp_path):
     prefs = CCP4Modules.PREFERENCES()
     assert prefs.SHELXDIR == "/opt/shelx"      # from file
     assert prefs.BUSTERDIR is None             # unset -> None, never raises
+
+
+# ---------------------------------------------------------------------------
+# sqlite "database" URL parsing (cross-platform — the form the Electron app writes)
+# ---------------------------------------------------------------------------
+
+def test_settings_sqlite_url_posix(tmp_path):
+    home = tmp_path / "home"
+    out = _probe_settings(home, {"database": "sqlite:///data/proj/db.sqlite3"})
+    assert out["engine"] == "django.db.backends.sqlite3"
+    assert out["name"] == "/data/proj/db.sqlite3"
+
+
+def test_settings_sqlite_url_windows_drive(tmp_path):
+    # urlparse keeps the leading slash before the drive letter ("/C:/...");
+    # settings.py strips it so SQLite gets "C:/...".
+    home = tmp_path / "home"
+    out = _probe_settings(home, {"database": "sqlite:///C:/proj/db.sqlite3"})
+    assert out["engine"] == "django.db.backends.sqlite3"
+    assert out["name"] == "C:/proj/db.sqlite3"


### PR DESCRIPTION
Introduces a single source of truth for desktop config that the GUI, the `i2`/`i2run` CLI, and the Django control plane all share — closing the gap where the Electron app kept settings in `electron-store` while the server/CLI read env vars and `~/.ccp4i2` defaults that never saw them. Two consumers of the new store land here.

## The store
- **`config/preferences.py`** — pure-stdlib loader for `~/.ccp4i2/preferences.json` (home overridable via `CCP4I2_HOME`), atomic save, and `resolve()` / `user_preference()` implementing **env var > preferences.json > default**. Never raises on a missing/corrupt file.

## Consumer 1 — bootstrap settings
- **`config/settings.py`** — resolve home / database / projects dir / `CCP4I2_ROOT` through that precedence (was env-only). Because `i2run` and the control plane both boot this settings module, they share preferences automatically.

## Consumer 2 — functional preferences (closes a real gap)
- **`core/CCP4Modules.py`** — `PREFERENCES().SHELXDIR` (and `BUSTERDIR`, `COOT_EXECUTABLE`, `PDB_REDO_TOKEN_ID/SECRET`, `RETAIN_DIAGNOSTIC_FILES`, …) previously returned **`None` for everything** (a stub), so configured program paths and credentials were silently unavailable to wrappers. It now resolves each attribute from the shared store (`userPreferences` bag) with the same precedence; unknown prefs still return `None`, so access never raises.

## Cloud is a strict no-op
Containers set config (and secrets) via env (which win) and ship no `preferences.json`, so the file layer stays inert; defaults are byte-identical to before. Verified against Materia and dynamically (`DATABASE_URL` env still → `postgresql`).

## Tests
`tests/unit/config/` — 15 cases: module load/save/atomic/resolve/home-override/corrupt-file, end-to-end settings precedence via subprocess, functional-preference resolution (file/env/default, JSON bool preserved), and the `PREFERENCES()` accessor. **Pass on slim CPython and ccp4-python**; the CCP4-free import guard stays green.

## Design
`docs/preferences-proposal.md` is superseded by the accepted design (file-based JSON + env override + a site-defaults layer), reconciling the cloud/container, desktop-Electron, and `i2run` perspectives.

Follows #170–172. Remaining (per the design doc): site-defaults layer in `resolve()`, the Electron write-side, `i2 preferences` CLI, `/api/preferences/`, and legacy migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)