### PR TITLE
freerflag: gemmi/numpy-native free-R generation, drop the binary

### DIFF
--- a/server/ccp4i2/core/tasks.py
+++ b/server/ccp4i2/core/tasks.py
@@ -675,6 +675,7 @@ TASKS = {
         pluginPath="ccp4i2.wrappers.freerflag.script.freerflag:freerflag",
         defXmlPath="wrappers/freerflag/script/freerflag.def.xml",
         reportPath="ccp4i2.wrappers.freerflag.script.freerflag_report:freerflag_report",
+        ccp4_free=True,  # gemmi-native free-R generation (no freerflag binary)
     ),
     "gesamt": Task(
         title="Structural alignment - Gesamt",

--- a/server/ccp4i2/tests/parity/test_freerflag_parity.py
+++ b/server/ccp4i2/tests/parity/test_freerflag_parity.py
@@ -1,0 +1,60 @@
+"""
+Parity test: gemmi/numpy-native free-R assignment vs the CCP4 freerflag binary.
+
+freerflag's exact byte stream is *not* reproducible (it bottoms out in the
+compiler's RNG, which is gfortran-version-dependent), so this checks *statistical*
+parity rather than flag-for-flag: native and binary must land in the same regime
+(valid range, same free fraction, ~same number of segments). Skipped when the
+freerflag binary is absent (i.e. on a slim CCP4-free interpreter).
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+
+import numpy as np
+import gemmi
+import pytest
+
+from ccp4i2 import I2_TOP
+from ccp4i2.wrappers.freerflag.script.freerflag import assign_class_flags
+
+FREERFLAG = shutil.which("freerflag")
+pytestmark = pytest.mark.skipif(FREERFLAG is None, reason="freerflag binary not on PATH")
+
+MTZ = I2_TOP / "demo_data" / "gamma" / "HKLOUT_unmerged.mtz"
+IRFRAC = 20
+
+
+def _binary_flags(mtz_path, frac=0.05):
+    out = tempfile.mktemp(suffix=".mtz")
+    subprocess.run([FREERFLAG, "HKLIN", str(mtz_path), "HKLOUT", out],
+                   input=f"FREERFRAC {frac}\nEND\n", text=True,
+                   capture_output=True, timeout=60)
+    m = gemmi.read_mtz_file(out)
+    os.unlink(out)
+    col = next(c for c in m.columns
+               if c.type == 'I' and 'free' in c.label.lower())
+    return np.array(col, dtype=int)
+
+
+def test_native_and_binary_same_regime():
+    m = gemmi.read_mtz_file(str(MTZ))
+    hkl = np.array(m, copy=False)[:, :3].astype(int)
+    native, _ = assign_class_flags(hkl, m.spacegroup, IRFRAC)
+    binary = _binary_flags(MTZ)
+
+    # Both must produce valid flags in [0, IRFRAC-1]
+    assert 0 <= native.min() and native.max() <= IRFRAC - 1
+    assert 0 <= binary.min() and binary.max() <= IRFRAC - 1
+
+    # Both must hold out ~1/IRFRAC as the free set, and agree with each other
+    fn = (native == 0).mean()
+    fb = (binary == 0).mean()
+    assert 0.03 <= fn <= 0.07, f"native free fraction {fn}"
+    assert 0.03 <= fb <= 0.07, f"binary free fraction {fb}"
+    assert abs(fn - fb) < 0.02, f"native {fn} vs binary {fb} free fraction differ too much"
+
+    # Both should use the full set of segments (0..IRFRAC-1)
+    assert len(np.unique(binary)) == IRFRAC
+    assert len(np.unique(native)) == IRFRAC

--- a/server/ccp4i2/tests/unit/mtz/test_freerflag_native.py
+++ b/server/ccp4i2/tests/unit/mtz/test_freerflag_native.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for the gemmi/numpy-native free-R assignment (freerflag.assign_class_flags),
+which replaced the CCP4 freerflag binary. These run CCP4-free and assert the
+*semantics* we reproduce from freerflag (binning, free set = 0, one draw per
+symmetry-equivalence class so equivalents share a flag, reproducibility).
+Statistical parity with the binary is covered by tests/parity/test_freerflag_parity.py.
+"""
+from collections import defaultdict
+
+import numpy as np
+import gemmi
+import pytest
+
+from ccp4i2 import I2_TOP
+from ccp4i2.wrappers.freerflag.script.freerflag import assign_class_flags
+
+# unmerged demo data: has symmetry-equivalent reflections, so the sharing
+# invariant is non-trivial here.
+MTZ = I2_TOP / "demo_data" / "gamma" / "HKLOUT_unmerged.mtz"
+IRFRAC = 20  # 1/0.05
+
+
+@pytest.fixture
+def mtz():
+    return gemmi.read_mtz_file(str(MTZ))
+
+
+def _hkl(mtz):
+    return np.array(mtz, copy=False)[:, :3].astype(int)
+
+
+def test_flags_in_valid_range(mtz):
+    flags, _ = assign_class_flags(_hkl(mtz), mtz.spacegroup, IRFRAC)
+    assert flags.min() >= 0
+    assert flags.max() <= IRFRAC - 1
+
+
+def test_free_fraction_near_target(mtz):
+    flags, _ = assign_class_flags(_hkl(mtz), mtz.spacegroup, IRFRAC)
+    frac = (flags == 0).mean()
+    assert 0.03 <= frac <= 0.07, f"free fraction {frac} not near 1/{IRFRAC}"
+
+
+def test_symmetry_equivalents_share_a_flag(mtz):
+    flags, keys = assign_class_flags(_hkl(mtz), mtz.spacegroup, IRFRAC)
+    by_class = defaultdict(set)
+    for f, k in zip(flags, keys):
+        by_class[k].add(int(f))
+    # every equivalence class has exactly one flag
+    assert all(len(s) == 1 for s in by_class.values())
+    # and there really are multi-reflection classes here (else the test is vacuous)
+    sizes = defaultdict(int)
+    for k in keys:
+        sizes[k] += 1
+    assert max(sizes.values()) > 1, "expected symmetry-equivalent reflections in unmerged data"
+
+
+def test_reproducible_for_fixed_seed(mtz):
+    a, _ = assign_class_flags(_hkl(mtz), mtz.spacegroup, IRFRAC)
+    b, _ = assign_class_flags(_hkl(mtz), mtz.spacegroup, IRFRAC)
+    assert np.array_equal(a, b)
+
+
+def test_seed_changes_assignment(mtz):
+    a, _ = assign_class_flags(_hkl(mtz), mtz.spacegroup, IRFRAC, seed=1)
+    b, _ = assign_class_flags(_hkl(mtz), mtz.spacegroup, IRFRAC, seed=2)
+    assert not np.array_equal(a, b)

--- a/server/ccp4i2/wrappers/freerflag/script/freerflag.py
+++ b/server/ccp4i2/wrappers/freerflag/script/freerflag.py
@@ -1,15 +1,43 @@
 import os
 
 import gemmi
+import numpy as np
 from lxml import etree
 
 from ccp4i2.core import CCP4ErrorHandling, CCP4Utils
 from ccp4i2.core.CCP4PluginScript import CPluginScript
 
+# Fixed seed so a re-run reproduces the same free set -- the reproducibility
+# property of CCP4 freerflag (whose default also uses iseed=123456789). The
+# native implementation reproduces freerflag's *semantics* (binning into
+# 1/fraction segments, free set = flag 0, one draw per symmetry-equivalence
+# class so equivalents share a flag) rather than its exact byte stream, which
+# bottoms out in the compiler's RNG and is gfortran-version-dependent.
+FREER_SEED = 123456789
+
+
+def assign_class_flags(hkl, spacegroup, irfrac, seed=FREER_SEED):
+    """Free-R flags reproducing freerflag's semantics.
+
+    One random draw per symmetry/Friedel equivalence class (so equivalent
+    reflections share a flag), values in [0, irfrac-1] with the free set = 0,
+    reproducible for a fixed seed.
+
+    Returns (flags array of length len(hkl), list of per-reflection class keys).
+    """
+    gops = spacegroup.operations()
+    asu = gemmi.ReciprocalAsu(spacegroup)
+    keys = [tuple(asu.to_asu((int(h[0]), int(h[1]), int(h[2])), gops)[0]) for h in hkl]
+    rng = np.random.default_rng(seed)
+    class_flag = {k: int(rng.integers(0, irfrac)) for k in sorted(set(keys))}
+    flags = np.array([class_flag[k] for k in keys], dtype=int)
+    return flags, keys
+
 
 class freerflag(CPluginScript):
     TASKNAME = 'freerflag'
-    TASKCOMMAND = 'freerflag'
+    # gemmi/numpy-native: no CCP4 binary (see generateFreeR). Removing TASKCOMMAND
+    # is what lets this run inline on a CCP4-free server (ccp4_free=True).
 
     # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     def processInputFiles(self):
@@ -83,29 +111,120 @@ class freerflag(CPluginScript):
 
     # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     def makeCommandAndScript(self):
-      self.hklout = os.path.join(self.workDirectory,"hklout.mtz")
-
-      self.appendCommandLine(['HKLIN', self.hklin])
-      self.appendCommandLine(['HKLOUT', self.hklout])
-
+      # Native task: no external command. Just fix the output path and validate.
+      self.hklout = os.path.join(self.workDirectory, "hklout.mtz")
       if self.container.controlParameters.GEN_MODE == 'COMPLETE':
-          if self.container.inputData.FREERFLAG.isSet():
-            self.appendCommandScript("COMPLETE FREE=FREER")
-          else:
-            self.appendErrorReport(101)
-      else:
-          # FREERFLAG keyword only applies if not completing existing freeR set
-          if self.container.controlParameters.FRAC.isSet():
-              self.appendCommandScript("FREERFRAC %s"%(str(self.container.controlParameters.FRAC)))
-
-      if self.container.controlParameters.UNIQUEIFY:
-          self.appendCommandScript("UNIQUE")
-          if self.container.controlParameters.RESMAX:
-              self.appendCommandScript("RESOL %s"%(str(self.container.controlParameters.RESMAX)))
-
-      self.appendCommandScript('END')
-
+          if not self.container.inputData.FREERFLAG.isSet():
+              self.appendErrorReport(101)
       return 0
+
+    # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    def startProcess(self, command=None, **kwargs):
+      # Generate the free-R flags in-process with gemmi/numpy (no CCP4 binary).
+      try:
+          self.generateFreeR()
+      except Exception as e:
+          import traceback
+          traceback.print_exc()
+          self.appendErrorReport(102, str(e))
+          return CPluginScript.FAILED
+      return CPluginScript.SUCCEEDED
+
+    # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    def postProcessCheck(self, processId=None):
+      # No subprocess ran; success is simply that hklout was written.
+      if os.path.isfile(self.hklout):
+          return self.SUCCEEDED, self.SUCCEEDED, 0
+      return self.FAILED, self.FAILED, 1
+
+    # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+    def _irfrac(self):
+      cp = self.container.controlParameters
+      rfrac = float(cp.FRAC) if cp.FRAC.isSet() else 0.05
+      if not (0.0 < rfrac < 1.0):
+          rfrac = 0.05
+      return int(round(1.0 / rfrac))
+
+    def _class_keyer(self, spacegroup):
+      gops = spacegroup.operations()
+      asu = gemmi.ReciprocalAsu(spacegroup)
+
+      def key(h):
+          # ASU representative merges symmetry- and Friedel-equivalent reflections,
+          # so they all land in the same class (and thus share a flag).
+          rep, _isym = asu.to_asu((int(h[0]), int(h[1]), int(h[2])), gops)
+          return (rep[0], rep[1], rep[2])
+      return key
+
+    def generateFreeR(self):
+      cp = self.container.controlParameters
+      complete = (str(cp.GEN_MODE) == 'COMPLETE')
+      uniqueify = bool(cp.UNIQUEIFY)
+
+      mtz = gemmi.read_mtz_file(self.hklin)
+      spacegroup = mtz.spacegroup or gemmi.SpaceGroup('P 1')
+      key = self._class_keyer(spacegroup)
+      rng = np.random.default_rng(FREER_SEED)
+
+      data = np.array(mtz, copy=True)
+      hkl = data[:, :3].astype(int)
+
+      if complete:
+          # Preserve existing flags, fill only the missing ones (per class).
+          idx = self._freer_column_index(mtz)
+          existing = data[:, idx].astype(float)
+          present = ~np.isnan(existing)
+          irfrac = (int(round(existing[present].max())) + 1) if present.any() else self._irfrac()
+          keys = [key(h) for h in hkl]
+          class_flag = {}
+          # seed class flags from reflections that already have one
+          for i, kk in enumerate(keys):
+              if present[i]:
+                  class_flag.setdefault(kk, int(existing[i]))
+          # draw flags for the remaining classes
+          for kk in sorted(set(keys)):
+              class_flag.setdefault(kk, int(rng.integers(0, irfrac)))
+          for i, kk in enumerate(keys):
+              if not present[i]:
+                  existing[i] = class_flag[kk]
+          data[:, idx] = existing
+          mtz.set_data(data)
+      else:
+          irfrac = self._irfrac()
+          if uniqueify:
+              hkl, data = self._complete_to_unique(mtz, data)
+          flags, _keys = assign_class_flags(hkl, spacegroup, irfrac, seed=FREER_SEED)
+          mtz.add_column('FreeR_flag', 'I')
+          data = np.concatenate([data, flags.reshape(-1, 1).astype(np.float32)], axis=1)
+          mtz.set_data(data)
+
+      mtz.write_to_file(self.hklout)
+
+    def _freer_column_index(self, mtz):
+      for j, c in enumerate(mtz.columns):
+          if c.type == 'I' and ('free' in c.label.lower() or 'flag' in c.label.lower()):
+              return j
+      raise RuntimeError("COMPLETE mode: no FreeR (type I) column found in the joined input")
+
+    def _complete_to_unique(self, mtz, data):
+      # UNIQUEIFY: extend the reflection list to the full unique (ASU) set within
+      # the resolution range; generated reflections carry NaN data + a flag.
+      cp = self.container.controlParameters
+      dmin = mtz.resolution_high()
+      if cp.RESMAX.isSet() and float(cp.RESMAX) > 0.0:
+          dmin = float(cp.RESMAX)
+      full = np.array(gemmi.make_miller_array(mtz.cell, mtz.spacegroup, dmin), dtype=int)
+      ncol = data.shape[1]
+      obs = {(int(h[0]), int(h[1]), int(h[2])): data[i] for i, h in enumerate(data[:, :3].astype(int))}
+      rows = np.empty((len(full), ncol), dtype=np.float32)
+      for i, h in enumerate(full):
+          t = (int(h[0]), int(h[1]), int(h[2]))
+          if t in obs:
+              rows[i] = obs[t]
+          else:
+              rows[i] = np.nan
+              rows[i, :3] = h
+      return full, rows
 
     # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
     def processOutputFiles(self):


### PR DESCRIPTION
## What
Reimplement `freerflag` natively (gemmi + numpy) and flip it to `ccp4_free=True`.
It was the second live inline-binary leak the audit found (`TASKCOMMAND='freerflag'`,
run inline by the FreeR-import dialog → would 411 on a CCP4-free server like
matthewsCoeff did).

## Semantics reproduced (not bytes)
- bin into `nint(1/fraction)` segments, **free set = flag 0**;
- **one draw per symmetry/Friedel equivalence class** (`gemmi.ReciprocalAsu`), so
  equivalents share a flag — the invariant that stops test reflections leaking
  into the work set via symmetry mates;
- `GEN_NEW`, `COMPLETE` (preserve existing, fill missing per class), and
  `UNIQUEIFY` (extend to the full ASU via `gemmi.make_miller_array`);
- fixed seed → reproducible across runs.

## Why not bit-exact
The source (`ccp4-progs/freerflag.f90`) seeds a custom xorshift from
`iseed=123456789`, but the **actual draws use gfortran's `RANDOM_NUMBER`
intrinsic** — a compiler artifact that's gfortran-version-dependent. So bit-exact
is heavy *and* fragile (a CCP4 rebuild on newer gfortran changes the binary's own
output). Statistical equivalence is the robust, scientifically-faithful target.

## Verification
- i2run **`test_freerflag.py` passes CCP4-free** (`env -i`, slim venv) **and** under CCP4.
- behavioural guard now includes `freerflag` and passes (ccp4_free, no TASKCOMMAND).
- native unit tests (5, CCP4-free): valid range, ~5% free, **symmetry-equivalents
  share a flag**, reproducible, seed-sensitive.
- parity vs the binary: **same statistical regime** (free fraction within 0.02,
  full 0..19 range).

Closes the last known inline-binary leak; the FreeR-import dialog now runs CCP4-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)