### PR TITLE
acorn + nucleofind: last two slim-import blockers -> zero

### DIFF
--- a/server/ccp4i2/wrappers/acorn/script/acorn.py
+++ b/server/ccp4i2/wrappers/acorn/script/acorn.py
@@ -2,7 +2,10 @@ import os
 import sys
 import traceback
 
-import clipper
+# clipper is imported lazily inside the execution methods below (it is used only
+# for the anisotropy correction + E-value calculation at run time, on the
+# CCP4-bearing worker). Keeping it out of module scope lets this plugin import on
+# the slim, CCP4-free API so the task can be configured in the GUI.
 
 from ccp4i2.core import CCP4XtalData
 from ccp4i2.core.CCP4PluginScript import CPluginScript
@@ -14,8 +17,9 @@ class acorn(CPluginScript):
     PERFORMANCECLASS = 'CExpPhasPerformance'
 
     def processInputFiles(self):
+        import clipper  # lazy: anisotropy/E-value calc, only at execution (worker)
         print("Processing INPUT Files - (Acorn)")
-        
+
         # Need to input the necessary input files for an Acorn Run. This will be conditional.
         self.hklin, error = self.makeHklInput([['F_SIGF',CCP4XtalData.CObsDataFile.CONTENT_FLAG_FMEAN]])
 
@@ -111,6 +115,7 @@ class acorn(CPluginScript):
                 return CPluginScript.FAILED
 
     def processOutputFiles(self):
+        import clipper  # lazy: mini-MTZ generation, only at execution (worker)
         # Parse the output text file to create an xml file which can then be parsed by the report to make html .......
         from lxml import etree
         rootNode = etree.Element("acorn")

--- a/server/ccp4i2/wrappers/nucleofind/nucleofind.py
+++ b/server/ccp4i2/wrappers/nucleofind/nucleofind.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from core.CCP4PluginScript import CPluginScript
+from ccp4i2.core.CCP4PluginScript import CPluginScript
 
 
 class nucleofind(CPluginScript):


### PR DESCRIPTION
## What
The final two plugins that could not be imported on the slim, CCP4-free API:

- **acorn**: defer the module-level `import clipper` into its two execution
  methods. clipper is used only at run time (anisotropy correction + E-value
  calculation in `processInputFiles`; mini-MTZ generation in
  `processOutputFiles`), on the CCP4-bearing worker. The maths is untouched.
- **nucleofind**: fix `from core.CCP4PluginScript import CPluginScript` (a stale
  bare-`core` path that only resolved under the legacy layout) to
  `ccp4i2.core.CCP4PluginScript`, matching every other plugin.

## Why
These were the last blockers. With them, **every registered plugin imports on
the slim API** — the GUI can configure/validate any task with no CCP4 install;
only execution needs the full suite.

## Verification
- **slim scan: 0 import-failures** across all TASKS on stock CPython 3.13 + pip
  gemmi with CCP4 absent (down from 26 at the start of this effort).
- i2run **`test_acorn.py` PASSES** under CCP4 — the deferred clipper import fires
  at execution.
- nucleofind's pre-existing i2run failure is a separate ML-tooling CLI gap
  (`--OUTPUT_TYPE RAW` unrecognised), unaffected by this import-path correction.

Completes the slim/CCP4-free plugin-import stream (follows #188). Next: the
`pyproject.toml` packaging capstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)