### PR TITLE
Fragment campaign summary: fix loading, add Scenes tab, broaden hit detection

### DIFF
--- a/client/renderer/app/ccp4i2/(authed)/moorhen-page/campaign/[id]/campaign-page-client.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/moorhen-page/campaign/[id]/campaign-page-client.tsx
@@ -56,15 +56,19 @@ function CampaignPageContent() {
     setSelectedJobId(null); // Reset to auto-select latest job
   }, []);
 
-  // Summary mode: fetch the campaign overview scene once on entry.
+  // Summary mode: fetch the campaign overview scene.
+  //
+  // The deps here must stay free of unstable values. `campaignsApi` is a fresh
+  // object every render, and `summaryLoading`-style state we set in the effect
+  // would also churn the deps — either makes the effect re-run mid-flight, fire
+  // its cleanup, and cancel the in-flight fetch, so the scene gets fetched and
+  // then silently discarded. We depend only on the stable inputs and rely on
+  // the `cancelled` flag (which is StrictMode-safe: the second mount re-fetches
+  // and wins).
   const [summaryScene, setSummaryScene] = useState<MoorhenScene | null>(null);
-  const [summaryLoading, setSummaryLoading] = useState(false);
   useEffect(() => {
-    if (!summaryMode || campaignId === null || summaryScene !== null || summaryLoading) {
-      return;
-    }
+    if (!summaryMode || campaignId === null) return;
     let cancelled = false;
-    setSummaryLoading(true);
     campaignsApi
       .fetchSummaryScene(campaignId)
       .then((res) => {
@@ -72,22 +76,19 @@ function CampaignPageContent() {
       })
       .catch((err) => {
         console.error("Failed to load campaign summary scene:", err);
-      })
-      .finally(() => {
-        if (!cancelled) setSummaryLoading(false);
       });
     return () => {
       cancelled = true;
     };
-  }, [summaryMode, campaignId, summaryScene, summaryLoading, campaignsApi]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [summaryMode, campaignId]);
 
   // Determine which files to load based on selection
   const fileIds = useMemo(() => {
-    // Summary overview: the whole-campaign scene (parent + all fragments).
+    // Summary overview: the scene is applied by the Scenes panel (via the
+    // summaryScene prop), not the file loader — so load nothing here.
     if (summaryMode) {
-      return summaryScene
-        ? { type: "scene" as const, scene: summaryScene }
-        : { type: "none" as const };
+      return { type: "none" as const };
     }
 
     // If a specific job is selected, load that job
@@ -128,7 +129,7 @@ function CampaignPageContent() {
     }
     // Note: maps would need to be added here when parent has map files
     return { type: "files" as const, fileIds: ids };
-  }, [parentFiles, selectedMemberProjectId, selectedJobId, memberProjects, summaryMode, summaryScene]);
+  }, [parentFiles, selectedMemberProjectId, selectedJobId, memberProjects, summaryMode]);
 
   // Build breadcrumbs for the layout AppBar
   const { setBreadcrumbs } = useMoorhenBreadcrumbs();
@@ -199,6 +200,7 @@ function CampaignPageContent() {
       <CampaignMoorhenWrapper
         campaign={campaign}
         fileSource={fileIds}
+        summaryScene={summaryMode ? summaryScene : null}
         viewParam={viewParam}
         sites={sites || []}
         onUpdateSites={handleUpdateSites}

--- a/client/renderer/components/moorhen/campaign-moorhen-tabbed-panel.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-tabbed-panel.tsx
@@ -1,0 +1,116 @@
+/**
+ * Campaign tabbed side-panel — hosts the campaign Controls and the Scenes
+ * editor under one Moorhen side-panel registration, mirroring the generic
+ * job/file viewer's CCP4i2 tabbed panel.
+ *
+ * Registering two custom extraSidePanels with Moorhen only ever surfaces one
+ * tab (an upstream quirk), so we put our own MUI Tabs inside one panel. Both
+ * sub-panels stay mounted (the inactive one is display:none) so Monaco's
+ * editor state in the Scenes tab survives switching back to Controls.
+ *
+ * The campaign viewer applies scenes but does not lift them, so the Scenes
+ * panel here is given only onApplyScene — its Capture / Save-self-contained
+ * actions are hidden (those props are optional on MoorhenScenesPanel).
+ */
+import React, { useMemo, useState } from "react";
+import { Box, Tab, Tabs } from "@mui/material";
+
+import { CampaignControlPanel } from "./campaign-control-panel";
+import { MoorhenScenesPanel, SceneBundleAssets } from "./moorhen-scenes-panel";
+import type { SceneResolveResult } from "../../lib/moorhen-scene-resolver";
+
+export interface CampaignMoorhenTabbedPanelProps {
+  /** Everything the campaign control panel needs, forwarded verbatim. */
+  controlPanelProps: React.ComponentProps<typeof CampaignControlPanel>;
+  /** Apply the editor's YAML (+ bundle assets) to the current view. */
+  onApplyScene: (
+    yamlText: string,
+    assets: SceneBundleAssets,
+  ) => Promise<SceneResolveResult>;
+  /** True once Coot is ready (gates Apply / live-apply). */
+  cootInitialized: boolean;
+  /** Optional YAML to seed the Scenes editor with (the summary scene). */
+  initialSceneYaml?: string;
+  /** Apply `initialSceneYaml` automatically through the Scenes panel. */
+  autoApplyInitialScene?: boolean;
+}
+
+export const CampaignMoorhenTabbedPanel: React.FC<CampaignMoorhenTabbedPanelProps> = ({
+  controlPanelProps,
+  onApplyScene,
+  cootInitialized,
+  initialSceneYaml,
+  autoApplyInitialScene,
+}) => {
+  const [activeTab, setActiveTab] = useState<"campaign" | "scenes">("campaign");
+
+  const controlsContent = useMemo(
+    () => <CampaignControlPanel {...controlPanelProps} />,
+    [controlPanelProps],
+  );
+
+  // Stable across control-panel re-renders so Monaco editor state survives.
+  const scenesContent = useMemo(
+    () => (
+      <MoorhenScenesPanel
+        onApplyScene={onApplyScene}
+        enabled={cootInitialized}
+        initialYaml={initialSceneYaml}
+        autoApplyInitial={autoApplyInitialScene}
+      />
+    ),
+    [onApplyScene, cootInitialized, initialSceneYaml, autoApplyInitialScene],
+  );
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        width: "100%",
+        minWidth: 0,
+      }}
+    >
+      <Tabs
+        value={activeTab}
+        onChange={(_, v) => setActiveTab(v)}
+        variant="fullWidth"
+        sx={{ borderBottom: 1, borderColor: "divider", minHeight: 36 }}
+      >
+        <Tab
+          label="Campaign"
+          value="campaign"
+          sx={{ minHeight: 36, py: 0.5, fontSize: "0.75rem", textTransform: "none" }}
+        />
+        <Tab
+          label="Scenes"
+          value="scenes"
+          sx={{ minHeight: 36, py: 0.5, fontSize: "0.75rem", textTransform: "none" }}
+        />
+      </Tabs>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          width: "100%",
+          overflow: "hidden",
+          display: activeTab === "campaign" ? "block" : "none",
+        }}
+      >
+        {controlsContent}
+      </Box>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          width: "100%",
+          overflow: "hidden",
+          display: activeTab === "scenes" ? "block" : "none",
+        }}
+      >
+        {scenesContent}
+      </Box>
+    </Box>
+  );
+};

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -12,6 +12,7 @@
 
 import {
   addMolecule,
+  showMolecule,
   addMap,
   removeMolecule,
   removeMap,
@@ -42,7 +43,6 @@ import {
 import { moorhen } from "moorhen/types/moorhen";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import { webGL } from "moorhen/types/mgWebGL";
-import { CampaignControlPanel } from "./campaign-control-panel";
 import { apiText, apiArrayBuffer, apiGet, apiPost, apiUpload } from "../../api-fetch";
 import { useTheme } from "../../theme/theme-provider";
 import { useMoorhenViewState } from "../../hooks/use-moorhen-view-state";
@@ -65,18 +65,25 @@ import {
   SceneFileFetcher,
   SceneDictionaryFetcher,
   SceneDictionaryLoader,
+  SceneResolveResult,
 } from "../../lib/moorhen-scene-resolver";
+import { parseScene, serialiseScene } from "../../lib/moorhen-scene";
 import type { MoorhenScene, SceneFileRef } from "../../types/moorhen-scene";
+import { CampaignMoorhenTabbedPanel } from "./campaign-moorhen-tabbed-panel";
+import type { SceneBundleAssets } from "./moorhen-scenes-panel";
 
 type FileSource =
   | { type: "none" }
   | { type: "files"; fileIds: number[] }
-  | { type: "job"; jobId: number }
-  | { type: "scene"; scene: MoorhenScene };
+  | { type: "job"; jobId: number };
 
 export interface CampaignMoorhenWrapperProps {
   campaign: ProjectGroup;
   fileSource: FileSource;
+  /** Campaign summary scene (built server-side). When set, it's seeded into
+   *  the Scenes panel and auto-applied through that panel's own parse/apply
+   *  path — the single rendering pathway shared with hand-edited scenes. */
+  summaryScene?: MoorhenScene | null;
   viewParam?: string | null;
   sites: CampaignSite[];
   onUpdateSites: (sites: CampaignSite[]) => Promise<void>;
@@ -89,6 +96,7 @@ export interface CampaignMoorhenWrapperProps {
 const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
   campaign,
   fileSource,
+  summaryScene,
   viewParam,
   sites,
   onUpdateSites,
@@ -259,13 +267,22 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
   // dictionary dance the fragment-campaign case needs.
   // ----------------------------------------------------------------------
 
-  // Bare structure load for the scene fetcher: load coords and register the
-  // molecule, but DON'T impose representations — the scene owns the look
-  // (the resolver hides loader defaults and applies the scene's reps).
-  const loadSceneStructure = useCallback(
+  // Bundle assets (from an opened .scene.zip in the Scenes panel) live in a
+  // ref so the stable-identity fetchers below can reach this apply's assets;
+  // refreshed at the top of each apply.
+  const bundleAssetsRef = useRef<SceneBundleAssets>(new Map());
+
+  // Structure load for the scene fetcher. Mirrors the generic wrapper's
+  // proven loadStructureFromText: load coords, add default reps, centre, and
+  // crucially dispatch(showMolecule) so the molecule is actually visible. The
+  // resolver then hides these loader-default reps and applies the scene's own
+  // (so "scene owns the look" still holds) — but without showMolecule the
+  // molecule loads invisibly and the viewer stays blank.
+  const loadSceneStructureFromText = useCallback(
     async (
-      url: string,
+      coordText: string,
       molName: string,
+      uniqueId: string,
     ): Promise<moorhen.Molecule | null> => {
       if (!commandCentre.current) return null;
       const newMolecule = new MoorhenMolecule(
@@ -276,22 +293,62 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       newMolecule.setBackgroundColour(backgroundColor);
       newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness;
       try {
-        const pdbData = await apiText(url);
-        await newMolecule.loadToCootFromString(pdbData, molName);
+        await newMolecule.loadToCootFromString(coordText, molName);
         if (newMolecule.molNo === -1) throw new Error("Cannot read coordinates");
-        newMolecule.uniqueId = url;
+        newMolecule.uniqueId = uniqueId;
+        // Ribbon first (protein overview), fall back to sticks. These get
+        // hidden by the resolver and replaced with the scene's reps.
+        try {
+          await newMolecule.addRepresentation("CRs", "/*/*/*/*");
+        } catch {
+          await newMolecule.addRepresentation("CBs", "/*/*/*/*");
+        }
+        try {
+          await newMolecule.addRepresentation("ligands", "/*/*/*/*");
+        } catch {
+          /* no ligands present — fine */
+        }
+        await newMolecule.centreOn("/*/*/*/*", false, true);
         dispatch(addMolecule(newMolecule));
+        dispatch(showMolecule({ molNo: newMolecule.molNo } as never));
         return newMolecule;
       } catch (err) {
-        console.warn(`[scene] failed to load ${molName} from ${url}:`, err);
+        console.warn(`[scene] failed to load ${molName} (${uniqueId}):`, err);
         return null;
       }
     },
     [commandCentre, store, monomerLibraryPath, backgroundColor, defaultBondSmoothness, dispatch],
   );
 
+  const loadSceneStructure = useCallback(
+    async (url: string, molName: string): Promise<moorhen.Molecule | null> => {
+      try {
+        const pdbData = await apiText(url);
+        return loadSceneStructureFromText(pdbData, molName, url);
+      } catch (err) {
+        console.warn(`[scene] failed to fetch ${molName} from ${url}:`, err);
+        return null;
+      }
+    },
+    [loadSceneStructureFromText],
+  );
+
   const handleFetchSceneFile: SceneFileFetcher = useCallback(
     async (ref: SceneFileRef) => {
+      // Bundle: decode bytes from the in-memory asset map (no network).
+      if (ref.bundle) {
+        const buf = bundleAssetsRef.current.get(ref.bundle);
+        if (!buf) {
+          console.warn(`[scene] bundle lookup miss: ${ref.bundle}`);
+          return null;
+        }
+        const coordText = new TextDecoder("utf-8").decode(buf);
+        return loadSceneStructureFromText(
+          coordText,
+          ref.name || ref.bundle,
+          `bundle:${ref.bundle}`,
+        );
+      }
       if (ref.fileId !== undefined && ref.projectId) {
         return loadSceneStructure(
           `/api/proxy/ccp4i2/files/${ref.fileId}/download/`,
@@ -308,12 +365,17 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       if (ref.url) return loadSceneStructure(ref.url, ref.name || ref.url);
       return null;
     },
-    [loadSceneStructure],
+    [loadSceneStructure, loadSceneStructureFromText],
   );
 
   const handleFetchSceneDictionary: SceneDictionaryFetcher = useCallback(
     async (ref: SceneFileRef): Promise<string | null> => {
       if (ref.cifText) return ref.cifText;
+      if (ref.bundle) {
+        const buf = bundleAssetsRef.current.get(ref.bundle);
+        if (!buf) return null;
+        return new TextDecoder("utf-8").decode(buf);
+      }
       let url: string | null = null;
       if (ref.fileId !== undefined && ref.projectId) {
         url = `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
@@ -347,8 +409,13 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     [],
   );
 
-  const handleApplyScene = useCallback(
-    async (scene: MoorhenScene) => {
+  // Core apply: hand a parsed scene + bundle assets to the resolver.
+  const runScene = useCallback(
+    async (
+      scene: MoorhenScene,
+      assets: SceneBundleAssets = new Map(),
+    ): Promise<SceneResolveResult> => {
+      bundleAssetsRef.current = assets;
       const result = await applyScene({
         scene,
         molecules,
@@ -359,16 +426,6 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
         dictionaryLoader: handleLoadSceneDictionary,
       });
       dispatch(setRequestDrawScene(true));
-      const shown = result.applied.length;
-      if (shown === 0) {
-        setMessage(
-          "No fragment hits to display — no member dataset had a ligand in its refined model.",
-        );
-      } else if (result.unresolvedFiles.length > 0) {
-        setMessage(
-          `Showing ${shown} structure(s); ${result.unresolvedFiles.length} could not be loaded.`,
-        );
-      }
       return result;
     },
     [
@@ -378,8 +435,17 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       handleFetchSceneFile,
       handleFetchSceneDictionary,
       handleLoadSceneDictionary,
-      setMessage,
     ],
+  );
+
+  // Scenes-panel path: parse the editor YAML and apply (with bundle assets
+  // when opened from a .scene.zip). This is the single apply entry — the
+  // summary view drives it too, via the panel's auto-apply.
+  const handleApplyScene = useCallback(
+    (yamlText: string, assets: SceneBundleAssets): Promise<SceneResolveResult> => {
+      return runScene(parseScene(yamlText), assets);
+    },
+    [runScene],
   );
 
   // Load files when fileSource changes
@@ -404,10 +470,10 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       });
     } else if (fileSource.type === "job") {
       fetchJobFiles(fileSource.jobId);
-    } else if (fileSource.type === "scene") {
-      handleApplyScene(fileSource.scene);
     }
-  }, [fileSource, cootInitialized, cleanupLoadedContent, handleApplyScene]);
+    // The summary scene is applied by the Scenes panel (auto-apply), not here,
+    // so it shares one rendering pathway with hand-edited scenes.
+  }, [fileSource, cootInitialized, cleanupLoadedContent]);
 
   // Dimension updates are handled by Moorhen's MainContainer automatically
 
@@ -876,34 +942,54 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
   // (it builds the per-instance MoorhenInstance from it).
   const menuSystem = useMemo(() => new MoorhenMenuSystem(), []);
 
-  // Custom side panel containing our campaign control panel
+  // When viewing the campaign summary, serialise the scene to YAML so the
+  // Scenes panel can show it in the editor and auto-apply it through its own
+  // parse/apply path (one shared rendering pathway).
+  const summarySceneYaml = useMemo(() => {
+    if (!summaryScene) return undefined;
+    try {
+      return serialiseScene(summaryScene);
+    } catch (err) {
+      console.warn("[scene] failed to serialise summary scene for editor:", err);
+      return undefined;
+    }
+  }, [summaryScene]);
+
+  // Custom side panel: campaign Controls + Scenes editor under one Moorhen
+  // side-panel registration (matching the job/file viewers' tabbed panel).
   const extraSidePanels: Record<string, MoorhenPanel> = {
     campaignControls: {
       icon: "MatSymSettings",
       label: "Campaign",
       panelContent: (
-        <CampaignControlPanel
-          campaign={campaign}
-          sites={sites}
-          onGoToSite={handleGoToSite}
-          onSaveCurrentAsSite={handleSaveCurrentAsSite}
-          onUpdateSite={handleUpdateSite}
-          onDeleteSite={handleDeleteSite}
-          memberProjects={memberProjects}
-          selectedMemberProjectId={selectedMemberProjectId}
-          onSelectMemberProject={onSelectMemberProject}
-          parentProject={parentProject}
-          getViewUrl={getViewUrl}
-          molecules={molecules}
-          visibleRepresentations={visibleRepresentations}
-          onRepresentationsChange={setVisibleRepresentations}
-          ligandDictFileId={ligandDictFileId}
-          ligandName={ligandName}
-          maps={maps}
-          onMapContourLevelChange={handleMapContourLevelChange}
-          onTagProjectWithSite={handleTagProjectWithSite}
-          onFileSelect={fetchFile}
-          onRunServalcat={handleRunServalcat}
+        <CampaignMoorhenTabbedPanel
+          controlPanelProps={{
+            campaign,
+            sites,
+            onGoToSite: handleGoToSite,
+            onSaveCurrentAsSite: handleSaveCurrentAsSite,
+            onUpdateSite: handleUpdateSite,
+            onDeleteSite: handleDeleteSite,
+            memberProjects,
+            selectedMemberProjectId,
+            onSelectMemberProject,
+            parentProject,
+            getViewUrl,
+            molecules,
+            visibleRepresentations,
+            onRepresentationsChange: setVisibleRepresentations,
+            ligandDictFileId,
+            ligandName,
+            maps,
+            onMapContourLevelChange: handleMapContourLevelChange,
+            onTagProjectWithSite: handleTagProjectWithSite,
+            onFileSelect: fetchFile,
+            onRunServalcat: handleRunServalcat,
+          }}
+          onApplyScene={handleApplyScene}
+          cootInitialized={cootInitialized}
+          initialSceneYaml={summarySceneYaml}
+          autoApplyInitialScene={!!summarySceneYaml}
         />
       ),
     },

--- a/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
@@ -92,8 +92,10 @@ interface MoorhenScenesPanelProps {
   /** Capture the current view as a scene + lift hints + bundle assets.
    *  The lifter may inline non-portable molecule coords/dicts into the
    *  assets map; the panel will save as .scene.zip when assets are
-   *  present, plain .scene.yaml otherwise. */
-  onCaptureScene: () => Promise<{
+   *  present, plain .scene.yaml otherwise. Optional — when omitted the
+   *  Capture button is hidden (e.g. the campaign viewer, which applies
+   *  scenes but doesn't lift them). */
+  onCaptureScene?: () => Promise<{
     scene: MoorhenScene;
     hints: SceneLiftHints;
     assets: SceneBundleAssets;
@@ -101,8 +103,9 @@ interface MoorhenScenesPanelProps {
   /** Promote the editor YAML to a fully self-contained scene: every
    *  URL-resolvable ref is fetched, library-dict comp_ids are re-
    *  collected, and everything lands in the returned asset map under
-   *  bundle: paths. Used by Save (self-contained). */
-  onPromoteSceneToPortable: (
+   *  bundle: paths. Used by Save (self-contained). Optional — when
+   *  omitted the "Save self-contained" menu item is hidden. */
+  onPromoteSceneToPortable?: (
     yamlText: string,
     currentAssets: SceneBundleAssets,
   ) => Promise<{
@@ -112,6 +115,15 @@ interface MoorhenScenesPanelProps {
   }>;
   /** True once Moorhen / Coot is ready. Disables apply until then. */
   enabled: boolean;
+  /** Optional initial YAML to seed the editor with (e.g. the campaign
+   *  summary scene). Applied only while the editor is still untouched, so
+   *  it never clobbers what the user has typed. */
+  initialYaml?: string;
+  /** When true, `initialYaml` is not just shown in the editor but also
+   *  applied automatically (once, as soon as Coot is ready) through this
+   *  panel's own parse/apply path — so the summary view and hand-edited
+   *  scenes share exactly one rendering/orienting pathway. */
+  autoApplyInitial?: boolean;
 }
 
 type Severity = "info" | "success" | "warning" | "error";
@@ -127,8 +139,20 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
   onCaptureScene,
   onPromoteSceneToPortable,
   enabled,
+  initialYaml,
+  autoApplyInitial,
 }) => {
   const [yamlText, setYamlText] = useState<string>("");
+
+  // Seed the editor with a supplied scene (e.g. the campaign summary) the
+  // first time it arrives, but only while the editor is still empty so we
+  // never overwrite the user's own edits.
+  useEffect(() => {
+    if (initialYaml && !yamlText.trim()) {
+      setYamlText(initialYaml);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialYaml]);
   // Live apply is opt-in. Loading / capturing a scene populates the editor
   // but does not touch the viewer until the user clicks Apply (or enables
   // Live apply). This lets the user inspect/edit a YAML before committing.
@@ -143,6 +167,7 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
   // --- actions ------------------------------------------------------------
 
   const handleCapture = useCallback(async () => {
+    if (!onCaptureScene) return;
     try {
       const { scene, hints, assets } = await onCaptureScene();
       const yaml = serialiseSceneWithComments(scene, hints.fileComments);
@@ -284,6 +309,17 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
     void applyNow(yamlText, { silentOnParseError: false });
   }, [applyNow, yamlText]);
 
+  // Auto-apply a supplied scene (the campaign summary) through this panel's
+  // own apply path, once, as soon as Coot is ready. Keyed on the YAML value
+  // so a different summary re-applies but the user's own edits never do.
+  const autoAppliedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!autoApplyInitial || !enabled || !initialYaml) return;
+    if (autoAppliedRef.current === initialYaml) return;
+    autoAppliedRef.current = initialYaml;
+    void applyNow(initialYaml, { silentOnParseError: false });
+  }, [autoApplyInitial, enabled, initialYaml, applyNow]);
+
   // --- save (light vs self-contained) ------------------------------------
   //
   // Light: write whatever the editor holds. If any ref already uses a
@@ -356,6 +392,7 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
   }, [yamlText, triggerDownload]);
 
   const handleSaveSelfContained = useCallback(async () => {
+    if (!onPromoteSceneToPortable) return;
     if (!yamlText.trim()) {
       setMessage({ severity: "warning", text: "Nothing to save" });
       return;
@@ -433,19 +470,21 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
     >
       {/* Toolbar */}
       <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", alignItems: "center" }}>
-        <Tooltip title="Capture the current view into the editor (lifter)">
-          <span>
-            <Button
-              size="small"
-              variant="outlined"
-              startIcon={<CaptureIcon />}
-              onClick={handleCapture}
-              sx={{ fontSize: "0.75rem", textTransform: "none" }}
-            >
-              Capture
-            </Button>
-          </span>
-        </Tooltip>
+        {onCaptureScene && (
+          <Tooltip title="Capture the current view into the editor (lifter)">
+            <span>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<CaptureIcon />}
+                onClick={handleCapture}
+                sx={{ fontSize: "0.75rem", textTransform: "none" }}
+              >
+                Capture
+              </Button>
+            </span>
+          </Tooltip>
+        )}
 
         <Tooltip title="Open a .scene.yaml or .scene.zip from disk (zips bring their bundled assets along)">
           <span>
@@ -482,35 +521,39 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
               Save
             </Button>
           </Tooltip>
-          <Tooltip title="More save options">
-            <Button
-              size="small"
-              onClick={(e) => setSaveMenuAnchor(e.currentTarget)}
-              sx={{ px: 0.5, minWidth: 0 }}
-            >
-              <DropDownIcon fontSize="small" />
-            </Button>
-          </Tooltip>
+          {onPromoteSceneToPortable && (
+            <Tooltip title="More save options">
+              <Button
+                size="small"
+                onClick={(e) => setSaveMenuAnchor(e.currentTarget)}
+                sx={{ px: 0.5, minWidth: 0 }}
+              >
+                <DropDownIcon fontSize="small" />
+              </Button>
+            </Tooltip>
+          )}
         </ButtonGroup>
-        <Menu
-          anchorEl={saveMenuAnchor}
-          open={Boolean(saveMenuAnchor)}
-          onClose={() => setSaveMenuAnchor(null)}
-        >
-          <MenuItem
-            onClick={() => {
-              setSaveMenuAnchor(null);
-              void handleSaveSelfContained();
-            }}
+        {onPromoteSceneToPortable && (
+          <Menu
+            anchorEl={saveMenuAnchor}
+            open={Boolean(saveMenuAnchor)}
+            onClose={() => setSaveMenuAnchor(null)}
           >
-            <Stack>
-              <Typography variant="body2">Save self-contained…</Typography>
-              <Typography variant="caption" sx={{ color: "#666" }}>
-                Fetch every URL-resolvable ref and bundle into one .scene.zip
-              </Typography>
-            </Stack>
-          </MenuItem>
-        </Menu>
+            <MenuItem
+              onClick={() => {
+                setSaveMenuAnchor(null);
+                void handleSaveSelfContained();
+              }}
+            >
+              <Stack>
+                <Typography variant="body2">Save self-contained…</Typography>
+                <Typography variant="caption" sx={{ color: "#666" }}>
+                  Fetch every URL-resolvable ref and bundle into one .scene.zip
+                </Typography>
+              </Stack>
+            </MenuItem>
+          </Menu>
+        )}
 
         <FormControlLabel
           control={

--- a/server/ccp4i2/lib/campaign_scene.py
+++ b/server/ccp4i2/lib/campaign_scene.py
@@ -39,13 +39,20 @@ logger = logging.getLogger(f"ccp4i2:{__name__}")
 
 
 # Refinement tasks whose latest finished job carries the ligand-bound
-# coordinates. Mirrors the set the campaign Moorhen page already uses to
-# auto-select a member's job (campaign-page-client.tsx).
-REFINE_TASK_NAMES = ("refmac", "i2Refmac", "i2Dimple", "dimple")
-
-# Placeholder ligand codes used when a member has no dictionary to key
-# detection off (the user's original heuristic).
-FALLBACK_LIGAND_CODES = frozenset({"LIG", "DRG", "UNL"})
+# coordinates. Fragment campaigns here refine with servalcat (via
+# servalcat_pipe), so that must come first / be present — otherwise the
+# latest finished job falls back to an early apo refmac/dimple model and the
+# soaked ligand is missed. order doesn't affect selection (we take the
+# highest-id finished job among these), but servalcat_pipe is the canonical
+# campaign refinement and its XYZOUT is the final ligand-bound model.
+REFINE_TASK_NAMES = (
+    "servalcat_pipe",
+    "prosmart_refmac",
+    "refmac",
+    "i2Refmac",
+    "i2Dimple",
+    "dimple",
+)
 
 # Crystallisation additives, cryoprotectants and ions that commonly appear
 # as HET residues but are NOT a fragment hit. A refmac LIBOUT can also carry
@@ -141,10 +148,18 @@ def coordinate_residue_names(coord_path) -> set:
 def detect_ligands(coord_path, dict_path: Optional[object] = None) -> list:
     """Return the ligand codes a dataset should be judged a hit on.
 
-    Dictionary-driven: the intersection of the dictionary's comp_ids with
-    the residue names actually present in the coordinates. When no
-    dictionary is available (or it yields no match), fall back to the
-    conventional placeholder codes (LIG/DRG/UNL) found in the coords.
+    A dataset is a hit if its refined coordinates contain a *fragment-like*
+    HET residue: anything that isn't a standard amino acid / nucleic acid /
+    water / common crystallisation additive (see ``_is_fragment_code``). This
+    catches real three-letter ligand codes (e.g. ``NUT`` for Nutlin), not just
+    the conventional placeholders, and works even when no restraint dictionary
+    is present — fragment campaigns refined with servalcat often have none.
+
+    When a dictionary *is* available, the dictionary-confirmed subset is
+    preferred: it pins the comp_id we render and gives the scoped dictionary
+    that lets same-named ligands with different chemistry coexist. If the
+    dictionary covers none of the candidates, we still fall back to the
+    coordinate-derived candidates.
 
     Returns a sorted list (possibly empty -> not a hit).
     """
@@ -154,13 +169,16 @@ def detect_ligands(coord_path, dict_path: Optional[object] = None) -> list:
         logger.warning("Could not read coordinates %s: %s", coord_path, exc)
         return []
 
-    if dict_path is not None:
-        candidates = dictionary_comp_ids(dict_path) & coord_names
-        hits = sorted(c for c in candidates if _is_fragment_code(c))
-        if hits:
-            return hits
+    candidates = {name for name in coord_names if _is_fragment_code(name)}
+    if not candidates:
+        return []
 
-    return sorted(coord_names & FALLBACK_LIGAND_CODES)
+    if dict_path is not None:
+        confirmed = sorted(candidates & dictionary_comp_ids(dict_path))
+        if confirmed:
+            return confirmed
+
+    return sorted(candidates)
 
 
 # --------------------------------------------------------------------------

--- a/server/ccp4i2/tests/unit/lib/test_campaign_scene.py
+++ b/server/ccp4i2/tests/unit/lib/test_campaign_scene.py
@@ -132,16 +132,20 @@ def test_dictionary_present_but_ligand_absent_is_not_a_hit(tmp_path):
     assert campaign_scene.detect_ligands(coords, dictf) == []
 
 
-def test_fallback_codes_when_no_dictionary(tmp_path):
-    """Without a dictionary, LIG/DRG/UNL placeholder codes still register."""
+def test_placeholder_code_without_dictionary(tmp_path):
+    """Without a dictionary, a placeholder LIG still registers."""
     coords = _write_pdb(tmp_path / "model.pdb", ligand_code="LIG")
     assert campaign_scene.detect_ligands(coords, dict_path=None) == ["LIG"]
 
 
-def test_fallback_ignores_unknown_code_without_dictionary(tmp_path):
-    """A real 3-letter code is invisible to the no-dictionary fallback."""
-    coords = _write_pdb(tmp_path / "model.pdb", ligand_code="ABC")
-    assert campaign_scene.detect_ligands(coords, dict_path=None) == []
+def test_real_ligand_code_detected_without_dictionary(tmp_path):
+    """A real soaked-fragment code (e.g. NUT) is detected even with no dict.
+
+    Fragment campaigns refined with servalcat often carry no restraint
+    dictionary, so detection must not depend on one.
+    """
+    coords = _write_pdb(tmp_path / "model.pdb", ligand_code="NUT")
+    assert campaign_scene.detect_ligands(coords, dict_path=None) == ["NUT"]
 
 
 def test_merged_dict_with_standard_monomers_does_not_false_positive(tmp_path):


### PR DESCRIPTION
## Fragment campaign summary view — follow-up fixes

Fixes found while testing the summary view (#200) against a live MDM2 fragment campaign.

### Loading
- **Self-cancelling fetch.** `campaignsApi` (a fresh object each render) and `summaryLoading` were in the fetch effect's deps, so it re-ran on its own `setState`, fired cleanup, and cancelled the in-flight request — the scene was fetched then silently discarded (deterministically, every restart). Now depends only on stable inputs with the StrictMode-safe `cancelled` flag.
- **Blank viewer.** The scene loader added the molecule but never made it visible. Added default reps + `centreOn` + `dispatch(showMolecule)`, matching the proven generic/job loaders (the resolver still hides the defaults and applies the scene's own reps).

### Scenes panel on the campaign page
- Added a **Scenes tab** to the campaign Moorhen page (new campaign tabbed panel), on par with the job/file viewers.
- Made `onCaptureScene` / `onPromoteSceneToPortable` **optional** on `MoorhenScenesPanel` — the campaign viewer applies scenes but doesn't lift them, so Capture / Save-self-contained are hidden there (generic viewers unaffected).
- **Unified apply:** the summary now seeds the Scenes editor and auto-applies through that panel's own parse/apply path, so summary and hand-edited scenes share one rendering/orienting pathway.

### Hit detection
- Include **`servalcat_pipe`** (and `prosmart_refmac`) in the refinement task set — fragment campaigns refine with servalcat, so the previous refmac/dimple-only set picked an early apo model and missed the soaked ligand.
- **Broadened detection:** any non-standard, non-water, non-additive HET residue counts as the fragment (catches real codes like `NUT`, not just `LIG`/`DRG`/`UNL`), so it works even with no restraint dictionary present. A dictionary, when available, still scopes/confirms the comp_id.

### Verification
- `tsc --noEmit` clean.
- 12 Python tests pass (unit detection + e2e endpoint), incl. a new case asserting a real code (`NUT`) is detected without a dictionary.
- Confirmed live: MDM2Frags summary now reports `hits=1` with `CBs //*/(NUT)` over the parent ribbon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
