### PR TITLE
Fragment campaign summary view via moorhen-scenes

### DIFF
--- a/client/renderer/MOORHEN_SCENES.md
+++ b/client/renderer/MOORHEN_SCENES.md
@@ -1,12 +1,18 @@
-# Moorhen Scenes — branch handover
+# Moorhen Scenes — implementer notes
 
-A working summary of the `moorhen-scenes` feature work — what it does,
+A working summary of the `moorhen-scenes` feature — what it does,
 which files implement it, the design decisions worth knowing about,
 and what's deliberately not done yet.
 
 For the **authoring** reference (how to write a `.scene.yaml`), see
 [`types/moorhen-scene.md`](renderer/types/moorhen-scene.md). This
 document is the implementer's-eye view.
+
+**Status:** merged to `django` via PR #164 and live in the app. Runs
+against **Moorhen 1.0.0-alpha.3** (the `extraSidePanels` callback wiring
+in `moorhen-wrapper.tsx` tracks that version's API). MTZ map support
+landed after the initial merge; the lifter/resolver capture and re-apply
+maps as well as coordinates.
 
 ## What it is
 
@@ -22,8 +28,8 @@ my-view.scene.zip                     ┌─────────────
 ├── scene.yaml         drop on ─────► │  Moorhen Scenes panel   │
 └── assets/                            │  • Open / Apply / Save  │
     ├── coords/x0034.cif               │  • Live Monaco editor   │
-    └── dict/x0034_LIG.cif             │  • Validation messages  │
-                                       └─────────────────────────┘
+    ├── dict/x0034_LIG.cif             │  • Validation messages  │
+    └── mtz/x0034.mtz                  └─────────────────────────┘
 ```
 
 The format supports:
@@ -34,6 +40,8 @@ The format supports:
   where two molecules carry same-named ligands with different chemistry.
 - **Domain definitions** with by-domain colouring.
 - **SSM and LSQ superpositions** (with a `chain`+`range` shorthand).
+- **Electron-density maps** from MTZ refs (`kind: mtz` + a `maps:`
+  block), including difference maps and an `activeMap:` for refinement.
 - **Inline dict text** (`cifText:`) and **bundle: assets/...**
   references for sources without a stable URL.
 
@@ -51,13 +59,13 @@ The format supports:
 
 | File | Role |
 |------|------|
-| `renderer/lib/moorhen-scene-resolver.ts`  | The apply-time engine. Fetches files, runs superpositions, applies representations, sets the camera. Exposes a couple of small pure helpers (`splitMultiCid`, `clampRangeToPresent`, `expandLsqMatches`, `isFetchable`) for unit testing. |
+| `renderer/lib/moorhen-scene-resolver.ts`  | The apply-time engine. Fetches files, runs superpositions, applies representations, loads/contours maps, sets the camera. Exposes a couple of small pure helpers (`splitMultiCid`, `clampRangeToPresent`, `expandLsqMatches`, `isFetchable`) for unit testing. |
 
 ### Lifter (Moorhen state → scene)
 
 | File | Role |
 |------|------|
-| `renderer/lib/moorhen-scene-lifter.ts`    | The capture-time engine. `liftScene` writes a plain YAML; `liftSceneToBundle` inlines local coord/dict text into a returned asset map suitable for zipping. Conservative — only lifts things it recognises. |
+| `renderer/lib/moorhen-scene-lifter.ts`    | The capture-time engine. `liftScene` writes a plain YAML; `liftSceneToBundle` inlines local coord/dict/MTZ data into a returned asset map suitable for zipping. Captures loaded maps (columns + render state) alongside coordinates. Conservative — only lifts things it recognises. |
 
 ### UI
 
@@ -80,11 +88,11 @@ The format supports:
 
 | File | Tests |
 |------|-------|
-| `renderer/__tests__/moorhen-scene.test.ts`          | Schema, validator, serialiser, round-trip stability (65 tests) |
-| `renderer/__tests__/moorhen-scene-resolver.test.ts` | Pure resolver helpers — clamping, multi-CID splitting, LSQ expansion, isFetchable, chain selectors (28 tests) |
-| `renderer/__tests__/moorhen-scene-lifter.test.ts`   | Lifter behaviour, dict enumeration, round-trip via fake molecules (15 tests) |
+| `renderer/__tests__/moorhen-scene.test.ts`          | Schema, validator, serialiser, round-trip stability — including the `maps:` / `activeMap:` block (74 cases) |
+| `renderer/__tests__/moorhen-scene-resolver.test.ts` | Pure resolver helpers — clamping, multi-CID splitting, LSQ expansion, isFetchable, chain selectors (28 cases) |
+| `renderer/__tests__/moorhen-scene-lifter.test.ts`   | Lifter behaviour, dict enumeration, map capture, round-trip via fake molecules (20 cases) |
 
-**Total: 112 tests**, all passing. Run with `cd client && npx vitest run`.
+**~120 tests**, all passing. Run with `cd client && npx vitest run` for the live count.
 
 The resolver itself (the bit that drives Moorhen) is exercised by
 manual verification in the browser — too much runtime state to mock.
@@ -159,6 +167,18 @@ authoring doc tells the converter to use `style: CBs` with an
 explicit residue-name CID like `//*/(LIG)` for ligand sticks.
 This avoids the auto-discovery path entirely.
 
+### Maps are best-effort, never fatal
+
+A `maps:` entry needs the wrapper's map-fetcher to be wired in and an
+MTZ ref it can actually fetch. If either is missing, the resolver
+**drops the map with a log entry and carries on** — coordinates,
+representations, and camera still apply. A scene that can't find its
+density never renders as a hard failure. The lifter only emits
+render-state fields (`contourLevel`, `style`, colours, …) when the
+captured value differs from Moorhen's load-time default, so captured
+map blocks stay small. v1 handles MTZ refs only; pre-computed CCP4
+`.map` files and PDB-fetched maps are deferred.
+
 ### Camera handling: portable subset only
 
 The `view:` block captures origin, quat, zoom, optionally clip and
@@ -220,22 +240,23 @@ the round-trip works on a fresh install:
 5. Should see a structure load from PDBe and render with two
    coloured blocks on chain A.
 
-## Branching suggestion
+## How it landed, and the Materia pin
 
-Worth its own branch off the current `django` branch — the change
-set is large enough (12 new files, ~3000 lines including tests)
-that reviewers will want to read it in one place. Suggested name:
-`moorhen-scenes`. The Electron menu addition in
-`client/main/ccp4i2-menu.ts` is the only main-process touch; the
-rest is renderer-side.
+The feature merged to `django` via **PR #164**
+(`moorhen-scenes-into-django`). Follow-up commits added hex-alpha
+colours, an ATP-class dict skip, and MTZ map capture/apply. The
+Electron menu addition in `client/main/ccp4i2-menu.ts` is the only
+main-process touch; everything else is renderer-side.
 
 Two existing files are touched non-trivially:
 
 - `client/renderer/components/moorhen/moorhen-wrapper.tsx` —
-  +279 lines, mostly the scene callbacks and the bundle/dict
-  fetcher wiring.
+  the scene callbacks and the bundle/dict/map fetcher wiring.
 - `client/renderer/components/task/task-elements/fetch-file-for-param.tsx` —
-  a small change that routes PDBe fetches through the new
-  `/api/proxy/pdbe` route. Worth a separate commit so it can be
-  cherry-picked back to `django` independently if needed (it's
-  not scenes-specific).
+  routes PDBe fetches through the `/api/proxy/pdbe` route (not
+  scenes-specific; a drive-by COEP/CORP fix).
+
+Materia tracks scene work through its submodule pin — see
+[`packages/ccp4i2-api/RELEASING.md`](../../packages/ccp4i2-api/RELEASING.md)
+for the cherry-pick/branch convention when shipping scene changes
+that Materia needs ahead of a `django` merge.

--- a/client/renderer/app/ccp4i2/(authed)/campaigns/[id]/page.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/campaigns/[id]/page.tsx
@@ -79,6 +79,11 @@ function getFileDisplayLabel(file: CCP4File): string {
   return file.name;
 }
 
+// Refinement tasks whose finished jobs carry ligand-bound coordinates.
+// Mirrors REFINE_TASK_NAMES in server/ccp4i2/lib/campaign_scene.py and the
+// auto-select set in the campaign Moorhen page.
+const REFINEMENT_TASK_NAMES = ["refmac", "i2Refmac", "i2Dimple", "dimple"];
+
 interface CampaignDetailPageProps {
   params: Promise<{ id: string }>;
 }
@@ -478,25 +483,18 @@ export default function CampaignDetailPage({ params }: CampaignDetailPageProps) 
                   variant="outlined"
                   startIcon={<PreviewIcon />}
                   onClick={() => {
-                    // Open Summary View - Moorhen with all finished refmac jobs overlaid
-                    // For now, navigate to parent project's Moorhen view if there's a reference structure
-                    if (parentFiles?.coordinates?.[0]) {
-                      // Find first member with finished refmac
-                      const memberWithRefmac = memberProjects?.find(p =>
-                        p.jobs?.some(j => j.task_name === "refmac" && j.status === 6)
-                      );
-                      if (memberWithRefmac) {
-                        const refmacJob = memberWithRefmac.jobs?.find(
-                          j => j.task_name === "refmac" && j.status === 6
-                        );
-                        if (refmacJob) {
-                          window.open(`/ccp4i2/moorhen-page/job-by-id/${refmacJob.id}`, '_blank');
-                        }
-                      }
-                    }
+                    // Open the campaign Summary View: a Moorhen scene showing
+                    // the parent ribbon with every discovered fragment overlaid
+                    // (built server-side; see lib/campaign_scene.py).
+                    window.open(
+                      `/ccp4i2/moorhen-page/campaign/${campaignId}?summary=1`,
+                      "_blank"
+                    );
                   }}
                   disabled={!memberProjects?.some(p =>
-                    p.jobs?.some(j => j.task_name === "refmac" && j.status === 6)
+                    p.jobs?.some(j =>
+                      REFINEMENT_TASK_NAMES.includes(j.task_name) && j.status === 6
+                    )
                   )}
                 >
                   Summary View

--- a/client/renderer/app/ccp4i2/(authed)/moorhen-page/campaign/[id]/campaign-page-client.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/moorhen-page/campaign/[id]/campaign-page-client.tsx
@@ -5,6 +5,7 @@ import { ClientStoreProvider } from "@/providers/client-store-provider";
 import { useCampaignsApi } from "@/lib/campaigns-api";
 import { useMoorhenBreadcrumbs } from "@/providers/moorhen-breadcrumb-context";
 import CampaignMoorhenWrapper from "@/components/moorhen/campaign-moorhen-wrapper";
+import type { MoorhenScene } from "@/types/moorhen-scene";
 
 // Inner component that uses useSearchParams (requires Suspense boundary)
 function CampaignPageContent() {
@@ -13,6 +14,7 @@ function CampaignPageContent() {
   const searchParams = useSearchParams();
   const viewParam = searchParams?.get("view");
   const jobParam = searchParams?.get("job"); // Optional: specific job to load
+  const summaryMode = searchParams?.get("summary") === "1"; // Campaign overview
   const campaignId = id ? parseInt(id as string) : null;
   const initialJobId = jobParam ? parseInt(jobParam) : null;
 
@@ -54,8 +56,40 @@ function CampaignPageContent() {
     setSelectedJobId(null); // Reset to auto-select latest job
   }, []);
 
+  // Summary mode: fetch the campaign overview scene once on entry.
+  const [summaryScene, setSummaryScene] = useState<MoorhenScene | null>(null);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  useEffect(() => {
+    if (!summaryMode || campaignId === null || summaryScene !== null || summaryLoading) {
+      return;
+    }
+    let cancelled = false;
+    setSummaryLoading(true);
+    campaignsApi
+      .fetchSummaryScene(campaignId)
+      .then((res) => {
+        if (!cancelled) setSummaryScene(res.scene);
+      })
+      .catch((err) => {
+        console.error("Failed to load campaign summary scene:", err);
+      })
+      .finally(() => {
+        if (!cancelled) setSummaryLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [summaryMode, campaignId, summaryScene, summaryLoading, campaignsApi]);
+
   // Determine which files to load based on selection
   const fileIds = useMemo(() => {
+    // Summary overview: the whole-campaign scene (parent + all fragments).
+    if (summaryMode) {
+      return summaryScene
+        ? { type: "scene" as const, scene: summaryScene }
+        : { type: "none" as const };
+    }
+
     // If a specific job is selected, load that job
     if (selectedJobId !== null) {
       return { type: "job" as const, jobId: selectedJobId };
@@ -94,7 +128,7 @@ function CampaignPageContent() {
     }
     // Note: maps would need to be added here when parent has map files
     return { type: "files" as const, fileIds: ids };
-  }, [parentFiles, selectedMemberProjectId, selectedJobId, memberProjects]);
+  }, [parentFiles, selectedMemberProjectId, selectedJobId, memberProjects, summaryMode, summaryScene]);
 
   // Build breadcrumbs for the layout AppBar
   const { setBreadcrumbs } = useMoorhenBreadcrumbs();

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -60,11 +60,19 @@ import {
   useMoorhenCapabilities,
   isSafariBrowser,
 } from "./moorhen-capability-check";
+import {
+  applyScene,
+  SceneFileFetcher,
+  SceneDictionaryFetcher,
+  SceneDictionaryLoader,
+} from "../../lib/moorhen-scene-resolver";
+import type { MoorhenScene, SceneFileRef } from "../../types/moorhen-scene";
 
 type FileSource =
   | { type: "none" }
   | { type: "files"; fileIds: number[] }
-  | { type: "job"; jobId: number };
+  | { type: "job"; jobId: number }
+  | { type: "scene"; scene: MoorhenScene };
 
 export interface CampaignMoorhenWrapperProps {
   campaign: ProjectGroup;
@@ -240,6 +248,140 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     hasInitializedReps.current = false;
   }, [molecules, maps, dispatch]);
 
+  // ----------------------------------------------------------------------
+  // Scene apply path (used by the campaign "Summary View")
+  //
+  // A summary scene (built server-side by lib/campaign_scene.py) overlays
+  // every discovered fragment on the parent ribbon, each fragment scoped to
+  // its own restraint dictionary. We drive it through the shared scene
+  // resolver (applyScene) rather than the ad-hoc job loader above, because
+  // the resolver already does the load-global-then-scope-per-molecule
+  // dictionary dance the fragment-campaign case needs.
+  // ----------------------------------------------------------------------
+
+  // Bare structure load for the scene fetcher: load coords and register the
+  // molecule, but DON'T impose representations — the scene owns the look
+  // (the resolver hides loader defaults and applies the scene's reps).
+  const loadSceneStructure = useCallback(
+    async (
+      url: string,
+      molName: string,
+    ): Promise<moorhen.Molecule | null> => {
+      if (!commandCentre.current) return null;
+      const newMolecule = new MoorhenMolecule(
+        commandCentre as RefObject<moorhen.CommandCentre>,
+        store as any,
+        monomerLibraryPath,
+      );
+      newMolecule.setBackgroundColour(backgroundColor);
+      newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness;
+      try {
+        const pdbData = await apiText(url);
+        await newMolecule.loadToCootFromString(pdbData, molName);
+        if (newMolecule.molNo === -1) throw new Error("Cannot read coordinates");
+        newMolecule.uniqueId = url;
+        dispatch(addMolecule(newMolecule));
+        return newMolecule;
+      } catch (err) {
+        console.warn(`[scene] failed to load ${molName} from ${url}:`, err);
+        return null;
+      }
+    },
+    [commandCentre, store, monomerLibraryPath, backgroundColor, defaultBondSmoothness, dispatch],
+  );
+
+  const handleFetchSceneFile: SceneFileFetcher = useCallback(
+    async (ref: SceneFileRef) => {
+      if (ref.fileId !== undefined && ref.projectId) {
+        return loadSceneStructure(
+          `/api/proxy/ccp4i2/files/${ref.fileId}/download/`,
+          ref.name || `file_${ref.fileId}`,
+        );
+      }
+      if (ref.pdb) {
+        const pdbId = ref.pdb.toLowerCase();
+        return loadSceneStructure(
+          `/api/proxy/pdbe/entry-files/download/${pdbId}.cif`,
+          ref.name || pdbId,
+        );
+      }
+      if (ref.url) return loadSceneStructure(ref.url, ref.name || ref.url);
+      return null;
+    },
+    [loadSceneStructure],
+  );
+
+  const handleFetchSceneDictionary: SceneDictionaryFetcher = useCallback(
+    async (ref: SceneFileRef): Promise<string | null> => {
+      if (ref.cifText) return ref.cifText;
+      let url: string | null = null;
+      if (ref.fileId !== undefined && ref.projectId) {
+        url = `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
+      } else if (ref.url) {
+        url = ref.url;
+      }
+      if (!url) return null;
+      try {
+        return await apiText(url);
+      } catch (err) {
+        console.warn(`[scene] failed to fetch dictionary ${ref.name}:`, err);
+        return null;
+      }
+    },
+    [],
+  );
+
+  const handleLoadSceneDictionary: SceneDictionaryLoader = useCallback(
+    async (dictText: string, molNo: number): Promise<void> => {
+      if (!commandCentre.current) return;
+      await commandCentre.current.cootCommand(
+        {
+          returnType: "status",
+          command: "read_dictionary_string",
+          commandArgs: [dictText, molNo],
+          changesMolecules: molNo >= 0 ? [molNo] : [],
+        },
+        false,
+      );
+    },
+    [],
+  );
+
+  const handleApplyScene = useCallback(
+    async (scene: MoorhenScene) => {
+      const result = await applyScene({
+        scene,
+        molecules,
+        maps,
+        dispatch,
+        fetcher: handleFetchSceneFile,
+        dictionaryFetcher: handleFetchSceneDictionary,
+        dictionaryLoader: handleLoadSceneDictionary,
+      });
+      dispatch(setRequestDrawScene(true));
+      const shown = result.applied.length;
+      if (shown === 0) {
+        setMessage(
+          "No fragment hits to display — no member dataset had a ligand in its refined model.",
+        );
+      } else if (result.unresolvedFiles.length > 0) {
+        setMessage(
+          `Showing ${shown} structure(s); ${result.unresolvedFiles.length} could not be loaded.`,
+        );
+      }
+      return result;
+    },
+    [
+      molecules,
+      maps,
+      dispatch,
+      handleFetchSceneFile,
+      handleFetchSceneDictionary,
+      handleLoadSceneDictionary,
+      setMessage,
+    ],
+  );
+
   // Load files when fileSource changes
   useEffect(() => {
     if (!cootInitialized) return;
@@ -262,8 +404,10 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       });
     } else if (fileSource.type === "job") {
       fetchJobFiles(fileSource.jobId);
+    } else if (fileSource.type === "scene") {
+      handleApplyScene(fileSource.scene);
     }
-  }, [fileSource, cootInitialized, cleanupLoadedContent]);
+  }, [fileSource, cootInitialized, cleanupLoadedContent, handleApplyScene]);
 
   // Dimension updates are handled by Moorhen's MainContainer automatically
 

--- a/client/renderer/lib/campaigns-api.ts
+++ b/client/renderer/lib/campaigns-api.ts
@@ -8,7 +8,7 @@
 import { useMemo } from "react";
 import useSWR, { mutate } from "swr";
 import { useApi } from "../api";
-import { apiPost, apiDelete, apiPatch, apiPut, apiFetch } from "../api-fetch";
+import { apiGet, apiPost, apiDelete, apiPatch, apiPut, apiFetch } from "../api-fetch";
 import {
   ProjectGroup,
   ProjectGroupDetail,
@@ -19,6 +19,27 @@ import {
   CampaignSite,
 } from "../types/campaigns";
 import { Project } from "../types/models";
+import type { MoorhenScene } from "../types/moorhen-scene";
+
+/** A dataset the summary scene could not include, with the reason. */
+export interface SummarySceneSkip {
+  project: string;
+  reason: string;
+}
+
+/** Counts returned alongside a campaign summary scene. */
+export interface SummarySceneStats {
+  members_total: number;
+  hits: number;
+  skipped: SummarySceneSkip[];
+  parent_present: boolean;
+}
+
+/** Response of GET projectgroups/{id}/summary_scene. */
+export interface SummarySceneResponse {
+  scene: MoorhenScene;
+  stats: SummarySceneStats;
+}
 
 // =============================================================================
 // Hook for campaign operations
@@ -75,6 +96,16 @@ export function useCampaignsApi() {
         ? `projectgroups/${campaignId}/parent_files`
         : null;
       return api.get<ParentFilesResponse>(endpoint, refreshInterval);
+    },
+
+    /**
+     * Build the fragment-campaign summary scene (parent ribbon + every
+     * discovered fragment overlaid as ligand sticks, each scoped to its
+     * own restraint dictionary). Imperative: called once when the Moorhen
+     * page enters summary mode.
+     */
+    async fetchSummaryScene(campaignId: number): Promise<SummarySceneResponse> {
+      return apiGet(`projectgroups/${campaignId}/summary_scene`);
     },
 
     /**

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -37,11 +37,13 @@ authoredIn:                          # optional: provenance (never resolved)
   createdBy: <author>                # optional
   ccp4i2Version: <string>            # optional
 
-files: [ ... ]                       # optional: named coord + dict refs
+files: [ ... ]                       # optional: named coord + dict + mtz refs
 superpose: [ ... ]                   # optional: alignments, applied in order
 globalDictionaries: [ <name>, ... ]  # optional: dicts loaded on every molecule
 domains: [ ... ]                     # optional: reusable named residue blocks
 elements: [ ... ]                    # optional: per-file rendering instructions
+maps: [ ... ]                        # optional: electron-density maps from MTZ refs
+activeMap: <name>                    # optional: which map Moorhen refines against
 view: { ... }                        # optional: camera, clip, fog, background
 
 resolver:                            # optional: apply-time policy
@@ -55,7 +57,8 @@ Order of evaluation at apply-time:
 3. **Scope dictionaries** per element (re-associate to that molecule's molNo).
 4. **Run superpositions** (mutate moving structures' transforms).
 5. **Apply representations** per element.
-6. **Set camera**.
+6. **Load maps** (fetch/bind each MTZ, apply contour/colour/style, set `activeMap`).
+7. **Set camera**.
 
 ## `files`
 
@@ -66,7 +69,12 @@ file and doesn't have to mean anything outside.
 Each entry has:
 
 - `name`: **required**, unique within the block.
-- `kind`: optional, `"coordinates"` (default) or `"dictionary"`.
+- `kind`: optional, `"coordinates"` (default), `"dictionary"`, or `"mtz"`.
+  - `"coordinates"` — a PDB/mmCIF structure, loaded as a molecule.
+  - `"dictionary"` — a refmac/coot monomer CIF, loaded into Coot's
+    dictionary store and scoped to molecules via `dictionaries:`.
+  - `"mtz"` — reflection data, *not* loaded directly; referenced by an
+    entry in the [`maps:`](#maps) block that carries the column labels.
 - Exactly one resolution method:
 
   | Field                              | Use when                                                                                                                 |
@@ -349,7 +357,7 @@ row today. The practical advice:
 Four forms:
 
 ```yaml
-colour: "#4b8bbe"             # 1. Hex literal
+colour: "#4b8bbe"             # 1. Hex literal (#rrggbb or #rrggbbaa)
 colour: by-domain             # 2. Compile from the domains: block
 colour: b-factor              # 3. Named Moorhen scheme
 colour:                       # 4. Raw escape hatch (lossless, ugly)
@@ -358,6 +366,10 @@ colour:                       # 4. Raw escape hatch (lossless, ugly)
     args: [...]
     isMultiColourRule: <bool>
 ```
+
+Hex literals accept both 6-digit (`#rrggbb`) and 8-digit
+(`#rrggbbaa`, with alpha) forms — Moorhen's own per-chain rules come
+out as 8-hex, so the lifter round-trips them losslessly.
 
 Named schemes available out of the box:
 `by-domain`, `b-factor`, `b-factor-norm`, `af2-plddt`,
@@ -423,6 +435,99 @@ The LSQ `matchType` controls which atoms are fitted:
 
 `gesamt` is not currently supported because the Moorhen build doesn't
 expose it; the schema may grow to include it in a later version.
+
+## `maps`
+
+Electron-density (and difference) maps to contour. Each entry references
+an MTZ from the `files:` block — one declared with `kind: mtz` — and
+carries the column-label spec plus optional render state. The MTZ file
+ref itself is never loaded as a molecule; it exists only to be pointed
+at by a `maps:` entry.
+
+```yaml
+files:
+  - { name: refined,    pdb: 1m17 }
+  - { name: refl,       kind: mtz, url: https://example.org/refmac.mtz }
+
+maps:
+  # 2Fo-Fc style "best" map read straight from FWT/PHWT.
+  - name: best
+    file: refl
+    columns: { F: FWT, PHI: PHWT }
+    contourLevel: 1.5            # rmsd-relative
+    colour: "#3060c0"
+
+  # Fo-Fc difference map: two contour lobes, green/red by convention.
+  - name: diff
+    file: refl
+    columns: { F: DELFWT, PHI: PHDELWT }
+    isDifference: true
+    contourLevel: 3.0
+    positiveColour: "#00c000"
+    negativeColour: "#c00000"
+
+activeMap: best                 # Moorhen refines against this one
+```
+
+### Column spec (`columns`)
+
+Two ways to give Moorhen a map:
+
+- **Read coefficients directly** — set `F` + `PHI` (e.g. `FWT`/`PHWT`,
+  or `DELFWT`/`PHDELWT` for a difference map). This is the usual case
+  and the minimum required.
+- **Let Moorhen compute coefficients** — set `calcStructFact: true`
+  together with `Fobs` + `SigFobs` (and optionally `FreeR`). Moorhen
+  runs its own structure-factor calculation rather than reading
+  pre-computed `FWT`/`PHWT`.
+
+| Field            | Meaning                                                       |
+| ---------------- | ------------------------------------------------------------ |
+| `F`              | Structure-factor amplitude label (`FWT`, `F`, `DELFWT`).     |
+| `PHI`            | Phase label (`PHWT`, `PHI`, `PHDELWT`).                       |
+| `Fobs`           | Observed amplitude (only with `calcStructFact`).             |
+| `SigFobs`        | Sigma of `Fobs` (only with `calcStructFact`).               |
+| `FreeR`          | Free-R flag column (optional, with `calcStructFact`).        |
+| `useWeight`      | Apply the FOM weight column.                                  |
+| `calcStructFact` | Compute coefficients on the fly instead of reading `F`/`PHI`. |
+
+The validator requires **either** `F` + `PHI`, **or** `calcStructFact`
++ `Fobs` + `SigFobs`. Anything else is a validation error.
+
+### Render state (all optional)
+
+Any field you omit keeps Moorhen's load-time default; the lifter only
+emits a field when the captured value differs from that default, so
+captured scenes stay small.
+
+| Field             | Meaning                                                          |
+| ----------------- | ---------------------------------------------------------------- |
+| `isDifference`    | Render positive + negative lobes (uses the two `*Colour` fields).|
+| `contourLevel`    | Contour level, rmsd-relative.                                    |
+| `radius`          | Contour radius (Å) around the camera origin.                    |
+| `alpha`           | Opacity, 0–1.                                                    |
+| `style`           | `"lines"`, `"solid"`, or `"lit-lines"`.                          |
+| `colour`          | Hex (`#rrggbb` / `#rrggbbaa`). Non-difference maps only.         |
+| `positiveColour`  | Hex for the positive lobe of a difference map.                  |
+| `negativeColour`  | Hex for the negative lobe of a difference map.                  |
+| `visible`         | Whether the map is shown. Defaults to `true`.                   |
+
+### `activeMap`
+
+A top-level field (sibling of `maps:`, not nested inside it) naming the
+map Moorhen should make active after apply. Moorhen refines against the
+active map, so this is normally the best/calculated map — never a
+difference map. The value must match a `name` in the `maps:` block.
+
+### Map resolution at apply-time
+
+Maps need a map-fetcher to be wired into the resolver (the Moorhen
+wrapper provides one). If the host hasn't supplied a fetcher, or the
+MTZ ref isn't fetchable, the map entry is **dropped with a log entry**
+and the rest of the scene still applies — coordinates and
+representations never fail just because a map couldn't load. Today only
+MTZ refs are supported; pre-computed CCP4 `.map` files and
+PDB-fetched maps are planned for a later schema version.
 
 ## `view`
 
@@ -595,3 +700,43 @@ resolver:
 Drop that into the Scenes editor, click Apply, and you have two
 APAF-1 structures aligned on their NBDs with matching colour schemes
 — ready to compare conformations.
+
+### With electron density
+
+A refined model with its 2Fo-Fc and Fo-Fc maps, ready for inspection:
+
+```yaml
+scene: refined-with-density
+version: 1
+
+files:
+  - { name: model, fileId: 482, projectId: 3f8a-aaaa-bbbb-cccc-uuid }
+  - { name: refl,  kind: mtz, fileId: 483, projectId: 3f8a-aaaa-bbbb-cccc-uuid }
+
+elements:
+  - file: model
+    representations:
+      - { style: CRs, colour: secondary-structure }
+      - { style: CBs, selection: "//*/(LIG)", colour: "#2ecc71" }
+
+maps:
+  - name: best
+    file: refl
+    columns: { F: FWT, PHI: PHWT }
+    contourLevel: 1.5
+  - name: diff
+    file: refl
+    columns: { F: DELFWT, PHI: PHDELWT }
+    isDifference: true
+    contourLevel: 3.0
+
+activeMap: best
+
+view:
+  origin: [12.4, 8.1, -3.6]
+  zoom: 0.4
+```
+
+(The `fileId` + `projectId` refs resolve against the ccp4i2 project the
+recipient has open; share as a `.scene.zip` with the coords and MTZ
+bundled if the recipient won't have the project.)

--- a/server/ccp4i2/api/ProjectGroupViewSet.py
+++ b/server/ccp4i2/api/ProjectGroupViewSet.py
@@ -19,6 +19,7 @@ from . import serializers
 from ..db import models
 from ..lib.response import api_success, api_error
 from ..lib import pandda_export
+from ..lib import campaign_scene
 
 logger = logging.getLogger(f"ccp4i2:{__name__}")
 
@@ -564,6 +565,31 @@ class ProjectGroupViewSet(ModelViewSet):
         except Exception as e:
             logger.exception(
                 "Failed to get PANDDA data for group %s", pk, exc_info=e
+            )
+            return api_error(str(e), status=500)
+
+    @action(detail=True, methods=["get"], )
+    def summary_scene(self, request, pk=None):
+        """
+        Build a Moorhen summary scene for a fragment campaign.
+
+        Returns a scene that overlays every discovered fragment hit on the
+        parent reference structure: the parent as a ribbon, and each hit
+        dataset's ligand as sticks scoped to its own restraint dictionary.
+        A dataset counts as a hit when its refined coordinates contain the
+        ligand its dictionary describes (see ``lib.campaign_scene``).
+
+        Returns:
+            Response: ``{"scene": <MoorhenScene>, "stats": {...}}`` where
+                ``scene`` is a JSON-serialisable scene the frontend applies
+                directly via the scene resolver.
+        """
+        try:
+            group = self.get_object()
+            return Response(campaign_scene.build_summary_scene(group))
+        except Exception as e:
+            logger.exception(
+                "Failed to build summary scene for group %s", pk, exc_info=e
             )
             return api_error(str(e), status=500)
 

--- a/server/ccp4i2/lib/campaign_scene.py
+++ b/server/ccp4i2/lib/campaign_scene.py
@@ -1,0 +1,414 @@
+"""
+Fragment-campaign summary-scene service.
+
+Builds a Moorhen *scene* (see ``client/renderer/types/moorhen-scene.md``)
+that overlays every discovered fragment hit on the campaign's parent
+reference structure: the parent drawn as a ribbon, each hit dataset's
+ligand drawn as sticks, scoped to its own restraint dictionary.
+
+Two jobs this module does that the scene format then exploits:
+
+  * **Hit detection** — a dataset counts as a hit when its refined
+    coordinates actually contain the ligand its restraint dictionary
+    describes. We read the dictionary's comp_id(s) with gemmi and look
+    for those residue names in the coordinates. That single check both
+    decides "is this a hit?" and tells us the exact CID to render
+    (``//*/(CODE)``). When a member has no dictionary we fall back to
+    the conventional placeholder codes (LIG/DRG/UNL).
+
+  * **Dictionary scoping** — the scene lists each hit's dictionary in
+    the element's ``dictionaries:`` block, so the resolver loads it and
+    re-associates it with *that* molecule's molNo. Two datasets whose
+    ligands share a code but differ in chemistry stay correct.
+
+Like ``pandda_export``, this module is deliberately Django-light: it
+takes a ``ProjectGroup`` and reads the related ``Job``/``File`` tables,
+but does no request/response handling, so it is callable from a
+synchronous ViewSet today and a background worker tomorrow.
+"""
+import logging
+from pathlib import Path
+from typing import Optional
+
+import gemmi
+
+from ..db import models
+from . import pandda_export
+
+logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+
+# Refinement tasks whose latest finished job carries the ligand-bound
+# coordinates. Mirrors the set the campaign Moorhen page already uses to
+# auto-select a member's job (campaign-page-client.tsx).
+REFINE_TASK_NAMES = ("refmac", "i2Refmac", "i2Dimple", "dimple")
+
+# Placeholder ligand codes used when a member has no dictionary to key
+# detection off (the user's original heuristic).
+FALLBACK_LIGAND_CODES = frozenset({"LIG", "DRG", "UNL"})
+
+# Crystallisation additives, cryoprotectants and ions that commonly appear
+# as HET residues but are NOT a fragment hit. A refmac LIBOUT can also carry
+# standard monomers; those are filtered via gemmi's residue tabulation
+# (amino acid / nucleic acid / water) rather than enumerated here.
+COMMON_NON_LIGANDS = frozenset({
+    "HOH", "WAT", "DOD",
+    "GOL", "EDO", "PEG", "PG4", "PGE", "1PE", "2PE", "P6G", "PG0", "MPD", "BME",
+    "SO4", "PO4", "ACT", "ACY", "FMT", "CIT", "FLC", "TLA", "MES", "EPE", "TRS",
+    "IPA", "DMS", "NH4", "NO3", "CAC",
+    "NA", "K", "MG", "CA", "ZN", "MN", "FE", "FE2", "CL", "BR", "IOD",
+    "CD", "NI", "CO", "CU", "CU1", "HG",
+})
+
+# Parent ribbon colour — a muted grey so the coloured fragment sticks
+# read clearly against it.
+PARENT_RIBBON_COLOUR = "#b0bec5"
+
+DICT_FILE_TYPE = "application/refmac-dictionary"
+COORD_FILE_TYPES = ("chemical/x-pdb", "chemical/x-cif", "chemical/x-mmcif")
+
+
+# --------------------------------------------------------------------------
+# Ligand detection (pure; gemmi only, no DB) -- unit-testable
+# --------------------------------------------------------------------------
+
+def _clean_code(value: str) -> str:
+    """Normalise a comp_id / residue name: unquote, strip, upper-case."""
+    return gemmi.cif.as_string(value).strip().upper()
+
+
+def dictionary_comp_ids(dict_path) -> set:
+    """Return the set of comp_ids declared by a restraint CIF.
+
+    Reads ``_chem_comp.id`` (pair or loop) and ``_chem_comp_atom.comp_id``
+    across every block, plus the ``comp_<X>`` block-name convention.
+    Mirrors the extraction in ``FileViewSet.molblock`` but collects *all*
+    codes (a dict file may declare several monomers in one shot).
+    """
+    ids: set = set()
+    try:
+        doc = gemmi.cif.read_file(str(dict_path))
+    except Exception as exc:  # noqa: BLE001 - malformed dict shouldn't kill the scene
+        logger.warning("Could not read dictionary %s: %s", dict_path, exc)
+        return ids
+    for block in doc:
+        single = block.find_value("_chem_comp.id")
+        if single:
+            ids.add(_clean_code(single))
+        for cid in block.find_loop("_chem_comp.id"):
+            ids.add(_clean_code(cid))
+        for cid in block.find_loop("_chem_comp_atom.comp_id"):
+            ids.add(_clean_code(cid))
+        name = block.name or ""
+        if name.lower().startswith("comp_"):
+            token = name[len("comp_"):]
+            if 1 <= len(token) <= 5:
+                ids.add(token.upper())
+    # Drop empties and the dict's catch-all list block.
+    ids.discard("")
+    ids.discard("LIST")
+    return ids
+
+
+def _is_fragment_code(code: str) -> bool:
+    """True if ``code`` looks like a soaked fragment rather than a standard
+    biopolymer residue, water, ion, or crystallisation additive.
+
+    A refmac LIBOUT may declare standard monomers alongside the ligand, so
+    "the dict mentions it and the coords contain it" is not sufficient on its
+    own — we still exclude anything gemmi recognises as an amino acid /
+    nucleic acid / water, plus a curated additive list.
+    """
+    info = gemmi.find_tabulated_residue(code)
+    if info is not None and (
+        info.is_amino_acid() or info.is_nucleic_acid() or info.is_water()
+    ):
+        return False
+    return code not in COMMON_NON_LIGANDS
+
+
+def coordinate_residue_names(coord_path) -> set:
+    """Return the set of residue names present in a coordinate file."""
+    names: set = set()
+    st = gemmi.read_structure(str(coord_path))
+    for model in st:
+        for chain in model:
+            for res in chain:
+                names.add(res.name.strip().upper())
+    return names
+
+
+def detect_ligands(coord_path, dict_path: Optional[object] = None) -> list:
+    """Return the ligand codes a dataset should be judged a hit on.
+
+    Dictionary-driven: the intersection of the dictionary's comp_ids with
+    the residue names actually present in the coordinates. When no
+    dictionary is available (or it yields no match), fall back to the
+    conventional placeholder codes (LIG/DRG/UNL) found in the coords.
+
+    Returns a sorted list (possibly empty -> not a hit).
+    """
+    try:
+        coord_names = coordinate_residue_names(coord_path)
+    except Exception as exc:  # noqa: BLE001 - unreadable coords -> not a hit
+        logger.warning("Could not read coordinates %s: %s", coord_path, exc)
+        return []
+
+    if dict_path is not None:
+        candidates = dictionary_comp_ids(dict_path) & coord_names
+        hits = sorted(c for c in candidates if _is_fragment_code(c))
+        if hits:
+            return hits
+
+    return sorted(coord_names & FALLBACK_LIGAND_CODES)
+
+
+# --------------------------------------------------------------------------
+# Scene assembly (touches the DB)
+# --------------------------------------------------------------------------
+
+def _parent_coord_file(group):
+    """The parent project's reference XYZOUT coordinate File, or None."""
+    parent_membership = group.memberships.filter(
+        type=models.ProjectGroupMembership.MembershipType.PARENT
+    ).select_related("project").first()
+    if not parent_membership:
+        return None, None
+    parent_project = parent_membership.project
+    coord_file = (
+        models.File.objects.filter(
+            job__project=parent_project,
+            job_param_name="XYZOUT",
+            type__name="chemical/x-pdb",
+        )
+        .order_by("-id")
+        .first()
+    )
+    return parent_project, coord_file
+
+
+def _member_coord_file(job):
+    """Pick a refined-coordinate File for a refinement job.
+
+    Prefer the XYZOUT PDB (the canonical refined-model output); fall back
+    to any coordinate-typed output of the job.
+    """
+    xyzout = (
+        models.File.objects.filter(job=job, job_param_name="XYZOUT")
+        .order_by("-id")
+    )
+    pdb = xyzout.filter(type__name="chemical/x-pdb").first()
+    if pdb:
+        return pdb
+    any_xyz = xyzout.filter(type__name__in=COORD_FILE_TYPES).first()
+    if any_xyz:
+        return any_xyz
+    return (
+        models.File.objects.filter(job=job, type__name__in=COORD_FILE_TYPES)
+        .order_by("-id")
+        .first()
+    )
+
+
+def _member_dict_file(project, refine_job):
+    """Find the restraint dictionary File for a member.
+
+    First the dictionary emitted by the refinement job itself (guaranteed
+    to pair with its coordinates); otherwise the dictionary File of the
+    member's latest finished acedrg job.
+    """
+    own = (
+        models.File.objects.filter(job=refine_job, type__name=DICT_FILE_TYPE)
+        .order_by("-id")
+        .first()
+    )
+    if own:
+        return own
+    acedrg_job = pandda_export._latest_finished_job(
+        project, pandda_export.ACEDRG_TASK_NAMES
+    )
+    if not acedrg_job:
+        return None
+    return (
+        models.File.objects.filter(job=acedrg_job, type__name=DICT_FILE_TYPE)
+        .order_by("-id")
+        .first()
+    )
+
+
+def _safe_name(raw: str, used: set) -> str:
+    """Slug a project name into a unique, scene-safe file identifier."""
+    base = "".join(c if c.isalnum() else "_" for c in (raw or "")).strip("_")
+    base = base or "dataset"
+    name = base
+    n = 2
+    while name in used:
+        name = f"{base}_{n}"
+        n += 1
+    used.add(name)
+    return name
+
+
+def build_summary_scene(group) -> dict:
+    """Build the fragment-campaign summary scene for ``group``.
+
+    Returns ``{"scene": <MoorhenScene>, "stats": {...}}``. The scene is a
+    plain JSON-serialisable dict matching the MoorhenScene TypeScript
+    shape; the frontend applies it directly via the scene resolver.
+    """
+    files: list = []
+    elements: list = []
+    used_names: set = set()
+    stats = {
+        "members_total": 0,
+        "hits": 0,
+        "skipped": [],            # [{project, reason}]
+        "parent_present": False,
+    }
+
+    # -- Parent reference: ribbon -----------------------------------------
+    parent_project, parent_coord = _parent_coord_file(group)
+    if parent_coord is not None:
+        ref_name = _safe_name("reference", used_names)
+        files.append(
+            {
+                "name": ref_name,
+                "kind": "coordinates",
+                "fileId": parent_coord.id,
+                "projectId": str(parent_project.uuid),
+            }
+        )
+        elements.append(
+            {
+                "file": ref_name,
+                "representations": [
+                    {
+                        "style": "CRs",
+                        "selection": "/*/*/*/*",
+                        "colour": PARENT_RIBBON_COLOUR,
+                    }
+                ],
+            }
+        )
+        stats["parent_present"] = True
+    else:
+        ref_name = None
+
+    # -- Member hits: ligand sticks, each with its scoped dictionary ------
+    member_memberships = group.memberships.filter(
+        type=models.ProjectGroupMembership.MembershipType.MEMBER
+    ).select_related("project")
+
+    for membership in member_memberships:
+        project = membership.project
+        stats["members_total"] += 1
+
+        refine_job = pandda_export._latest_finished_job(project, REFINE_TASK_NAMES)
+        if not refine_job:
+            stats["skipped"].append(
+                {"project": project.name, "reason": "no finished refinement job"}
+            )
+            continue
+
+        coord_file = _member_coord_file(refine_job)
+        if coord_file is None or not coord_file.path.exists():
+            stats["skipped"].append(
+                {"project": project.name, "reason": "no refined coordinate file"}
+            )
+            continue
+
+        dict_file = _member_dict_file(project, refine_job)
+        dict_path = None
+        if dict_file is not None and dict_file.path.exists():
+            dict_path = dict_file.path
+        else:
+            # Disk-only acedrg dictionary (no File record): inline its text.
+            acedrg_job = pandda_export._latest_finished_job(
+                project, pandda_export.ACEDRG_TASK_NAMES
+            )
+            disk_dict = pandda_export._find_dictionary_cif(acedrg_job)
+            if disk_dict is not None:
+                dict_path = disk_dict
+
+        codes = detect_ligands(coord_file.path, dict_path)
+        if not codes:
+            stats["skipped"].append(
+                {"project": project.name, "reason": "no ligand in refined model"}
+            )
+            continue
+
+        ds_name = _safe_name(project.name, used_names)
+        files.append(
+            {
+                "name": ds_name,
+                "kind": "coordinates",
+                "fileId": coord_file.id,
+                "projectId": str(project.uuid),
+            }
+        )
+
+        dict_ref_name = None
+        if dict_file is not None and dict_file.path.exists():
+            dict_ref_name = _safe_name(f"{ds_name}_dict", used_names)
+            files.append(
+                {
+                    "name": dict_ref_name,
+                    "kind": "dictionary",
+                    "fileId": dict_file.id,
+                    "projectId": str(project.uuid),
+                }
+            )
+        elif dict_path is not None:
+            try:
+                cif_text = Path(dict_path).read_text()
+                dict_ref_name = _safe_name(f"{ds_name}_dict", used_names)
+                files.append(
+                    {
+                        "name": dict_ref_name,
+                        "kind": "dictionary",
+                        "cifText": cif_text,
+                    }
+                )
+            except OSError as exc:
+                logger.warning("Could not inline dictionary %s: %s", dict_path, exc)
+
+        selection = "||".join(f"//*/({code})" for code in codes)
+        element = {
+            "file": ds_name,
+            "representations": [{"style": "CBs", "selection": selection}],
+        }
+        if dict_ref_name:
+            element["dictionaries"] = [dict_ref_name]
+        elements.append(element)
+        stats["hits"] += 1
+
+    scene = {
+        "scene": f"{group.name} - fragment summary",
+        "version": 1,
+        "authoredIn": {"projectName": group.name},
+        "files": files,
+        "elements": elements,
+        "resolver": {"onMissingResidues": "clamp-and-log"},
+    }
+
+    view = _first_site_view(group)
+    if view:
+        scene["view"] = view
+
+    return {"scene": scene, "stats": stats}
+
+
+def _first_site_view(group) -> Optional[dict]:
+    """Camera from the campaign's first saved binding site, if any."""
+    sites = getattr(group, "sites", None) or []
+    if not sites:
+        return None
+    site = sites[0]
+    view: dict = {}
+    if site.get("origin"):
+        view["origin"] = site["origin"]
+    if site.get("quat"):
+        view["quat"] = site["quat"]
+    if site.get("zoom") is not None:
+        view["zoom"] = site["zoom"]
+    return view or None

--- a/server/ccp4i2/tests/api/unit/test_summary_scene_api.py
+++ b/server/ccp4i2/tests/api/unit/test_summary_scene_api.py
@@ -1,0 +1,274 @@
+"""
+E2E test for the fragment-campaign summary-scene endpoint.
+
+    GET /api/ccp4i2/projectgroups/{id}/summary_scene/
+
+This drives the whole path the real feature uses: DB rows (ProjectGroup ->
+memberships -> Projects -> Jobs -> Files) plus the actual coordinate /
+dictionary files on disk, read back by gemmi in
+``lib/campaign_scene.build_summary_scene``.
+
+The fixture builds a synthetic campaign:
+
+  * a parent reference (apo, no ligand)         -> parent ribbon
+  * member "frag-drg": refined, ligand DRG      -> hit
+  * member "frag-lig": refined, ligand LIG      -> hit
+  * member "frag-apo": refined, no ligand       -> skipped
+
+so we can assert the parent ribbon, two fragment-stick elements (each scoped
+to its own dictionary), and the skip accounting. The shapes are synthetic;
+expect to revisit thresholds/labels once this runs against real XChem data,
+but the contract (parent + per-hit element + scoped dict + stats) should hold.
+
+Uses the api/ conftest, which auto-applies django_db(transaction=True) and
+sets AllowAny on the viewsets — do NOT add @pytest.mark.django_db here.
+"""
+
+import uuid
+from pathlib import Path
+
+import gemmi
+from rest_framework.test import APIClient
+
+from ccp4i2.db import models
+
+
+# --------------------------------------------------------------------------
+# Minimal on-disk coordinate / dictionary builders (gemmi only)
+# --------------------------------------------------------------------------
+
+def _write_pdb(path: Path, ligand_code=None):
+    """One-residue alanine 'protein', optionally plus a HET ligand."""
+    st = gemmi.Structure()
+    st.spacegroup_hm = "P 1"
+    st.cell = gemmi.UnitCell(30, 30, 30, 90, 90, 90)
+    model = gemmi.Model(1)
+    chain = gemmi.Chain("A")
+
+    res = gemmi.Residue()
+    res.name = "ALA"
+    res.seqid = gemmi.SeqId("1")
+    for nm, el in [("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O")]:
+        a = gemmi.Atom()
+        a.name = nm
+        a.element = gemmi.Element(el)
+        a.pos = gemmi.Position(1, 2, 3)
+        a.occ = 1.0
+        a.b_iso = 20.0
+        res.add_atom(a)
+    chain.add_residue(res)
+
+    if ligand_code:
+        lig = gemmi.Residue()
+        lig.name = ligand_code
+        lig.seqid = gemmi.SeqId("2")
+        lig.het_flag = "H"
+        a = gemmi.Atom()
+        a.name = "C1"
+        a.element = gemmi.Element("C")
+        a.pos = gemmi.Position(5, 5, 5)
+        a.occ = 1.0
+        a.b_iso = 30.0
+        lig.add_atom(a)
+        chain.add_residue(lig)
+
+    model.add_chain(chain)
+    st.add_model(model)
+    st.setup_entities()
+    path.write_text(st.make_pdb_string())
+
+
+def _write_dict(path: Path, *codes):
+    """Minimal refmac-style restraint CIF declaring one or more monomers."""
+    list_rows = "\n".join(f"{c} {c} 'monomer' non-polymer 3 3 ." for c in codes)
+    comp_blocks = "\n".join(
+        f"""data_comp_{c}
+loop_
+_chem_comp_atom.comp_id
+_chem_comp_atom.atom_id
+_chem_comp_atom.type_symbol
+{c} C1 C
+{c} C2 C
+{c} O1 O"""
+        for c in codes
+    )
+    path.write_text(
+        f"""data_comp_list
+loop_
+_chem_comp.id
+_chem_comp.three_letter_code
+_chem_comp.name
+_chem_comp.group
+_chem_comp.number_atoms_all
+_chem_comp.number_atoms_nh
+_chem_comp.desc_level
+{list_rows}
+{comp_blocks}
+"""
+    )
+
+
+# --------------------------------------------------------------------------
+# DB + on-disk fixture builders
+# --------------------------------------------------------------------------
+
+def _make_refined_project(root: Path, name, pdb_type, dict_type,
+                          ligand_code=None, dict_codes=None):
+    """A Project with one finished refmac job carrying XYZOUT (+ optional dict)."""
+    project = models.Project.objects.create(
+        name=name, directory=str(root / name)
+    )
+    job = models.Job.objects.create(
+        uuid=uuid.uuid4(),
+        project=project,
+        number="1",
+        title=f"{name} refinement",
+        task_name="refmac",
+        status=models.Job.Status.FINISHED,
+    )
+    job.directory.mkdir(parents=True, exist_ok=True)
+
+    _write_pdb(job.directory / "XYZOUT.pdb", ligand_code=ligand_code)
+    models.File.objects.create(
+        uuid=uuid.uuid4(),
+        name="XYZOUT.pdb",
+        directory=models.File.Directory.JOB_DIR,
+        type=pdb_type,
+        job=job,
+        job_param_name="XYZOUT",
+    )
+
+    if dict_codes:
+        _write_dict(job.directory / "LIBOUT.cif", *dict_codes)
+        models.File.objects.create(
+            uuid=uuid.uuid4(),
+            name="LIBOUT.cif",
+            directory=models.File.Directory.JOB_DIR,
+            type=dict_type,
+            job=job,
+            job_param_name="LIBOUT",
+        )
+    return project
+
+
+def _build_campaign(root: Path):
+    """Parent + 2 hit members + 1 apo member, wired into a fragment_set group."""
+    pdb_type, _ = models.FileType.objects.get_or_create(name="chemical/x-pdb")
+    dict_type, _ = models.FileType.objects.get_or_create(
+        name="application/refmac-dictionary"
+    )
+
+    parent = _make_refined_project(root, "parent_ref", pdb_type, dict_type)
+    frag_drg = _make_refined_project(
+        root, "frag_drg", pdb_type, dict_type, ligand_code="DRG", dict_codes=["DRG"]
+    )
+    frag_lig = _make_refined_project(
+        root, "frag_lig", pdb_type, dict_type, ligand_code="LIG", dict_codes=["LIG"]
+    )
+    # Apo: refined but no ligand bound; dict present but irrelevant.
+    frag_apo = _make_refined_project(
+        root, "frag_apo", pdb_type, dict_type, ligand_code=None, dict_codes=["DRG"]
+    )
+
+    group = models.ProjectGroup.objects.create(
+        name="test_fragment_campaign",
+        type=models.ProjectGroup.GroupType.FRAGMENT_SET,
+    )
+    models.ProjectGroupMembership.objects.create(
+        group=group, project=parent,
+        type=models.ProjectGroupMembership.MembershipType.PARENT,
+    )
+    for member in (frag_drg, frag_lig, frag_apo):
+        models.ProjectGroupMembership.objects.create(
+            group=group, project=member,
+            type=models.ProjectGroupMembership.MembershipType.MEMBER,
+        )
+    return group
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+def test_summary_scene_endpoint(bypass_api_permissions, test_project_path):
+    test_project_path.mkdir(parents=True, exist_ok=True)
+    group = _build_campaign(test_project_path)
+
+    client = APIClient()
+    response = client.get(
+        f"/api/ccp4i2/projectgroups/{group.id}/summary_scene/"
+    )
+    assert response.status_code == 200, response.content
+    data = response.json()
+
+    # ---- stats ----------------------------------------------------------
+    stats = data["stats"]
+    assert stats["members_total"] == 3
+    assert stats["hits"] == 2               # DRG + LIG, not the apo member
+    assert stats["parent_present"] is True
+    skipped_reasons = [s["reason"] for s in stats["skipped"]]
+    assert len(skipped_reasons) == 1
+    assert "no ligand" in skipped_reasons[0].lower()
+
+    # ---- scene shape ----------------------------------------------------
+    scene = data["scene"]
+    assert scene["version"] == 1
+    files = scene["files"]
+    elements = scene["elements"]
+
+    # Parent reference: a coordinates file rendered as a ribbon (CRs).
+    ref_files = [f for f in files if f["name"] == "reference"]
+    assert len(ref_files) == 1
+    assert ref_files[0]["fileId"] is not None
+    assert ref_files[0]["projectId"]
+    ribbon_elements = [
+        e for e in elements
+        if any(r["style"] == "CRs" for r in e["representations"])
+    ]
+    assert len(ribbon_elements) == 1
+    assert ribbon_elements[0]["file"] == "reference"
+
+    # Two fragment elements: ligand sticks (CBs), each scoped to a dictionary.
+    stick_elements = [
+        e for e in elements
+        if any(r["style"] == "CBs" for r in e["representations"])
+    ]
+    assert len(stick_elements) == 2
+
+    selections = " ".join(
+        r["selection"]
+        for e in stick_elements
+        for r in e["representations"]
+    )
+    assert "DRG" in selections
+    assert "LIG" in selections
+
+    # Challenge B: every hit element references its own dictionary, and that
+    # dictionary is declared in files[] as kind: dictionary.
+    dict_names = {f["name"] for f in files if f.get("kind") == "dictionary"}
+    assert len(dict_names) == 2
+    for element in stick_elements:
+        assert element["dictionaries"], f"{element['file']} has no scoped dict"
+        for dname in element["dictionaries"]:
+            assert dname in dict_names
+
+
+def test_summary_scene_empty_campaign(bypass_api_permissions, test_project_path):
+    """A campaign with no members yields an empty-but-valid scene, not a 500."""
+    test_project_path.mkdir(parents=True, exist_ok=True)
+    group = models.ProjectGroup.objects.create(
+        name="empty_campaign",
+        type=models.ProjectGroup.GroupType.FRAGMENT_SET,
+    )
+
+    client = APIClient()
+    response = client.get(
+        f"/api/ccp4i2/projectgroups/{group.id}/summary_scene/"
+    )
+    assert response.status_code == 200, response.content
+    data = response.json()
+    assert data["stats"]["members_total"] == 0
+    assert data["stats"]["hits"] == 0
+    assert data["stats"]["parent_present"] is False
+    assert data["scene"]["files"] == []
+    assert data["scene"]["elements"] == []

--- a/server/ccp4i2/tests/unit/lib/test_campaign_scene.py
+++ b/server/ccp4i2/tests/unit/lib/test_campaign_scene.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for fragment-campaign hit detection (``lib.campaign_scene``).
+
+These exercise the pure, gemmi-only detection helpers — no Django models,
+no CCP4 binaries — using tiny coordinate + dictionary files built in a
+tmp dir. The scene-assembly half (``build_summary_scene``) touches the DB
+and is covered by the API e2e suite instead.
+"""
+
+import gemmi
+import pytest
+
+from ccp4i2.lib import campaign_scene
+
+
+# --------------------------------------------------------------------------
+# Fixtures: build minimal coord + dict files
+# --------------------------------------------------------------------------
+
+def _write_pdb(path, ligand_code=None):
+    """A one-residue alanine 'protein', optionally plus a HET ligand."""
+    st = gemmi.Structure()
+    st.spacegroup_hm = "P 1"
+    st.cell = gemmi.UnitCell(30, 30, 30, 90, 90, 90)
+    model = gemmi.Model(1)
+    chain = gemmi.Chain("A")
+
+    res = gemmi.Residue()
+    res.name = "ALA"
+    res.seqid = gemmi.SeqId("1")
+    for nm, el in [("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O")]:
+        a = gemmi.Atom()
+        a.name = nm
+        a.element = gemmi.Element(el)
+        a.pos = gemmi.Position(1, 2, 3)
+        a.occ = 1.0
+        a.b_iso = 20.0
+        res.add_atom(a)
+    chain.add_residue(res)
+
+    if ligand_code:
+        lig = gemmi.Residue()
+        lig.name = ligand_code
+        lig.seqid = gemmi.SeqId("2")
+        lig.het_flag = "H"
+        a = gemmi.Atom()
+        a.name = "C1"
+        a.element = gemmi.Element("C")
+        a.pos = gemmi.Position(5, 5, 5)
+        a.occ = 1.0
+        a.b_iso = 30.0
+        lig.add_atom(a)
+        chain.add_residue(lig)
+
+    model.add_chain(chain)
+    st.add_model(model)
+    st.setup_entities()
+    path.write_text(st.make_pdb_string())
+    return path
+
+
+def _write_dict(path, *codes):
+    """A minimal refmac-style restraint CIF declaring one or more monomers.
+
+    Passing several codes simulates a merged LIBOUT that carries standard
+    monomers (ALA, GLY, ...) alongside the actual ligand.
+    """
+    list_rows = "\n".join(
+        f"{c} {c} 'monomer' non-polymer 3 3 ." for c in codes
+    )
+    comp_blocks = "\n".join(
+        f"""data_comp_{c}
+loop_
+_chem_comp_atom.comp_id
+_chem_comp_atom.atom_id
+_chem_comp_atom.type_symbol
+{c} C1 C
+{c} C2 C
+{c} O1 O"""
+        for c in codes
+    )
+    text = f"""data_comp_list
+loop_
+_chem_comp.id
+_chem_comp.three_letter_code
+_chem_comp.name
+_chem_comp.group
+_chem_comp.number_atoms_all
+_chem_comp.number_atoms_nh
+_chem_comp.desc_level
+{list_rows}
+{comp_blocks}
+"""
+    path.write_text(text)
+    return path
+
+
+# --------------------------------------------------------------------------
+# dictionary_comp_ids / coordinate_residue_names
+# --------------------------------------------------------------------------
+
+def test_dictionary_comp_ids_reads_all_sources(tmp_path):
+    d = _write_dict(tmp_path / "DRG.cif", "DRG")
+    ids = campaign_scene.dictionary_comp_ids(d)
+    assert "DRG" in ids
+    # The catch-all list block must not leak in as a comp id.
+    assert "LIST" not in ids
+
+
+def test_coordinate_residue_names(tmp_path):
+    p = _write_pdb(tmp_path / "model.pdb", ligand_code="DRG")
+    names = campaign_scene.coordinate_residue_names(p)
+    assert "ALA" in names
+    assert "DRG" in names
+
+
+# --------------------------------------------------------------------------
+# detect_ligands — the hit decision
+# --------------------------------------------------------------------------
+
+def test_dictionary_driven_hit(tmp_path):
+    """Ligand named for its dict comp_id is detected even with a non-LIG code."""
+    coords = _write_pdb(tmp_path / "model.pdb", ligand_code="ABC")
+    dictf = _write_dict(tmp_path / "ABC.cif", "ABC")
+    assert campaign_scene.detect_ligands(coords, dictf) == ["ABC"]
+
+
+def test_dictionary_present_but_ligand_absent_is_not_a_hit(tmp_path):
+    """An apo dataset (dict exists, but no such residue in coords) is no hit."""
+    coords = _write_pdb(tmp_path / "apo.pdb", ligand_code=None)
+    dictf = _write_dict(tmp_path / "DRG.cif", "DRG")
+    assert campaign_scene.detect_ligands(coords, dictf) == []
+
+
+def test_fallback_codes_when_no_dictionary(tmp_path):
+    """Without a dictionary, LIG/DRG/UNL placeholder codes still register."""
+    coords = _write_pdb(tmp_path / "model.pdb", ligand_code="LIG")
+    assert campaign_scene.detect_ligands(coords, dict_path=None) == ["LIG"]
+
+
+def test_fallback_ignores_unknown_code_without_dictionary(tmp_path):
+    """A real 3-letter code is invisible to the no-dictionary fallback."""
+    coords = _write_pdb(tmp_path / "model.pdb", ligand_code="ABC")
+    assert campaign_scene.detect_ligands(coords, dict_path=None) == []
+
+
+def test_merged_dict_with_standard_monomers_does_not_false_positive(tmp_path):
+    """A LIBOUT carrying ALA/GLY alongside the ligand flags only the ligand."""
+    coords = _write_pdb(tmp_path / "model.pdb", ligand_code="ABC")
+    # Dict declares the fragment plus standard amino acids (as merged LIBOUTs do).
+    dictf = _write_dict(tmp_path / "merged.cif", "ABC", "ALA", "GLY")
+    assert campaign_scene.detect_ligands(coords, dictf) == ["ABC"]
+
+
+def test_apo_with_merged_dict_is_not_a_hit(tmp_path):
+    """An apo model whose only dict comps are standard residues is no hit."""
+    coords = _write_pdb(tmp_path / "apo.pdb", ligand_code=None)
+    dictf = _write_dict(tmp_path / "merged.cif", "DRG", "ALA", "GLY")
+    assert campaign_scene.detect_ligands(coords, dictf) == []
+
+
+def test_crystallisation_additive_is_not_a_hit(tmp_path):
+    """Glycerol bound (and in the dict) must not register as a fragment."""
+    coords = _write_pdb(tmp_path / "model.pdb", ligand_code="GOL")
+    dictf = _write_dict(tmp_path / "GOL.cif", "GOL")
+    assert campaign_scene.detect_ligands(coords, dictf) == []
+
+
+def test_unreadable_coordinates_are_not_a_hit(tmp_path):
+    bad = tmp_path / "nope.pdb"
+    bad.write_text("this is not a coordinate file\n")
+    # Should swallow the gemmi error and report no hit, not raise.
+    assert campaign_scene.detect_ligands(bad, dict_path=None) == []


### PR DESCRIPTION
## Fragment Campaign — Summary View (Moorhen scene)

Adds a one-click **Summary View** for fragment campaigns: the parent reference rendered as a ribbon, with **every discovered fragment** overlaid as ligand sticks at its binding site — each fragment associated with its correct restraint dictionary. Built on the moorhen-scenes format (the per-molecule scoped-dictionary case it was designed for).

### How the two hard parts are solved
- **Which datasets are hits** — dictionary-driven detection (`server/ccp4i2/lib/campaign_scene.py`): read each member's restraint CIF comp_ids with gemmi, intersect with residues actually present in the refined coordinates. Match = hit, and it yields the exact ligand CID to render. Falls back to `LIG`/`DRG`/`UNL` when a member has no dictionary. Standard amino acids / nucleotides / water / common crystallisation additives are filtered out, so a merged `LIBOUT` (or a bound glycerol) doesn't false-positive every dataset.
- **Coords pulled in with the *correct* dictionary** — the generated scene lists each hit's dictionary in the element's `dictionaries:` block; the existing scene resolver loads it globally then re-scopes it to that molecule's molNo, so two datasets whose ligands share a code but differ in chemistry stay correct.

### Changes
- **Backend**: new `lib/campaign_scene.py` (`detect_ligands` + `build_summary_scene`, reusing `pandda_export`'s job/dictionary helpers) and a `summary_scene` action on `ProjectGroupViewSet` → `GET /api/ccp4i2/projectgroups/{id}/summary_scene/`.
- **Frontend**: `applyScene` wired natively into the campaign Moorhen wrapper via a new `scene` file source; `?summary=1` mode on the campaign Moorhen page; `fetchSummaryScene` API hook; the placeholder **Summary View** button rewired to open the overview.
- **Docs**: refreshed `MOORHEN_SCENES.md` and `types/moorhen-scene.md` (maps/`activeMap`, hex-alpha, current status).

### Tests
- 10 unit tests for detection (hit / apo / non-LIG codes / merged-dict + additive false-positive guards).
- 2 e2e API tests that build a synthetic campaign (parent + 2 hit members + 1 apo) on disk and assert the endpoint's scene shape, scoped dictionaries, and skip accounting.
- `tsc --noEmit` clean.

The synthetic e2e shapes are deliberately minimal; thresholds/labels may need revisiting against real XChem data, but the contract (parent ribbon + per-hit scoped-dictionary stick element + honest skip accounting) should hold.

### Out of scope (v1)
No superposition (assumes isomorphous soaks already in the parent frame), no maps in the overview, no per-member ribbons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
