### PR TITLE
Defer execution-only imports so 12 tasks configure CCP4-free

### DIFF
--- a/server/ccp4i2/pipelines/SubstituteLigand/script/SubstituteLigand.py
+++ b/server/ccp4i2/pipelines/SubstituteLigand/script/SubstituteLigand.py
@@ -5,7 +5,10 @@ import traceback
 
 from lxml import etree
 
-import coot_headless_api
+try:  # external Coot API, present only in the execution (worker) env, not the slim API
+    import coot_headless_api
+except ImportError:
+    coot_headless_api = None
 
 from ccp4i2.core import CCP4Utils
 from ccp4i2.core.CCP4PluginScript import CPluginScript

--- a/server/ccp4i2/wrappers/AMPLE/script/AMPLE.py
+++ b/server/ccp4i2/wrappers/AMPLE/script/AMPLE.py
@@ -1,9 +1,12 @@
 import os
 import shutil
 
-from ample.constants import AMPLE_PKL
-from ample.util import mrbump_util
-from ample.util.ample_util import I2DIR
+try:
+    from ample.constants import AMPLE_PKL
+    from ample.util import mrbump_util
+    from ample.util.ample_util import I2DIR
+except ImportError:  # `ample` is present only in the execution (worker) env, not on the slim API
+    AMPLE_PKL = mrbump_util = I2DIR = None
 from lxml import etree
 
 from ccp4i2.core.CCP4PluginScript import CPluginScript

--- a/server/ccp4i2/wrappers/SIMBAD/script/SIMBAD.py
+++ b/server/ccp4i2/wrappers/SIMBAD/script/SIMBAD.py
@@ -1,8 +1,11 @@
 import os
 import shutil
 
-from simbad.util import SIMBAD_DIRNAME
-from simbad.util.simbad_results import SimbadResults
+try:
+    from simbad.util import SIMBAD_DIRNAME
+    from simbad.util.simbad_results import SimbadResults
+except ImportError:  # `simbad` is present only in the execution (worker) env, not on the slim API
+    SIMBAD_DIRNAME = SimbadResults = None
 
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 

--- a/server/ccp4i2/wrappers/SubtractNative/script/SubtractNative.py
+++ b/server/ccp4i2/wrappers/SubtractNative/script/SubtractNative.py
@@ -1,12 +1,17 @@
-import clipper
-
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 
 
 class SubtractNative(CPluginScript):
+    """DEPRECATED. Computes a "binding event"-style difference map by subtracting
+    model-calculated density from the observed map. Slated for replacement by an
+    interactive Moorhen feature; kept for backward compatibility only. Still uses
+    clipper at execution (imported lazily, below) — not ported to gemmi on purpose.
+    """
     TASKNAME = "SubtractNative"
+    DEPRECATED = True
 
     def startProcess(self):
+        import clipper  # lazy: deprecated task, clipper only needed at execution (worker)
         mtz_file = clipper.CCP4MTZfile()
         hkl_info = clipper.HKL_info()
         coefficientsPath = str(self.container.inputData.MAPIN.fullPath)

--- a/server/ccp4i2/wrappers/coot_find_ligand/script/coot_find_ligand.py
+++ b/server/ccp4i2/wrappers/coot_find_ligand/script/coot_find_ligand.py
@@ -4,8 +4,6 @@ import pathlib
 import shutil
 import xml.etree.ElementTree as ET
 
-import coot_headless_api
-
 from ccp4i2.core.CCP4ModelData import CPdbDataFile
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 
@@ -15,6 +13,7 @@ class coot_find_ligand(CPluginScript):
     WHATNEXT = ["prosmart_refmac"]
 
     def startProcess(self):
+        import coot_headless_api  # lazy: external Coot API, only needed at execution (worker)
         inputData = self.container.inputData
         outputData = self.container.outputData
         params = self.container.controlParameters

--- a/server/ccp4i2/wrappers/coot_find_waters/script/coot_find_waters.py
+++ b/server/ccp4i2/wrappers/coot_find_waters/script/coot_find_waters.py
@@ -3,8 +3,6 @@ import pathlib
 import shutil
 import xml.etree.ElementTree as ET
 
-import coot_headless_api
-
 from ccp4i2.core.CCP4ModelData import CPdbDataFile
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 
@@ -15,6 +13,7 @@ class coot_find_waters(CPluginScript):
     ASYNCHRONOUS = True
 
     def startProcess(self):
+        import coot_headless_api  # lazy: external Coot API, only needed at execution (worker)
         outFormat = "cif" if self.container.inputData.XYZIN.isMMCIF() else "pdb"
         oldFullPath = pathlib.Path(str(self.container.outputData.XYZOUT.fullPath))
         if outFormat == "cif":

--- a/server/ccp4i2/wrappers/coot_rsr_morph/script/coot_rsr_morph.py
+++ b/server/ccp4i2/wrappers/coot_rsr_morph/script/coot_rsr_morph.py
@@ -2,8 +2,6 @@ import os
 import shutil
 import pathlib
 
-import coot_headless_api
-
 from ccp4i2.core.CCP4ModelData import CPdbDataFile
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 
@@ -14,6 +12,7 @@ class coot_rsr_morph(CPluginScript):
     ASYNCHRONOUS = True
 
     def startProcess(self):
+        import coot_headless_api  # lazy: external Coot API, only needed at execution (worker)
         outFormat = "cif" if self.container.inputData.XYZIN.isMMCIF() else "pdb"
         oldFullPath = pathlib.Path(str(self.container.outputData.XYZOUT.fullPath))
         if outFormat == "cif":

--- a/server/ccp4i2/wrappers/editbfac/script/editbfac.py
+++ b/server/ccp4i2/wrappers/editbfac/script/editbfac.py
@@ -2,11 +2,14 @@ import os
 import sys
 
 import gemmi
-import iotbx.phil
-from iotbx.data_manager import DataManager
 from lxml import etree
-from mmtbx import process_predicted_model
-from mmtbx.domains_from_pae import parse_pae_file
+try:  # iotbx/mmtbx (cctbx) present only in the execution (worker) env, not the slim API
+    import iotbx.phil
+    from iotbx.data_manager import DataManager
+    from mmtbx import process_predicted_model
+    from mmtbx.domains_from_pae import parse_pae_file
+except ImportError:
+    iotbx = DataManager = process_predicted_model = parse_pae_file = None
 
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 

--- a/server/ccp4i2/wrappers/phaser_analysis/script/phaser_analysis.py
+++ b/server/ccp4i2/wrappers/phaser_analysis/script/phaser_analysis.py
@@ -12,7 +12,10 @@ See:
 import math
 import os
 
-import phaser
+try:  # `phaser` present only in the execution (worker) env, not the slim API
+    import phaser
+except ImportError:
+    phaser = None
 from lxml import etree
 
 from ccp4i2.core.CCP4PluginScript import CPluginScript

--- a/server/ccp4i2/wrappers/validate_protein/script/validate_protein.py
+++ b/server/ccp4i2/wrappers/validate_protein/script/validate_protein.py
@@ -9,10 +9,13 @@ import traceback
 import warnings
 from math import pi
 
-import iris_validation
 import numpy as np
-from iris_validation.graphics import Panel
-from iris_validation.metrics import metrics_model_series_from_files
+try:
+    import iris_validation
+    from iris_validation.graphics import Panel
+    from iris_validation.metrics import metrics_model_series_from_files
+except ImportError:  # `iris_validation` present only in the execution (worker) env, not the slim API
+    iris_validation = Panel = metrics_model_series_from_files = None
 from lxml import etree
 
 from ccp4i2.core import CCP4Modules, CCP4Utils, CCP4XtalData

--- a/server/ccp4i2/wrappers/xia2_multiplex/script/xia2_multiplex.py
+++ b/server/ccp4i2/wrappers/xia2_multiplex/script/xia2_multiplex.py
@@ -4,7 +4,10 @@ import os
 import shutil
 from math import sqrt
 
-from dxtbx.model.experiment_list import ExperimentList
+try:  # dxtbx present only in the execution (worker) env, not the slim API
+    from dxtbx.model.experiment_list import ExperimentList
+except ImportError:
+    ExperimentList = None
 
 from lxml import etree
 

--- a/server/ccp4i2/wrappers/xia2_ssx_reduce/script/xia2_ssx_reduce.py
+++ b/server/ccp4i2/wrappers/xia2_ssx_reduce/script/xia2_ssx_reduce.py
@@ -6,7 +6,10 @@ from math import sqrt
 from pathlib import Path
 
 import gemmi
-from dxtbx.model.experiment_list import ExperimentList
+try:  # dxtbx present only in the execution (worker) env, not the slim API
+    from dxtbx.model.experiment_list import ExperimentList
+except ImportError:
+    ExperimentList = None
 from lxml import etree
 
 from ccp4i2.core import CCP4Container, CCP4XtalData


### PR DESCRIPTION
Part of the slim/CCP4-free server work. The `/validation/` and task-config endpoints instantiate a task's plugin on the API, so a plugin **module** that imports its external program package at top-level blocks GUI configuration/validation of that task on the CCP4-free server — even though the dependency is only needed to *run* the program (on the worker).

This defers those imports for 12 tasks (into the execution method, or a module-level optional-import guard where the dep is used across several methods), so the module imports CCP4-free and the dependency loads at execution time. **No behaviour change on a full install.**

- coot_find_ligand / coot_find_waters / coot_rsr_morph / SubstituteLigand — `coot_headless_api`
- AMPLE (`ample`), SIMBAD (`simbad`), validate_protein (`iris_validation`), phaser_analysis (`phaser`), editbfac (`iotbx`/`mmtbx`), xia2_multiplex / xia2_ssx_reduce (`dxtbx`)
- **SubtractNative** — lazy `clipper` + marked `DEPRECATED` (Pandda-like difference map; earmarked for a future interactive Moorhen feature rather than a gemmi port)

Verified: all 12 now import on a slim CPython interpreter (no CCP4); plugin-module import-failure count **26 → 14**. The remaining 14 are the clipper/ccp4mg *toolkit* users — being **gemmi-ported** (gesamt, tableone, acedrgNew, …) so the dependency is removed entirely — plus a few pip-dep / module-level `$CCP4` cases, handled in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)