### PR TITLE
release prep: packaging README + version date for PyPI

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,63 @@
+# ccp4i2
+
+**ccp4i2** is the Python backend of [CCP4i2](https://www.ccp4.ac.uk/) — the
+graphical interface and scripting environment for the CCP4 macromolecular
+crystallography suite. This is the Django/Qt-free generation of CCP4i2: a REST
+API, a task/pipeline framework, and the data-management core that drive the
+CCP4i2 desktop (Electron/React) and web deployments.
+
+## CCP4-free control plane
+
+The control plane — the REST API, task configuration, parameter validation, and
+the container/digest machinery — imports and runs on a **stock Python with no
+CCP4 installation**. Only actual **job execution** (running Refmac, Phaser,
+Servalcat, …) needs the full CCP4 suite, and that always happens out-of-process
+on a CCP4-bearing worker.
+
+In practice that means you can `pip install ccp4i2` into a plain virtual
+environment to configure and validate tasks, serve the API, and drive the
+frontend; the crystallographic binaries and their toolkits (clipper, iotbx,
+mmtbx, ccp4mg, phaser, dials, xia2, …) are supplied by CCP4 at execution time and
+are deliberately **not** pip dependencies.
+
+## Installation
+
+```bash
+pip install ccp4i2
+```
+
+Optional extras:
+
+```bash
+pip install ccp4i2[science]   # rdkit, scipy, pandas — fuller local execution
+pip install ccp4i2[dev]       # test/lint toolchain (pytest, mypy, black, …)
+```
+
+`ccp4i2` depends on the shared
+[`ccp4i2-api`](https://pypi.org/project/ccp4i2-api/) library (authentication +
+DRF integration), which is installed automatically.
+
+> **Note** — `demo_data` (the ~400 MB of example datasets used by the test/demo
+> workflows) is **not** bundled in the package; it is distributed out-of-band.
+
+## Running
+
+```bash
+export DJANGO_SETTINGS_MODULE=ccp4i2.config.settings
+
+# i2run — run a task from the command line
+i2run <task> --project_name <proj> [--PARAM value ...]
+
+# development server
+python -m uvicorn ccp4i2.config.asgi:application
+```
+
+## Links
+
+- CCP4: https://www.ccp4.ac.uk/
+- Source: https://github.com/ccp4/ccp4i2
+- Documentation: https://www.ccp4.ac.uk/html/INDEX.html
+
+## Licence
+
+LGPL-3.0. See the repository for full licensing details.

--- a/server/ccp4i2/__init__.py
+++ b/server/ccp4i2/__init__.py
@@ -16,7 +16,7 @@ MINOR = 0
 PATCH = 0
 
 __version__ = f"{MAJOR}.{MINOR}.{PATCH}"
-__version_date__ = datetime(2025, 12, 10)
+__version_date__ = datetime(2026, 6, 15)
 __version_info__ = (MAJOR, MINOR, PATCH)
 
 I2_TOP = Path(__file__).resolve().parent


### PR DESCRIPTION
## What
Final pre-publish tidy-up for the `ccp4i2` PyPI package.

- **Add `server/README.md`** — `pyproject` declares `readme = "README.md"` and is
  built from `server/`, where no README existed, so `long_description` was empty
  and `twine check` warned. The new README is PyPI-focused (CCP4-free control
  plane, `pip install` + `[science]`/`[dev]` extras, `ccp4i2-api` relationship,
  demo_data distributed out-of-band).
- **Refresh `__version_date__`** to the 3.0.0 release date.

## Verification
`twine check` now **PASSES with no warnings** on both the sdist and the wheel
(`Description-Content-Type: text/markdown`). Wheel install-verified earlier in a
fresh CPython 3.13 venv with no CCP4.

Sets up the TestPyPI dry-run of `ccp4i2` 3.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)