### PR TITLE
Fix checkMonomeCoverage: skip standard residues, defer without a monomer library

### DIFF
--- a/server/ccp4i2/core/CCP4PluginScript.py
+++ b/server/ccp4i2/core/CCP4PluginScript.py
@@ -2480,6 +2480,18 @@ class CPluginScript(CData):
             if ccp4:
                 monlib_dir = os.path.join(ccp4, 'lib', 'data', 'monomers')
 
+        # Without the CCP4 monomer library this check cannot run meaningfully.
+        # That is the case on a CCP4-free interpreter — e.g. the slim Django
+        # API server, where runTimeValidity() is polled at submission but no
+        # CCP4 suite is installed. Reading the library is impossible, so every
+        # residue (standard amino acids included) would be reported as having
+        # "no dictionary at all". Defer to the worker's process(), which runs
+        # runTimeValidity() again with the library present, rather than block
+        # submission with a spurious error. (Mirrors the other "don't block;
+        # refinement itself will catch it" guards below.)
+        if not monlib_dir or not os.path.isdir(monlib_dir):
+            return self.SUCCEEDED
+
         # Read the structure
         try:
             st = gemmi.read_structure(str(xyzin_path))
@@ -2528,8 +2540,20 @@ class CPluginScript(CData):
 
         missing_from_model = topo.find_missing_atoms()
 
-        # Identify residues with no dictionary at all
-        no_dict = sorted(c for c in all_codes if c not in ml.monomers)
+        # Identify residues with no dictionary at all. Standard amino acids /
+        # nucleotides and water are handled by the refinement program's
+        # built-in machinery and never need an explicit monomer dictionary, so
+        # they must not be flagged here regardless of whether the library
+        # happens to define them. This is the docstring's "non-polymer
+        # residues" intent: only ligands / modified residues need coverage.
+        def _builtin_residue(code):
+            info = gemmi.find_tabulated_residue(code)
+            return info is not None and (info.is_standard() or info.is_water())
+
+        no_dict = sorted(
+            c for c in all_codes
+            if c not in ml.monomers and not _builtin_residue(c)
+        )
 
         if not no_dict and not unrestrained:
             return self.SUCCEEDED

--- a/server/ccp4i2/tests/i2run/test_monomer_coverage.py
+++ b/server/ccp4i2/tests/i2run/test_monomer_coverage.py
@@ -247,6 +247,34 @@ class TestCheckMonomeCoverage:
         finally:
             os.unlink(path)
 
+    def test_no_monomer_library_defers(self, plugin, monkeypatch):
+        """Without a CCP4 monomer library the check must defer, not flag.
+
+        On a CCP4-free interpreter — e.g. the slim Django API server, where
+        runTimeValidity() is polled at submission but no CCP4 suite is
+        installed — neither CLIBD_MON nor CCP4 is set, so the monomer library
+        cannot be read. Previously every residue, standard amino acids
+        included, was reported as "no dictionary at all" (a plain protein
+        refinement was blocked at the Confirm dialog). The check must instead
+        return SUCCEEDED and defer to the worker's process(), which re-runs
+        runTimeValidity() with the library present.
+        """
+        monkeypatch.delenv("CLIBD_MON", raising=False)
+        monkeypatch.delenv("CCP4", raising=False)
+        # Includes an unknown ligand that WOULD fail if a library were present,
+        # proving the deferral is unconditional when no library is available.
+        path = _make_structure([
+            ("A", "ALA", 1, gemmi.EntityType.Polymer,
+             [("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O"), ("CB", "C")]),
+            ("A", "QQQ", 2, gemmi.EntityType.NonPolymer,
+             [("C1", "C"), ("N1", "N"), ("O1", "O")]),
+        ])
+        try:
+            assert plugin.checkMonomeCoverage(path) == CPluginScript.SUCCEEDED
+            assert plugin.errorReport.count() == 0
+        finally:
+            os.unlink(path)
+
     def test_empty_structure_passes(self, plugin):
         """Empty structure should pass (nothing to check)."""
         st = gemmi.Structure()


### PR DESCRIPTION
## Problem

At the Confirm dialog, `prosmart_refmac` (and any refinement task) reports:

> Monomer coverage check failed: No dictionary at all for: ALA, ARG, ASN, ASP, GLN, GLU, GLY, HIS, ILE, LEU, LYS, MET, PHE, PRO, SER, THR, TRP, TYR, VAL

i.e. **every standard amino acid** of a plain protein is flagged as missing a dictionary. It only appears on the **CCP4-free slim Django API server** — invisible on the macOS Electron desktop and the old CCP4-bundled container, where the monomer library masks it.

## Root cause

`checkMonomeCoverage` collects *all* residue codes (despite its "non-polymer residues" docstring) and flags any not in `ml.monomers`. With the CCP4 monomer library present, `read_monomer_lib` loads the standard residues so the over-broad check passes; with no library (`CLIBD_MON`/`CCP4` unset on the slim server) the library is never read, so everything — ALA included — is flagged, blocking submission.

## Fix

- **Defer when no library:** return `SUCCEEDED` if `monlib_dir` is unavailable. `runTimeValidity()` is also re-run by the worker's `process()`, which *does* have the library and performs the real check. Mirrors the existing "don't block; refinement will catch it" guards.
- **Scope to non-standard residues:** exclude `is_standard()` / `is_water()` residues (via `gemmi.find_tabulated_residue`) from the no-dictionary report — only ligand / modified residues need explicit dictionary coverage, per the docstring intent.

## Tests

- `tests/i2run/test_monomer_coverage.py`: **11/11 pass** — 10 existing + new `test_no_monomer_library_defers` (a structure with an unknown ligand, which would otherwise FAIL, defers cleanly when no library is present).
- Slim import guard (`tests/unit/slim/test_no_ccp4_native_imports.py`) still passes — no CCP4-native dependency added to the API surface.
- Genuine missing-ligand / code-collision cases still FAIL — real coverage checking is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)