### PR TITLE
i2Dimple: cast mmCIF->PDB with gemmi instead of mmdb2/ccp4mg

### DIFF
--- a/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.py
+++ b/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.py
@@ -1,9 +1,10 @@
 import os
 
+import gemmi
+
 from ccp4i2.core import CCP4ErrorHandling
 from ccp4i2.core import CCP4XtalData
 from ccp4i2.core.CCP4PluginScript import CPluginScript
-from ccp4i2.core.mgimports import mmdb2 as mmdb
 
 
 class i2Dimple(CPluginScript):
@@ -25,11 +26,14 @@ class i2Dimple(CPluginScript):
         self.xyzin = os.path.join(self.getWorkDirectory(),"selected_xyzin.pdb")
 
         #A work around to cast input coordinates into PDB format for dimple if necessary
-        testLoader = mmdb.Manager()
-        result = testLoader.ReadCIFASCII(str(self.container.inputData.XYZIN.fullPath))
-        if result == 0:
+        # dimple needs PDB input. If XYZIN is mmCIF, convert it to PDB first so the
+        # (PDB-based) atom-selection machinery can be applied; otherwise use XYZIN
+        # directly. gemmi auto-detects the input format, replacing the previous
+        # mmdb2 ReadCIFASCII/WritePDBASCII cast (which needed the CCP4 toolkit).
+        structure = gemmi.read_structure(str(self.container.inputData.XYZIN.fullPath))
+        if structure.input_format == gemmi.CoorFormat.Mmcif:
             temp_pdb = os.path.join(self.getWorkDirectory(),"selected_xyzin_temp.pdb")
-            RC=testLoader.WritePDBASCII(self.xyzin)
+            structure.write_pdb(self.xyzin)
             from ccp4i2.core.CCP4ModelData import CPdbDataFile
             temporaryObject = CPdbDataFile(fullPath=self.xyzin)
             temporaryObject.loadFile()


### PR DESCRIPTION
## What
Replace i2Dimple's mmdb2-based mmCIF→PDB cast with gemmi.

## Why
i2Dimple imported `mmdb2` via `ccp4i2.core.mgimports` (which does `import ccp4mg`
at module level) only to convert mmCIF input coordinates to PDB for dimple. That
import blocked the plugin from loading on the slim, CCP4-free API used to
configure/validate tasks in the GUI.

`gemmi.read_structure` auto-detects the input format; when it's mmCIF we write a
PDB and feed it through the existing (PDB-based) atom-selection machinery,
exactly as before. The PDB-input path is untouched.

## Verification
- `get_plugin_class('i2Dimple')` imports on stock CPython 3.13 + pip gemmi, no
  CCP4 toolkits present.
- **i2run `test_dimple.py` PASSES** under CCP4 (1 passed, 14s).
- mmCIF→PDB conversion validated independently: atom count preserved (20454 →
  20454) and the written PDB round-trips through gemmi.

Part of the slim/CCP4-free API stream (follows clustalw/coot1 #185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)