### PR TITLE
clustalw/coot1: guard module-level $CCP4 reads for slim API

### DIFF
--- a/server/ccp4i2/wrappers/clustalw/script/clustalw.py
+++ b/server/ccp4i2/wrappers/clustalw/script/clustalw.py
@@ -14,7 +14,13 @@ logger = logging.getLogger(f"ccp4i2:{__name__}")
 
 class clustalw(CPluginScript):
     TASKNAME = 'clustalw'
-    TASKCOMMAND = shutil.which("clustalw2", path=Path(os.environ["CCP4"], "libexec"))
+    # Resolve the binary under $CCP4/libexec when CCP4 is present; fall back to a
+    # bare command name on the slim, CCP4-free API (which only configures the
+    # task and never executes it -- the worker always has $CCP4 set).
+    TASKCOMMAND = (
+        shutil.which("clustalw2", path=Path(os.environ["CCP4"], "libexec"))
+        if "CCP4" in os.environ else "clustalw2"
+    )
 
     ERROR_CODES = {  200 : { 'description' : 'Failed to catenate sequences' },201 : { 'description' : 'Failed to setFullPath' },}
     

--- a/server/ccp4i2/wrappers/coot1/script/coot1.py
+++ b/server/ccp4i2/wrappers/coot1/script/coot1.py
@@ -6,7 +6,13 @@ from ccp4i2.core.CCP4ModelData import CPdbDataFile
 
 
 def coot1Command():
-    ccp4 = Path(environ["CCP4"])
+    ccp4 = environ.get("CCP4")
+    if ccp4 is None:
+        # CCP4 absent (e.g. the slim, CCP4-free API used only to configure the
+        # task) -- the full path is resolved at execution time on the worker,
+        # which always has $CCP4 set.
+        return "coot"
+    ccp4 = Path(ccp4)
     if platform == "win32":
         return str(ccp4 / ".." / "WinCoot1" / "wincoot.bat")
     return str(ccp4 / "coot_py3" / "bin" / "coot")


### PR DESCRIPTION
## What
Guard the `os.environ["CCP4"]` reads that `clustalw` and `coot1` perform at
class-definition (import) time when resolving `TASKCOMMAND`.

## Why
On the slim, CCP4-free API (used only to configure/validate tasks in the GUI),
`$CCP4` is unset, so importing either plugin raised `KeyError` — the task
couldn't be configured at all.

- `clustalw`: `shutil.which("clustalw2", path=Path(os.environ["CCP4"],"libexec"))`
  → falls back to `"clustalw2"` when `$CCP4` is absent.
- `coot1`: `coot1Command()` builds the path from `environ["CCP4"]`
  → returns the bare `"coot"` when `$CCP4` is absent.

The full path is resolved on the worker (which always has `$CCP4` set), so
execution behaviour is unchanged.

## Verification
Both import on stock CPython 3.13 with `$CCP4` unset.

Part of the slim/CCP4-free API stream (follows mtzheader #184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)