### PR TITLE
Defer rdkit/scipy/pandas pip-imports to execution for slim API

### DIFF
--- a/server/ccp4i2/pipelines/prosmart_refmac/script/prosmart_refmac.py
+++ b/server/ccp4i2/pipelines/prosmart_refmac/script/prosmart_refmac.py
@@ -4,7 +4,7 @@ import shutil
 import traceback
 
 from lxml import etree
-from rdkit import Chem
+# rdkit imported lazily below — only used at execution to render a ligand SVG
 
 from ccp4i2.core import CCP4ErrorHandling, CCP4Utils
 from ccp4i2.core.CCP4ErrorHandling import CErrorReport
@@ -289,6 +289,7 @@ class prosmart_refmac(CPluginScript):
         if statusDict['finishStatus'] == CPluginScript.UNSATISFACTORY:
             if os.path.isfile(self.firstRefmac.container.outputData.LIBOUT.__str__()):
                 from ccp4i2.wrappers.acedrg.script import acedrg
+                from rdkit import Chem  # lazy: pip dep, only at execution (worker)
                 try:
                     rdkitMol = acedrg.molFromDict(self.firstRefmac.container.outputData.LIBOUT.__str__())
                     molRemovedHs = Chem.RemoveHs(rdkitMol)

--- a/server/ccp4i2/pipelines/servalcat_pipe/script/monitor_differences.py
+++ b/server/ccp4i2/pipelines/servalcat_pipe/script/monitor_differences.py
@@ -14,7 +14,7 @@ __version__ = "0.5"
 
 from argparse import ArgumentParser
 import gemmi
-import pandas as pd
+# pandas imported lazily inside main() — only needed at execution (worker)
 
 
 def makeAddressStr(cra):
@@ -59,6 +59,7 @@ def search(st1Cras, st2Cras, output, minCoordDev, minAdpDev):
 
 
 def main(file1, file2, output=None, minCoordDev=0, minAdpDev=0, useHydrogens=False):
+    import pandas as pd  # lazy: pip dep, only at execution (worker)
     print("File 1 is " + file1 + ".")
     print("File 2 is " + file2 + ".")
     try:

--- a/server/ccp4i2/wrappers/modelASUCheck/script/modelASUCheck.py
+++ b/server/ccp4i2/wrappers/modelASUCheck/script/modelASUCheck.py
@@ -1,7 +1,6 @@
 import traceback
 
 from lxml import etree
-from scipy.optimize import linear_sum_assignment
 import gemmi
 import numpy as np
 
@@ -28,6 +27,7 @@ class modelASUCheck(CPluginScript):
 
 
 def sequenceAlignment(xyzinPath, asuin):
+    from scipy.optimize import linear_sum_assignment  # lazy: pip dep, execution only
     structure = gemmi.read_structure(xyzinPath)
     structure.setup_entities()
 


### PR DESCRIPTION
## What
Move three execution-only pip imports from module level into their points of use.

| plugin | import | used in |
|--------|--------|---------|
| prosmart_refmac | `from rdkit import Chem` | ligand-SVG render on UNSATISFACTORY |
| modelASUCheck | `from scipy.optimize import linear_sum_assignment` | `sequenceAlignment()` |
| servalcat_pipe | `import pandas` (in `monitor_differences`) | `monitor_differences.main()` |

## Why
On the slim, CCP4-free API used to configure/validate tasks in the GUI, these
module-level imports caused the plugins to fail to load. (prosmart_refmac also
imports modelASUCheck, so it inherited the scipy failure.) Deferring keeps the
heavy deps — rdkit (~100MB+), scipy, pandas — off the control-plane import
surface while leaving execution unchanged.

## Verification
- `get_plugin_class` for all three imports on stock CPython 3.13 + pip gemmi with
  none of rdkit/scipy/pandas/CCP4 installed.
- i2run **`test_model_asu_check.py` + `test_servalcat.py`: 5 passed** under CCP4
  — the scipy and pandas execution paths fire correctly through the lazy imports.

Part of the slim/CCP4-free API stream (follows i2Dimple #186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)