### PR TITLE
acedrgNew: defer atomMatching/cifToMolBlock imports for slim API

### DIFF
--- a/server/ccp4i2/wrappers/acedrgNew/script/acedrgNew.py
+++ b/server/ccp4i2/wrappers/acedrgNew/script/acedrgNew.py
@@ -7,7 +7,10 @@ from lxml import etree
 from ccp4i2.core import CCP4Utils
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 
-from . import atomMatching, cifToMolBlock
+# NB atomMatching (ccp4srs/mmdb2) and cifToMolBlock (rdkit) are imported lazily
+# inside the execution methods below, so this plugin stays importable on the
+# slim, CCP4-free API where those toolkits are absent. They run only at job
+# execution time (on the worker), never during GUI configuration/validation.
 
 
 class acedrgNew(CPluginScript):
@@ -91,6 +94,7 @@ class acedrgNew(CPluginScript):
             self.originalMolFilePath = os.path.normpath(os.path.join(self.getWorkDirectory(),'MOLIN.mol'))
             print(self.originalMolFilePath)
             try:
+                from . import cifToMolBlock  # lazy: rdkit, only at execution (worker)
                 if self.container.inputData.DICTIN2.isSet():
                     molBlock = cifToMolBlock.cifFileToMolBlock(self.container.inputData.DICTIN2.__str__())
                 else:
@@ -199,7 +203,8 @@ class acedrgNew(CPluginScript):
         retMatches = {}
         if os.path.isfile(pdbFilePath):
             try:
-                import ccp4srs
+                import ccp4srs  # lazy: CCP4 SRS, only at execution (worker)
+                from . import atomMatching  # lazy: ccp4srs/mmdb2, only at execution
                 dummy = ccp4srs.Graph()
                 print("Atom name matching available ...")
                 if self.container.inputData.ATOMMATCHOPTION.__str__() == 'MONLIBCODE':


### PR DESCRIPTION
## What
Move acedrgNew's `atomMatching` (ccp4srs + mmdb2) and `cifToMolBlock` (rdkit)
imports from module level into the execution methods that use them.

## Why
On the slim, CCP4-free API (used to configure & validate tasks in the GUI),
acedrgNew could not be imported because `from . import atomMatching, cifToMolBlock`
transitively pulled in `ccp4srs`, `mmdb2`, and `rdkit`. A plugin that can't
import can't be configured in the GUI.

Both helpers run **only at job execution** (on the CCP4-bearing worker):
`cifToMolBlock` in `processInputFiles`, `atomMatching` in `processOutputFiles`.
rdkit was already deferred elsewhere in the file; this completes the pattern.

The ccp4srs atom-graph matching has no gemmi equivalent and is genuinely
execution-only, so deferral (not re-implementation) is the correct fix here.

## Verification
`get_plugin_class('acedrgNew')` now imports on stock CPython 3.13 + pip gemmi
with no CCP4 toolkits present. No behavioural change at execution time.

Part of the slim/CCP4-free API stream (follows gesamt #181, tableone #182).

🤖 Generated with [Claude Code](https://claude.com/claude-code)