### PR TITLE
mtzheader: read MTZ header with gemmi instead of hklfile/ccp4mg

### DIFF
--- a/server/ccp4i2/wrappers/mtzheader/script/mtzheader.py
+++ b/server/ccp4i2/wrappers/mtzheader/script/mtzheader.py
@@ -3,13 +3,17 @@
      Copyright (C) 2011 STFC
      Author: Martyn Winn
 
-     This wrapper uses Stuart's python wrapper to Phil's hklfile.
-     It deliberately does not use mtzdump.
-     You need hklfile.py and _hklfile.so on PYTHONPATH. Latter is
-     set in ccp4i2/utils/setup.sh
+     Reads the header of an MTZ reflection file (cell, spacegroup, resolution,
+     reflection count, merged/unmerged) and maps it onto ccp4i2 data items.
+
+     Originally wrapped Phil Evans' hklfile (via ccp4mg); reimplemented with
+     gemmi so the wrapper imports and runs without the CCP4 native toolkits
+     (keeping it usable on the slim, CCP4-free API). HKLIN is a CMtzDataFile,
+     so gemmi.read_mtz_file covers every field the old hklfile path provided.
 """
 
-from ccp4i2.core.mgimports import hklfile
+import gemmi
+
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 
 
@@ -25,45 +29,36 @@ class mtzheader(CPluginScript):
          return
 
        # No output files, so skip checkOutputData
-       reflection_list = hklfile.ReflectionList()
-       reflection_list.init(str(self.container.inputData.HKLIN))
+       mtz = gemmi.read_mtz_file(str(self.container.inputData.HKLIN))
 
-       ftype = reflection_list.FileType()
-       if ftype.FileType() == hklfile.ReflectionFileType.UNKNOWN:
-         print("HKLIN is of unknown type")
-         return
-       else:
-         print("Opening reflection file of type %s" % ftype.FileType())
-
-       isMerged = reflection_list.Merged()
+       # An unmerged MTZ carries batch headers; a merged one has none.
+       isMerged = len(mtz.batches) == 0
        if isMerged:
          print("Reflection file is merged")
        else:
          print("Reflection file is unmerged")
 
-       # issue of which cell to take
-       cell = hklfile.Scell(reflection_list.Cell())
-       print("Cell = ", cell.UnitCell())
-       spacegroup = hklfile.SpaceGroup(reflection_list.Spacegroup())
-       print("Spacegroup = %s" % spacegroup.Symbol_hm())
-       resolution = reflection_list.Resolution().ResHigh()
+       cell = mtz.cell
+       print("Cell = ", (cell.a, cell.b, cell.c, cell.alpha, cell.beta, cell.gamma))
+       spacegroup_hm = mtz.spacegroup.hm if mtz.spacegroup is not None else ''
+       print("Spacegroup = %s" % spacegroup_hm)
+       resolution = mtz.resolution_high()
        print("Resolution = %f" % resolution)
-       no_reflections = reflection_list.NumberReflections()
+       no_reflections = mtz.nreflections
        print("Number of reflections = %d" % no_reflections)
 
-       # map hklfile objects onto ccp4i2 data items
+       # map gemmi values onto ccp4i2 data items
        self.container.outputData.MERGED = isMerged
        self.container.outputData.SPACEGROUPCELL.cell.set(
-                                     { 'a' : cell.UnitCell()[0],
-                                       'b' : cell.UnitCell()[1],
-                                       'c' : cell.UnitCell()[2],
-                                       'alpha' :cell.UnitCell()[3],
-                                       'beta' : cell.UnitCell()[4],
-                                       'gamma' : cell.UnitCell()[5] } )
-       self.container.outputData.SPACEGROUPCELL.spaceGroup.set(spacegroup.Symbol_hm())
+                                     { 'a' : cell.a,
+                                       'b' : cell.b,
+                                       'c' : cell.c,
+                                       'alpha' : cell.alpha,
+                                       'beta' : cell.beta,
+                                       'gamma' : cell.gamma } )
+       self.container.outputData.SPACEGROUPCELL.spaceGroup.set(spacegroup_hm)
        self.container.outputData.MAXRESOLUTION = resolution
        self.container.outputData.NO_REFLECTIONS = no_reflections
 
        # Needed!
        self.reportStatus(CPluginScript.SUCCEEDED)
-


### PR DESCRIPTION
## What
Reimplement mtzheader's MTZ-header read with `gemmi.read_mtz_file` instead of
Phil Evans' `hklfile` (pulled in via `ccp4i2.core.mgimports`, which does
`import ccp4mg` at module level).

## Why
The `mgimports` -> `ccp4mg` import meant mtzheader could not be imported on the
slim, CCP4-free API used to configure/validate tasks in the GUI. HKLIN is a
`CMtzDataFile`, so gemmi covers every field the old path produced.

| field | old (hklfile) | new (gemmi) |
|-------|---------------|-------------|
| cell | `Scell(...).UnitCell()` | `mtz.cell.{a,b,c,alpha,beta,gamma}` |
| spacegroup | `SpaceGroup(...).Symbol_hm()` | `mtz.spacegroup.hm` |
| resolution | `Resolution().ResHigh()` | `mtz.resolution_high()` |
| no. reflections | `NumberReflections()` | `mtz.nreflections` |
| merged? | `Merged()` | `len(mtz.batches) == 0` |

## Verification
- `get_plugin_class('mtzheader')` imports on stock CPython 3.13 + pip gemmi, no
  CCP4 toolkits present.
- gemmi reads reproduce cell, spacegroup (P 21 21 21), resolution and reflection
  count on a demo MTZ.

Part of the slim/CCP4-free API stream (follows acedrgNew #183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)