### PR TITLE
Fix dm_multidomain NCS mask/operator frame mismatch (out-of-cell reference)

### DIFF
--- a/server/ccp4i2/tests/unit/plugins/test_dm_ncs_lib.py
+++ b/server/ccp4i2/tests/unit/plugins/test_dm_ncs_lib.py
@@ -1,0 +1,69 @@
+"""Unit tests for dm_multidomain's gemmi-only NCS helpers (no CCP4 binaries).
+
+Guards the mask/operator frame-consistency bug: the AHIR reference DARPIN sits
+OUTSIDE the primary unit cell (fractional y<0), so a naive set_points_around
+PBC-wraps the averaging mask ~118 A away from where the operators point, and dm
+then reports spurious ~0 NCS correlation. write_domain_mask and
+operator_ref_to_copy must bring the reference into the cell with the SAME shift.
+"""
+import os
+
+import gemmi
+import numpy as np
+import pytest
+
+import ccp4i2
+from ccp4i2.wrappers.dm_multidomain.script import dm_ncs_lib as L
+
+_MODEL = os.path.join(os.path.dirname(ccp4i2.__file__),
+                      "demo_data", "ahir", "ahir_model.cif")
+
+
+@pytest.fixture(scope="module")
+def model():
+    if not os.path.exists(_MODEL):
+        pytest.skip("AHIR demo model not present")
+    st = gemmi.read_structure(_MODEL)
+    st.setup_entities()
+    return st
+
+
+def test_reference_darpin_is_outside_cell(model):
+    """Precondition: the thing that triggered the bug actually holds here."""
+    cell = model.cell
+    fr = [cell.fractionalize(p)
+          for p in L.ca_positions(model[0], "A", 13, 139).values()]
+    assert min(f.y for f in fr) < 0.0   # DARPIN reaches outside [0,1)
+
+
+def test_mask_lands_on_domain_not_lattice_image(model, tmp_path):
+    m = model[0]
+    cell, sg = model.cell, model.find_spacegroup()
+    mask = str(tmp_path / "darpin.msk")
+    n = L.write_domain_mask(m, "A", 13, 139, cell, sg, mask, radius=2.5)
+    assert n > 1000
+
+    # reference atoms shifted into the cell with the SAME shift the mask used
+    s = L._lattice_shift(list(L.ca_positions(m, "A", 13, 139).values()), cell)
+    ref = np.array([list(L._shift(p, s, cell))
+                    for p in L.all_atom_positions(m, "A", 13, 139)])
+
+    grid = gemmi.read_ccp4_mask(mask).grid
+    idx = np.argwhere(np.array(grid, copy=False) > 0)[:3000]
+    pos = np.array([list(grid.get_position(int(i), int(j), int(k)))
+                    for i, j, k in idx])
+    # every mask point must sit within ~ (radius + a grid step) of the domain,
+    # NOT a lattice vector (~100 A) away
+    from scipy.spatial import cKDTree
+    d = cKDTree(ref).query(pos)[0]
+    assert d.mean() < 3.0, f"mask displaced from domain (mean {d.mean():.1f} A)"
+
+
+def test_operator_targets_intended_copy(model):
+    """Each A->copy operator must superpose A's domain onto THAT copy."""
+    m = model[0]
+    cell = model.cell
+    ref_ca = L.ca_positions(m, "A", 13, 139)
+    for c in ["B", "C", "D", "E", "F"]:
+        T, rmsd = L.operator_ref_to_copy(m, "A", c, 13, 139, cell=cell)
+        assert rmsd < 1.5   # genuine superposition onto that copy

--- a/server/ccp4i2/wrappers/dm_multidomain/script/dm_multidomain.py
+++ b/server/ccp4i2/wrappers/dm_multidomain/script/dm_multidomain.py
@@ -112,7 +112,7 @@ class dm_multidomain(CPluginScript):
                 if d['mode'] == 'exclude':
                     continue
                 ops, rmsds = dm_ncs_lib.domain_operators(
-                    model, ref, copies, d['lo'], d['hi'])
+                    model, ref, copies, d['lo'], d['hi'], cell=cell)
                 operators_by_domain[d['name']] = ops
                 rmsd_str = ", ".join(f"{c}:{r:.2f}" for c, r in rmsds.items())
                 print(f"  domain {d['name']} ({d['lo']}-{d['hi']}, {d['mode']}): "

--- a/server/ccp4i2/wrappers/dm_multidomain/script/dm_ncs_lib.py
+++ b/server/ccp4i2/wrappers/dm_multidomain/script/dm_ncs_lib.py
@@ -108,12 +108,36 @@ def _rmsd(a, b):
          for p, q in zip(a, b)])))
 
 
-def operator_ref_to_copy(model, ref, copy, lo, hi):
+def _lattice_shift(positions, cell):
+    """Integer lattice vector that brings the centroid of `positions` into the
+    primary cell [0,1). Computed from CA-style positions so the mask and the
+    operators use an IDENTICAL shift."""
+    import math
+    fr = [cell.fractionalize(p) for p in positions]
+    n = len(fr)
+    cen = (sum(f.x for f in fr) / n, sum(f.y for f in fr) / n,
+           sum(f.z for f in fr) / n)
+    return (-math.floor(cen[0]), -math.floor(cen[1]), -math.floor(cen[2]))
+
+
+def _shift(p, s, cell):
+    f = cell.fractionalize(p)
+    return cell.orthogonalize(gemmi.Fractional(f.x + s[0], f.y + s[1],
+                                               f.z + s[2]))
+
+
+def operator_ref_to_copy(model, ref, copy, lo, hi, cell=None):
     """(gemmi.Transform T, rmsd) with T mapping REFERENCE coords -> COPY coords.
 
     Self-orienting: compute a superposition, then keep whichever of T / T^-1
     actually maps ref->copy. Independent of gemmi's internal convention.
     Raises ValueError if fewer than 3 common CA atoms are available.
+
+    If `cell` is given, the reference is first brought into the primary unit
+    cell (rigid lattice shift) so the operator shares the frame of the
+    PBC-wrapped averaging mask -- otherwise, for a reference copy outside
+    [0,1), dm would average density displaced by a lattice vector and report
+    spurious ~0 NCS correlation.
     """
     ref_ca = ca_positions(model, ref, lo, hi)
     cp_ca = ca_positions(model, copy, lo, hi)
@@ -123,6 +147,9 @@ def operator_ref_to_copy(model, ref, copy, lo, hi):
             f"<3 common CA atoms between {ref} and {copy} in {lo}-{hi}")
     ref_pts = [ref_ca[n] for n in common]
     cp_pts = [cp_ca[n] for n in common]
+    if cell is not None:
+        s = _lattice_shift(ref_pts, cell)
+        ref_pts = [_shift(p, s, cell) for p in ref_pts]
 
     sup = gemmi.superpose_positions(cp_pts, ref_pts)
     T = sup.transform
@@ -143,7 +170,7 @@ def transform_to_dm(T):
     return rota, tran
 
 
-def domain_operators(model, ref, copies, lo, hi):
+def domain_operators(model, ref, copies, lo, hi, cell=None):
     """List of (rota, tran) dm lines for a domain: identity first, then ref->copy_n.
 
     Also returns the per-copy RMSDs for diagnostics/logging.
@@ -151,7 +178,7 @@ def domain_operators(model, ref, copies, lo, hi):
     ops = [IDENTITY_DM]
     rmsds = {}
     for c in copies:
-        T, rmsd = operator_ref_to_copy(model, ref, c, lo, hi)
+        T, rmsd = operator_ref_to_copy(model, ref, c, lo, hi, cell=cell)
         ops.append(transform_to_dm(T))
         rmsds[c] = rmsd
     return ops, rmsds
@@ -168,8 +195,12 @@ def write_domain_mask(model, ref, lo, hi, cell, spacegroup, path,
     g.unit_cell = cell
     g.spacegroup = spacegroup
     g.set_size_from_spacing(spacing, gemmi.GridSizeRounding.Up)
+    # Bring the reference into the cell with the SAME shift the operators use
+    # (computed from the reference CA centroid), so set_points_around's PBC
+    # wrap cannot displace the mask relative to the operators.
+    s = _lattice_shift(list(ca_positions(model, ref, lo, hi).values()), cell)
     for p in all_atom_positions(model, ref, lo, hi):
-        g.set_points_around(p, radius=radius, value=1)
+        g.set_points_around(_shift(p, s, cell), radius=radius, value=1)
     ccp4 = gemmi.Ccp4Mask()
     ccp4.grid = g
     ccp4.update_ccp4_header()


### PR DESCRIPTION
## The bug
`dm_multidomain` builds per-domain NCS averaging masks with `set_points_around`, which PBC-wraps points into the primary unit cell. When the **reference copy sits outside [0,1)** — e.g. the AHIR DARPIN at fractional y<0 — the mask landed **~118 Å** from where the operators (derived in the model coordinate frame) pointed. dm then averaged density a lattice vector away and reported a spurious **~0 NCS correlation** with an `initial value too low` ERROR — making an ordered, NCS-related domain look un-averageable.

## The fix
Bring the reference into the cell with a single rigid lattice shift, using the **same** shift (from the reference CA centroid) for **both** the mask (`write_domain_mask`) and the operator superposition (`operator_ref_to_copy`), so they share a frame.

## Effect (AHIR DARPIN)
- dm NCS correlation: `~0 (ERROR)` → **0.61 → 0.75 (OK)**, consistent with the 0.77–0.87 real-space inter-copy density correlation.

## Tests
Adds `tests/unit/plugins/test_dm_ncs_lib.py` (gemmi-only): the AHIR reference DARPIN is confirmed outside the cell, the mask must land on the domain (not ~100 Å away), and each operator must superpose onto its intended copy. i2run tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)