### PR TITLE
API: environment-aware local-execution feasibility for run_local

### DIFF
--- a/server/ccp4i2/api/JobViewSet.py
+++ b/server/ccp4i2/api/JobViewSet.py
@@ -950,18 +950,62 @@ class JobViewSet(ModelViewSet):
             - Synchronous mode is useful for scripting and automation
         """
         try:
-            from ..lib.utils.jobs.context_run import run_job_context_aware
+            from ..lib.utils.jobs.context_run import (
+                run_job_context_aware,
+                can_run_local,
+                ccp4_available,
+            )
 
             job = models.Job.objects.get(id=pk)
 
-            # Parse synchronous parameter from request body
+            # Parse request body: synchronous, and an optional on_unavailable hint
+            # ("queue" => fall back to async dispatch instead of being told no).
             synchronous = False
+            on_unavailable = None
             if request.body:
                 try:
                     body_data = json.loads(request.body.decode("utf-8"))
                     synchronous = body_data.get("synchronous", False)
+                    on_unavailable = body_data.get("on_unavailable")
                 except (json.JSONDecodeError, UnicodeDecodeError):
-                    pass  # Use default (False) if body is invalid
+                    pass  # Use defaults if body is invalid
+
+            # Pre-flight feasibility: the client *requests* local execution, but the
+            # server decides whether it is actually possible here. A task that needs
+            # a CCP4 binary cannot run inline on a CCP4-free server.
+            if not can_run_local(job.task_name):
+                if on_unavailable == "queue":
+                    # Caller opted into async fallback: dispatch via the normal
+                    # (environment-determined) execution path rather than forcing local.
+                    logger.info(
+                        "Local execution not possible for job %s (task=%s, no CCP4); "
+                        "caller requested queue fallback",
+                        job.id, job.task_name,
+                    )
+                    result = run_job_context_aware(job, synchronous=False)
+                    if result["success"]:
+                        return Response(
+                            {"disposition": "queued",
+                             "reason": "local execution unavailable; dispatched asynchronously",
+                             "job": serializers.JobSerializer(result["data"]).data},
+                            status=202,
+                        )
+                    return api_error(result["error"], status=result["status"])
+
+                # Default: notify and let the caller decide what to do.
+                logger.info(
+                    "Refusing local execution for job %s: task=%s needs CCP4, none on this server",
+                    job.id, job.task_name,
+                )
+                return Response(
+                    {"error": "local_execution_unavailable",
+                     "task": job.task_name,
+                     "reason": (f"task '{job.task_name}' requires a CCP4 installation, "
+                                "which is not present on this server"),
+                     "ccp4_available": ccp4_available(),
+                     "async_available": True},
+                    status=409,
+                )
 
             logger.info(
                 "Forcing local execution for job %s (uuid=%s, task=%s, synchronous=%s)",

--- a/server/ccp4i2/core/tasks.py
+++ b/server/ccp4i2/core/tasks.py
@@ -18,6 +18,12 @@ class Task:
     reportPath: str = None
     runningReport: bool = False
     watchedFile: str = None
+    # True only if the task's execution needs NO CCP4 binary or $CCP4 environment
+    # (e.g. pure gemmi/python). Such tasks may run inline on a CCP4-free server.
+    # Conservative default False: a task is assumed to need CCP4 until proven
+    # otherwise (and verified by the CCP4-free behavioural guard). See
+    # lib/utils/jobs/context_run.can_run_local().
+    ccp4_free: bool = False
 
 
 TASKS = {
@@ -129,6 +135,7 @@ TASKS = {
         pluginPath="ccp4i2.wrappers.ProvideAsuContents.script.ProvideAsuContents:ProvideAsuContents",
         defXmlPath="wrappers/ProvideAsuContents/script/ProvideAsuContents.def.xml",
         reportPath="ccp4i2.wrappers.ProvideAsuContents.script.ProvideAsuContents_report:ProvideAsuContents_report",
+        ccp4_free=True,  # gemmi-native Matthews (no matthews_coef binary)
     ),
     "ProvideSequence": Task(
         shortTitle="Import Sequence",
@@ -391,6 +398,7 @@ TASKS = {
         pluginPath="ccp4i2.wrappers.coordinate_selector.script.coordinate_selector:coordinate_selector",
         defXmlPath="wrappers/coordinate_selector/script/coordinate_selector.def.xml",
         reportPath="ccp4i2.wrappers.coordinate_selector.script.coordinate_selector_report:coordinate_selector_report",
+        ccp4_free=True,  # pure gemmi/file ops
     ),
     "coot1": Task(
         title="Coot 1",
@@ -947,6 +955,7 @@ TASKS = {
         shortTitle="MTZ Header",
         pluginPath="ccp4i2.wrappers.mtzheader.script.mtzheader:mtzheader",
         defXmlPath="wrappers/mtzheader/script/mtzheader.def.xml",
+        ccp4_free=True,  # gemmi-native MTZ header read
     ),
     "mtzutils": Task(
         title="Add or delete MTZ columns",
@@ -1347,6 +1356,7 @@ TASKS = {
         pluginPath="ccp4i2.wrappers.splitMtz.script.splitMtz:splitMtz",
         defXmlPath="wrappers/splitMtz/script/splitMtz.def.xml",
         reportPath="ccp4i2.wrappers.splitMtz.script.splitMtz_report:splitMtz_report",
+        ccp4_free=True,  # gemmi-native MTZ split
     ),
     "tableone": Task(
         title="Generate Table One",

--- a/server/ccp4i2/lib/utils/jobs/context_run.py
+++ b/server/ccp4i2/lib/utils/jobs/context_run.py
@@ -29,11 +29,54 @@ Example Usage:
 import os
 import json
 import logging
+import functools
+import shutil
 import subprocess
 import pathlib
 import sys
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def ccp4_available():
+    """True if this server has a usable CCP4 installation (can run CCP4 binaries).
+
+    A CCP4-free deployment (e.g. the slim Django API container) returns False, so
+    callers can decide not to attempt local execution of tasks that need a binary.
+    Cached: the environment is fixed for the life of the server process.
+    """
+    ccp4 = os.environ.get("CCP4")
+    if not ccp4 or not os.path.isdir(ccp4):
+        return False
+    # Probe a core CCP4 program ('cad' is present in any real install).
+    if shutil.which("cad"):
+        return True
+    return os.path.exists(os.path.join(ccp4, "bin", "cad"))
+
+
+def task_requires_ccp4(task_name):
+    """True unless the task is declared ccp4_free in the registry.
+
+    Conservative: an unknown or unflagged task is assumed to need CCP4.
+    """
+    try:
+        from ccp4i2.core.tasks import TASKS
+        task = TASKS.get(task_name)
+    except Exception:
+        task = None
+    return not bool(task and getattr(task, "ccp4_free", False))
+
+
+def can_run_local(task_name):
+    """Whether `task_name` can be executed locally in this environment.
+
+    True if either the server has CCP4, or the task needs no CCP4 (ccp4_free).
+    This is the server-side feasibility decision behind the run_local endpoint:
+    the client may *request* local execution, but the server reports whether it
+    is actually possible here.
+    """
+    return ccp4_available() or not task_requires_ccp4(task_name)
 
 
 def _lazy_import_azure_servicebus():

--- a/server/ccp4i2/tests/unit/lib/test_local_feasibility.py
+++ b/server/ccp4i2/tests/unit/lib/test_local_feasibility.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for the environment-aware local-execution feasibility logic
+(ccp4i2.lib.utils.jobs.context_run): ccp4_available / task_requires_ccp4 /
+can_run_local. These are the server-side decision behind the run_local endpoint
+— the client may *request* local execution, but the server decides whether it is
+actually possible in this environment.
+
+Pure functions, no database; run on a CCP4-free interpreter.
+"""
+import pytest
+
+from ccp4i2.lib.utils.jobs import context_run
+
+
+class TestTaskRequiresCCP4:
+    def test_unflagged_task_requires_ccp4(self):
+        # freerflag shells out to the freerflag binary -> not ccp4_free
+        assert context_run.task_requires_ccp4("freerflag") is True
+
+    def test_unknown_task_is_conservative(self):
+        assert context_run.task_requires_ccp4("no_such_task_xyz") is True
+
+    @pytest.mark.parametrize(
+        "task", ["ProvideAsuContents", "coordinate_selector", "splitMtz", "mtzheader"]
+    )
+    def test_ccp4_free_tasks_do_not_require_ccp4(self, task):
+        assert context_run.task_requires_ccp4(task) is False
+
+
+class TestCanRunLocal:
+    def test_no_ccp4_ccp4free_task_allowed(self, monkeypatch):
+        monkeypatch.setattr(context_run, "ccp4_available", lambda: False)
+        assert context_run.can_run_local("ProvideAsuContents") is True
+
+    def test_no_ccp4_binary_task_refused(self, monkeypatch):
+        monkeypatch.setattr(context_run, "ccp4_available", lambda: False)
+        assert context_run.can_run_local("freerflag") is False
+
+    def test_with_ccp4_anything_allowed(self, monkeypatch):
+        monkeypatch.setattr(context_run, "ccp4_available", lambda: True)
+        assert context_run.can_run_local("freerflag") is True
+        assert context_run.can_run_local("ProvideAsuContents") is True
+
+
+class TestCCP4Available:
+    def test_false_without_ccp4_env(self, monkeypatch):
+        context_run.ccp4_available.cache_clear()
+        monkeypatch.delenv("CCP4", raising=False)
+        try:
+            assert context_run.ccp4_available() is False
+        finally:
+            context_run.ccp4_available.cache_clear()
+
+    def test_false_when_ccp4_points_nowhere(self, monkeypatch):
+        context_run.ccp4_available.cache_clear()
+        monkeypatch.setenv("CCP4", "/nonexistent/ccp4/path/zzz")
+        try:
+            assert context_run.ccp4_available() is False
+        finally:
+            context_run.ccp4_available.cache_clear()


### PR DESCRIPTION
## What
Move the "can this task run inline here?" decision from the **client** into the
**API**, which is the component that actually knows its own environment.

## Why
Today each client dialog calls `run_local` for specific tasks and the server
obeys `force_local` unconditionally. Any non-client caller (script, i2run, third
party) bypasses that policy, and a task that needs a CCP4 binary gets attempted
on a CCP4-free server and **fails late** — exactly what bit `matthewsCoeff` (411)
and what `freerflag` would do next. The policy belongs server-side.

## How
- **`core/tasks.py`** — add a conservative `ccp4_free` flag to the `Task`
  registry (**default `False`**: a task is assumed to need CCP4 until proven
  otherwise). Verified gemmi-native inline tasks flagged `True`:
  `ProvideAsuContents`, `coordinate_selector`, `splitMtz`, `mtzheader`.
- **`lib/utils/jobs/context_run.py`** — `ccp4_available()` (cached env probe),
  `task_requires_ccp4()`, `can_run_local(task)` = `ccp4_available or ccp4_free`.
- **`api/JobViewSet.run_local`** — **pre-flight feasibility**. The client
  *requests* local; the server decides. If not possible (binary task on a
  CCP4-free server) it returns a structured **`409`**:
  ```json
  { "error": "local_execution_unavailable", "task": "freerflag",
    "reason": "...", "ccp4_available": false, "async_available": true }
  ```
  A *notification*, not a silent reroute — the caller decides. Optional
  `"on_unavailable": "queue"` body hint opts into async fallback (`202
  {disposition: "queued"}`).

## Notes
- Protects **every** caller (client and direct API); turns late binary-exec
  failures into a clean pre-flight verdict.
- **No `ccp4i2-api` bump** — the shared lib is auth/transport only; CCP4
  task-execution feasibility is ccp4i2 domain, and Materia never runs CCP4 jobs.
- Backward-compatible on a CCP4-present (desktop) server: `can_run_local` is True
  for everything, so behaviour is unchanged.

## Tests
`tests/unit/lib/test_local_feasibility.py` — **11 pure-function tests, CCP4-free,
no DB**. Verified on a CCP4-free interpreter: `can_run_local` is True for
`ProvideAsuContents` (ccp4_free) and False for `freerflag` (would 409).

First of the env-aware-execution trio (this), then the behavioural CI guard
(proves `ccp4_free=True` tasks really are binary-free), then gemmi-port freerflag
to flip it to `ccp4_free=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)