### PR TITLE
ccp4mg_edit_model + arcimboldo: clear remaining slim-import blockers

### DIFF
--- a/server/ccp4i2/wrappers/arcimboldo/script/arcimboldo.py
+++ b/server/ccp4i2/wrappers/arcimboldo/script/arcimboldo.py
@@ -1,7 +1,7 @@
 # This script runs all three versions of arcimboldo
 
 import os
-from distutils.dir_util import copy_tree
+import shutil
 
 from lxml import etree
 
@@ -164,7 +164,9 @@ class arcimboldo(CPluginScript):
         if exitCode != 0:
             return CPluginScript.FAILED
         if developerOptions.DEVELOPER_MODE == 'EXISTING':
-            copy_tree(str(developerOptions.EXISTING_FOLDER), str(self.getWorkDirectory()), update=1)
+            # shutil.copytree(dirs_exist_ok=True) merges into the (freshly created)
+            # work directory, matching distutils copy_tree (removed in Python 3.12).
+            shutil.copytree(str(developerOptions.EXISTING_FOLDER), str(self.getWorkDirectory()), dirs_exist_ok=True)
         self.generateBor(self.hklin, self.columns)
         self.generateProgram()
         return CPluginScript.SUCCEEDED

--- a/server/ccp4i2/wrappers/ccp4mg_edit_model/script/ccp4mg_edit_model.py
+++ b/server/ccp4i2/wrappers/ccp4mg_edit_model/script/ccp4mg_edit_model.py
@@ -6,7 +6,9 @@ from lxml import etree
 
 from ccp4i2.core import CCP4Utils
 from ccp4i2.core.CCP4PluginScript import CPluginScript
-from ccp4i2.core.mgimports import PhmmerReportNoGui
+# PhmmerReportNoGui (via ccp4mg) imported lazily at its point of use below, so
+# this plugin stays importable on the slim, CCP4-free API. It runs only at job
+# execution on the CCP4-bearing worker, which also launches CCP4MG itself.
 
 
 class ccp4mg_edit_model(CPluginScript):
@@ -205,6 +207,7 @@ class ccp4mg_edit_model(CPluginScript):
                             shutil.copyfile(log, os.path.join(self.workDirectory,"mrbump_"+os.path.basename(log)))
                     if mrBumpDir is not None:
                         try:
+                            from ccp4i2.core.mgimports import PhmmerReportNoGui  # lazy: ccp4mg, execution only
                             win = PhmmerReportNoGui()
                             win.setResultsDir(mrBumpDir)
                             svg = win.svg(500,short=True)


### PR DESCRIPTION
## What
- **ccp4mg_edit_model**: defer the `PhmmerReportNoGui` import (via
  `ccp4i2.core.mgimports` → `import ccp4mg`) to its single point of use at
  execution.
- **arcimboldo**: replace `distutils.dir_util.copy_tree` (removed in Python 3.12)
  with `shutil.copytree(..., dirs_exist_ok=True)`.

## Why
Both were module-level blockers preventing the plugins from importing on the
slim, CCP4-free API used to configure/validate tasks in the GUI. `copy_tree` was
additionally a hard incompatibility with the slim bundle's CPython 3.13.

`shutil.copytree(dirs_exist_ok=True)` merges into the freshly created work
directory exactly as `copy_tree` did; the PhmmerReportNoGui path runs only on the
CCP4-bearing worker (which also launches CCP4MG).

## Verification
Both import on stock CPython 3.13 with no CCP4 toolkits present. After this, the
**only** remaining slim import-failures are `acorn` (clipper) and `nucleofind`
(bundled ML module) — tracked separately.

Part of the slim/CCP4-free API stream (follows the rdkit/scipy/pandas PR #187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)