### PR TITLE
Classify native crashes (signal / NTSTATUS) distinctly from clean exits

### DIFF
--- a/server/ccp4i2/core/CCP4PluginScript.py
+++ b/server/ccp4i2/core/CCP4PluginScript.py
@@ -24,6 +24,53 @@ from ccp4i2.core.base_object.class_metadata import cdata_class
 logger = logging.getLogger(__name__)
 
 
+# Windows native-crash exit codes (NTSTATUS, returned as large unsigned ints by
+# subprocess). Unlike POSIX, Windows has no negative "killed by signal" code, so
+# crashes surface as these.
+_WINDOWS_CRASH_CODES = {
+    0xC0000005: 'access violation (segfault)',
+    0xC000001D: 'illegal instruction',
+    0xC0000094: 'integer divide by zero',
+    0xC00000FD: 'stack overflow',
+    0xC0000409: 'stack buffer overrun',
+    0xC0000374: 'heap corruption',
+    0x80000003: 'breakpoint / abort',
+}
+
+
+def describe_signal_exit(returncode):
+    """Classify a subprocess return code as a *native crash* vs. a clean error.
+
+    A process that ran and reported a problem exits with a small positive code
+    (1, 2, ...). A process killed by a signal (segfault, abort, illegal
+    instruction) is a different class of failure: the program did not get to
+    report anything, the failure is in native code, and it is worth surfacing
+    distinctly across every executor.
+
+    On POSIX, ``subprocess`` reports signal death as a NEGATIVE return code
+    (``-N`` for signal ``N``). On Windows there are no negative codes; native
+    crashes appear as large unsigned NTSTATUS values (e.g. 0xC0000005).
+
+    Returns a human-readable description if ``returncode`` denotes such a crash,
+    otherwise ``None`` (clean exit, or an ordinary non-zero program error).
+    """
+    if returncode is None:
+        return None
+    if returncode < 0:  # POSIX: terminated by signal -returncode
+        signum = -returncode
+        try:
+            import signal
+            name = signal.Signals(signum).name
+        except (ValueError, AttributeError, ImportError):
+            name = f'SIG{signum}'
+        return f'terminated by {name} (signal {signum})'
+    code = returncode & 0xFFFFFFFF
+    if code >= 0x80000000:  # Windows NTSTATUS crash code
+        desc = _WINDOWS_CRASH_CODES.get(code, 'abnormal termination')
+        return f'{desc} (NTSTATUS 0x{code:08X})'
+    return None
+
+
 @cdata_class(
     error_codes={
         '200': {'description': 'Error merging MTZ files'},
@@ -1749,12 +1796,23 @@ class CPluginScript(CData):
 
             # Check return code
             if result.returncode != 0:
-                error.append(
-                    klass=self.__class__.__name__,
-                    code=101,
-                    details=f"Process {self.TASKCOMMAND} exited with code {result.returncode}",
-                    severity=4  # ERROR
-                )
+                crash = describe_signal_exit(result.returncode)
+                if crash is not None:
+                    # A native crash (signal death / NTSTATUS), not a clean
+                    # program error - flag it as its own class with code 105.
+                    error.append(
+                        klass=self.__class__.__name__,
+                        code=105,
+                        details=f"Process {self.TASKCOMMAND} crashed: {crash}",
+                        severity=4  # ERROR
+                    )
+                else:
+                    error.append(
+                        klass=self.__class__.__name__,
+                        code=101,
+                        details=f"Process {self.TASKCOMMAND} exited with code {result.returncode}",
+                        severity=4  # ERROR
+                    )
 
                 # Read stderr for error details
                 if os.path.exists(stderr_path):
@@ -2072,7 +2130,11 @@ class CPluginScript(CData):
             exit_status = self._exitStatus if hasattr(self, '_exitStatus') else (0 if exit_code == 0 else 1)
             if exit_code != 0:
                 # Process failed - error already added by _startProcessSync
-                logger.debug(f"[postProcessCheck] Returning FAILED due to non-zero exit code: {exit_code}")
+                crash = describe_signal_exit(exit_code)
+                if crash is not None:
+                    logger.warning(f"[postProcessCheck] {self.TASKCOMMAND} crashed: {crash}")
+                else:
+                    logger.debug(f"[postProcessCheck] Returning FAILED due to non-zero exit code: {exit_code}")
                 status = self.FAILED
 
         # For async processes, check the exit code from the process manager
@@ -2085,11 +2147,17 @@ class CPluginScript(CData):
 
             if exit_code is not None and exit_code != 0:
                 # Process failed - add to error report
+                crash = describe_signal_exit(exit_code)
+                if crash is not None:
+                    details = (f'Program {self.TASKCOMMAND} crashed: {crash}. '
+                               f'Check {self.makeFileName("LOG")} and {self.makeFileName("STDERR")} for details.')
+                else:
+                    details = (f'Program {self.TASKCOMMAND} exited with error code {exit_code}. '
+                               f'Check {self.makeFileName("LOG")} and {self.makeFileName("STDERR")} for details.')
                 self.errorReport.append(
                     klass=self.__class__.__name__,
                     code=993,
-                    details=f'Program {self.TASKCOMMAND} exited with error code {exit_code}. '
-                           f'Check {self.makeFileName("LOG")} and {self.makeFileName("STDERR")} for details.',
+                    details=details,
                     name='postProcessCheck',
                     severity=4  # ERROR
                 )

--- a/server/ccp4i2/tests/unit/plugins/test_signal_exit_classification.py
+++ b/server/ccp4i2/tests/unit/plugins/test_signal_exit_classification.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for describe_signal_exit() -- the classifier that distinguishes a
+native crash (signal death / Windows NTSTATUS) from a clean non-zero program
+exit. Pure Python, no CCP4 binaries needed.
+
+This is the mechanism that lets every subprocess boundary in CCP4i2 (external
+binary execution, and the worker's per-job subprocess) report "the process
+crashed in native code" as its own class of failure, instead of laundering a
+SIGSEGV into a generic "exited non-zero".
+"""
+import signal
+
+import pytest
+
+from ccp4i2.core.CCP4PluginScript import describe_signal_exit
+
+
+def test_clean_exit_is_not_a_crash():
+    assert describe_signal_exit(0) is None
+
+
+@pytest.mark.parametrize("code", [1, 2, 3, 42, 255])
+def test_ordinary_nonzero_exit_is_not_a_crash(code):
+    """A program that ran and reported a problem is NOT a crash."""
+    assert describe_signal_exit(code) is None
+
+
+def test_none_returncode_is_not_a_crash():
+    assert describe_signal_exit(None) is None
+
+
+@pytest.mark.parametrize(
+    "sig,expected_name",
+    [
+        (signal.SIGSEGV, "SIGSEGV"),
+        (signal.SIGABRT, "SIGABRT"),
+        (signal.SIGILL, "SIGILL"),
+    ],
+)
+def test_posix_signal_death_is_classified(sig, expected_name):
+    """POSIX subprocess reports signal death as a negative return code."""
+    desc = describe_signal_exit(-int(sig))
+    assert desc is not None
+    assert expected_name in desc
+    assert f"signal {int(sig)}" in desc
+
+
+def test_unknown_negative_code_still_flagged():
+    """An unrecognised signal number is still reported as a crash."""
+    desc = describe_signal_exit(-99)
+    assert desc is not None
+    assert "99" in desc
+
+
+@pytest.mark.parametrize(
+    "code,fragment",
+    [
+        (0xC0000005, "access violation"),
+        (0xC000001D, "illegal instruction"),
+        (0xC00000FD, "stack overflow"),
+    ],
+)
+def test_windows_ntstatus_crash_is_classified(code, fragment):
+    """Windows native crashes surface as large unsigned NTSTATUS exit codes."""
+    desc = describe_signal_exit(code)
+    assert desc is not None
+    assert fragment in desc
+    assert f"0x{code:08X}" in desc
+
+
+def test_unknown_ntstatus_code_still_flagged():
+    desc = describe_signal_exit(0xC0000000)
+    assert desc is not None
+    assert "abnormal termination" in desc

--- a/server/worker.py
+++ b/server/worker.py
@@ -273,12 +273,23 @@ def run_ccp4_analysis(parameters):
                 "stderr": result.stderr,
             }
         else:
-            logger.error("CCP4 analysis failed with return code %s", result.returncode)
+            # Distinguish a native crash of the job subprocess (signal death /
+            # NTSTATUS) from a clean non-zero exit where run_job reported failure
+            # itself. The former means the job process died in native code without
+            # getting to record its own status - worth surfacing explicitly.
+            from ccp4i2.core.CCP4PluginScript import describe_signal_exit
+            crash = describe_signal_exit(result.returncode)
+            if crash is not None:
+                error = "Job process crashed: %s (return code %s)" % (crash, result.returncode)
+                logger.error("CCP4 analysis crashed: %s", crash)
+            else:
+                error = "Command failed with return code %s" % result.returncode
+                logger.error("CCP4 analysis failed with return code %s", result.returncode)
             logger.error("STDOUT: %s", result.stdout)
             logger.error("STDERR: %s", result.stderr)
             return {
                 "status": "failed",
-                "error": "Command failed with return code %s" % result.returncode,
+                "error": error,
                 "stdout": result.stdout,
                 "stderr": result.stderr,
             }


### PR DESCRIPTION
## What

CCP4i2 already isolates two execution boundaries behind a subprocess:

1. **External binary execution** — every wrapper runs its CCP4 binary through `subprocess.run`/`Popen` and captures the return code (`CCP4PluginScript._startProcessSync`).
2. **The worker's per-job subprocess** — the worker spawns the whole job as `ccp4-python -m django run_job ...` and inspects its return code (`worker.run_ccp4_analysis`).

Both already turned a non-zero exit into a FAILED job — but they **flattened a native crash into a generic failure**. A segfault (`-11`/SIGSEGV) or `abort()` (`-6`/SIGABRT) was reported identically to a program that ran and cleanly exited `1`. That hid a whole class of failure: native code dying *without getting to report anything*.

## How

New `describe_signal_exit(returncode)` in `core/CCP4PluginScript.py`:

- **POSIX** signal death surfaces as a **negative** return code (`-N` for signal `N`) → mapped to the signal name (SIGSEGV, SIGABRT, …).
- **Windows** native crashes surface as large unsigned **NTSTATUS** codes (e.g. `0xC0000005` access violation) → mapped to a readable description.
- Returns a description for a genuine crash, `None` for clean exits *and ordinary non-zero program errors* (so `exit(1)` is **not** mislabelled a crash).

Wired into the three places that already capture return codes:

| Site | Before | After |
|------|--------|-------|
| `_startProcessSync` | error code 101, "exited with code N" | crash → code **105**, "crashed: terminated by SIGSEGV (signal 11)" |
| `postProcessCheck` | generic "exited with error code" | crash-specific detail + a `logger.warning` |
| `worker.run_ccp4_analysis` | "Command failed with return code N" | "Job process crashed: …" |

## Why this is the cheap half of a bigger idea

This is the low-risk, high-value slice of "catch a new class of fails in the executors". It does **not** change the in-process sub-plugin boundary (a pipeline calling `validate_protein.process()` in the same interpreter, where a native abort still takes the job process down) — closing that generally is a larger architectural change. But everywhere we are *already* subprocess-isolated, a crash is now first-class and greppable instead of invisible. Companion to #197, which isolated the one known in-process offender (Iris's clipper read).

## Tests

`tests/unit/plugins/test_signal_exit_classification.py` — pure Python, no CCP4 binaries. 15 cases: POSIX signals, Windows NTSTATUS codes, and the important negatives (clean exit and ordinary `exit(1..255)` are NOT reported as crashes). Full `tests/unit/plugins/` suite (59) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)