### PR TITLE
Behavioural guard: validity()/runTimeValidity() must run CCP4-free

### DIFF
--- a/server/ccp4i2/tests/unit/slim/_ccp4_free_validation_probe.py
+++ b/server/ccp4i2/tests/unit/slim/_ccp4_free_validation_probe.py
@@ -1,0 +1,83 @@
+"""Probe: run every task's validity()/runTimeValidity() with the CCP4 install
+made unavailable, and check that none of them require it.
+
+The slim/CCP4-free API boundary is wider than "no CCP4 imports" (which the
+sibling test_no_ccp4_native_imports.py covers). The /validation/ and
+/run_time_validation/ endpoints instantiate task plugins and call these methods
+on the API, so a method that reads CCP4 reference data (Class B) or shells out to
+a CCP4 binary (Class C) breaks on the CCP4-free server — even with no CCP4 import.
+That is the checkMonomeCoverage regression (PR #175): it located the monomer
+library via $CLIBD_MON/$CCP4 and, with none present, reported every residue as
+"no dictionary", blocking refinement at Confirm.
+
+This probe is run by test_validation_ccp4_free.py in a subprocess whose CCP4
+install has been scrubbed (env vars unset, CCP4 bin removed from PATH), so it is
+meaningful on a slim interpreter AND under ccp4-python.
+
+Exit 0 + "CLEAN" if no task needs the install; exit 1 + offenders otherwise.
+"""
+import logging
+logging.disable(logging.CRITICAL)
+
+import subprocess
+import sys
+import tempfile
+
+import django
+django.setup()
+
+from ccp4i2 import I2_TOP
+from ccp4i2.core.tasks import TASKS, get_plugin_class
+
+# The signatures of an install-access failure (missing data file / missing binary).
+INSTALL_ERRS = (FileNotFoundError, NotADirectoryError, PermissionError,
+                subprocess.CalledProcessError)
+
+failures = []
+
+# --- Part 1: every importable task, empty container -------------------------
+# Catches *unconditional* install access in validity()/runTimeValidity().
+# Tasks whose plugin module does not import on this interpreter (missing pip dep
+# or a CCP4-native import) yield get_plugin_class() -> None and are skipped here;
+# they are a separate (Class A) concern for the import guard / dependency set.
+for name in sorted(TASKS):
+    try:
+        cls = get_plugin_class(name)
+    except Exception:
+        continue
+    if cls is None:
+        continue
+    try:
+        plugin = cls(workDirectory=tempfile.mkdtemp())
+    except Exception:
+        continue
+    for meth in ("validity", "runTimeValidity"):
+        try:
+            getattr(plugin, meth)()
+        except INSTALL_ERRS as exc:
+            failures.append("%s.%s -> %s: %s" % (name, meth, type(exc).__name__, str(exc)[:140]))
+        except Exception:
+            pass  # validation-logic errors (returned via CErrorReport) are fine
+
+# --- Part 2: the monomer-coverage path with a real model --------------------
+# This is *input-gated*: it only runs when a model is present, so the Part-1
+# empty-container sweep would not reach it. Exercises the exact PR #175 scenario
+# under a CCP4-free env — it must defer gracefully, not raise FileNotFoundError.
+try:
+    refmac_cls = get_plugin_class("refmac")
+    if refmac_cls is not None:
+        plugin = refmac_cls(workDirectory=tempfile.mkdtemp())
+        model = str(I2_TOP / "demo_data" / "gamma" / "gamma_model.pdb")
+        plugin.checkMonomeCoverage(model)
+except INSTALL_ERRS as exc:
+    failures.append("checkMonomeCoverage(model) -> %s: %s" % (type(exc).__name__, str(exc)[:140]))
+except Exception:
+    pass
+
+if failures:
+    print("CCP4-FREE VALIDATION FAILURES (need the CCP4 install on the request path):")
+    for line in failures:
+        print("  " + line)
+    sys.exit(1)
+print("CLEAN")
+sys.exit(0)

--- a/server/ccp4i2/tests/unit/slim/test_validation_ccp4_free.py
+++ b/server/ccp4i2/tests/unit/slim/test_validation_ccp4_free.py
@@ -1,0 +1,65 @@
+"""
+Behavioural guard: no task's validity()/runTimeValidity() may require the CCP4
+install.
+
+Complements test_no_ccp4_native_imports.py. That guard fences Class A (CCP4-native
+*imports*) on the API surface; this one fences Class B (env-driven discovery of
+CCP4 reference data) and Class C (CCP4 binary execution) on the validation path,
+which the import guard cannot see. The real invariant is "nothing on the
+request/validation path requires the CCP4 install" — and validity()/
+runTimeValidity() run on the API via the /validation/ and /run_time_validation/
+endpoints.
+
+The work is done by _ccp4_free_validation_probe.py, run here in a subprocess whose
+CCP4 install is scrubbed (env vars unset + CCP4 bin removed from PATH), so the
+check is faithful on a slim interpreter AND under ccp4-python.
+
+If this fails: a task reads CCP4 reference data or runs a CCP4 binary from
+validity()/runTimeValidity(). Either defer it (return SUCCEEDED/skip when the
+install is absent; the worker re-runs it in process()) or port it to pure
+gemmi/numpy. Cf. PR #175 (checkMonomeCoverage defer) and the crossec->gemmi port.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SERVER_ROOT = Path(__file__).resolve().parents[4]  # .../server
+PROBE = Path(__file__).parent / "_ccp4_free_validation_probe.py"
+
+# CCP4-install variables to remove so the probe sees no install.
+_CCP4_ENV_VARS = (
+    "CCP4", "CLIBD", "CLIBD_MON", "CBIN", "CLIB", "CINCL",
+    "CCP4_SCR", "CETC", "CCP4_MASTER", "CCP4I2_TOP",
+)
+
+
+def test_validation_runs_with_no_ccp4_install(tmp_path):
+    env = dict(os.environ)
+    env.setdefault("DJANGO_SETTINGS_MODULE", "ccp4i2.config.settings")
+    env.setdefault("CCP4I2_BACKEND", "django")
+    env["CCP4I2_HOME"] = str(tmp_path)  # don't touch the real ~/.ccp4i2
+    env["PYTHONPATH"] = os.pathsep.join([str(SERVER_ROOT), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+
+    # Scrub the CCP4 install: unset env vars and drop CCP4 bin dirs from PATH so
+    # Class C (shutil.which(<binary>)) and Class B (env discovery) both see nothing.
+    ccp4 = env.get("CCP4")
+    for var in _CCP4_ENV_VARS:
+        env.pop(var, None)
+    if ccp4:
+        env["PATH"] = os.pathsep.join(
+            p for p in env.get("PATH", "").split(os.pathsep) if ccp4 not in p
+        )
+
+    result = subprocess.run(
+        [sys.executable, str(PROBE)], env=env,
+        capture_output=True, text=True, timeout=600,
+    )
+    out = (result.stdout + result.stderr).strip()
+    assert result.returncode == 0, (
+        "A task's validity()/runTimeValidity() requires the CCP4 install on the "
+        "request path — defer it (return SUCCEEDED when absent; worker re-runs in "
+        "process()) or port it to pure gemmi/numpy.\n" + out
+    )
+    assert "CLEAN" in result.stdout, f"Unexpected probe output:\n{out}"


### PR DESCRIPTION
Complements the import guard (#171). That fences Class A (CCP4-native *imports*) on the API surface; this fences **Class B** (reading CCP4 reference data, e.g. `$CLIBD_MON`) and **Class C** (shelling out to a CCP4 binary) on the **validation path** — which the import guard cannot see. `validity()`/`runTimeValidity()` run on the API via the `/validation/` and `/run_time_validation/` endpoints, so a B/C coupling there breaks on the CCP4-free server (invisibly elsewhere, because a local CCP4 install masks it). That was the `checkMonomeCoverage` regression (#175).

`tests/unit/slim/test_validation_ccp4_free.py` runs every importable task's `validity()` and `runTimeValidity()` with the CCP4 install **scrubbed** (env vars unset + CCP4 `bin` removed from PATH, in a subprocess — faithful on a slim interpreter AND under ccp4-python) and asserts none raise `FileNotFoundError`/`NotADirectoryError`/`PermissionError`/`CalledProcessError`. It also exercises the input-gated monomer-coverage path with a real model (the exact #175 scenario).

**Verified:** passes on slim CPython and ccp4-python (current tree is clean — 0 offenders across 144 importable tasks); fails with a clear report when a Class-C call is injected into a task's `runTimeValidity`.

Note: tasks whose plugin *module* doesn't import on the slim interpreter are skipped here (a separate, larger concern — ~21 plugins import an execution-only dependency at module top-level, blocking GUI configuration on the CCP4-free server; being addressed in a follow-up via lazy-loading + a module-import guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)