### PR TITLE
Masks: renderable in Moorhen views, describable in scenes

### DIFF
--- a/client/renderer/MOORHEN_SCENES.md
+++ b/client/renderer/MOORHEN_SCENES.md
@@ -42,6 +42,9 @@ The format supports:
 - **SSM and LSQ superpositions** (with a `chain`+`range` shorthand).
 - **Electron-density maps** from MTZ refs (`kind: mtz` + a `maps:`
   block), including difference maps and an `activeMap:` for refinement.
+- **Real-space CCP4 maps and masks** (`kind: map` + a `maps:` entry,
+  no columns); masks (`isMask: true`, `File.sub_type ==
+  CMapDataFile.SUBTYPE_MASK`) default to a translucent solid surface.
 - **Inline dict text** (`cifText:`) and **bundle: assets/...**
   references for sources without a stable URL.
 

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -948,7 +948,53 @@ maps:
     columns: { Fobs: FP, SigFobs: SIGFP, FreeR: FREE, calcStructFact: true }
 `;
     const scene = parseScene(yaml);
-    expect(scene.maps![0].columns.calcStructFact).toBe(true);
+    expect(scene.maps![0].columns!.calcStructFact).toBe(true);
+  });
+
+  it("parses a real-space map / mask (kind: map, no columns)", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: msk
+    kind: map
+    url: https://example/mask.map
+maps:
+  - name: domainA
+    file: msk
+    isMask: true
+`;
+    const scene = parseScene(yaml);
+    expect(scene.maps).toHaveLength(1);
+    expect(scene.maps![0]).toMatchObject({ name: "domainA", file: "msk", isMask: true });
+    expect(scene.maps![0].columns).toBeUndefined();
+  });
+
+  it("rejects columns on a kind: map (real-space) file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: msk
+    kind: map
+    url: https://example/mask.map
+maps:
+  - name: domainA
+    file: msk
+    columns: { F: FWT, PHI: PHWT }
+`;
+    expect(() => parseScene(yaml)).toThrow(/not allowed for kind: "map"/);
+  });
+
+  it("requires kind mtz or map for a maps[] file", () => {
+    const yaml = `scene: x
+version: 1
+files:
+  - name: coords
+    pdb: 1abc
+maps:
+  - name: m
+    file: coords
+`;
+    expect(() => parseScene(yaml)).toThrow(/must be a file with kind: "mtz" or "map"/);
   });
 
   it("rejects an unknown style", () => {

--- a/client/renderer/components/moorhen/campaign-control-panel.tsx
+++ b/client/renderer/components/moorhen/campaign-control-panel.tsx
@@ -387,8 +387,8 @@ export const CampaignControlPanel: React.FC<CampaignControlPanelProps> = ({
             };
 
             const sliderPosition = valueToSlider(level);
-            // Label based on map sub_type: 1=normal (2Fo-Fc), 2=difference (Fo-Fc), 3=anomalous (Anom)
-            const shortName = mapSubType === 3 ? "Anom" : mapSubType === 2 ? "Fo-Fc" : isDiff ? "Fo-Fc" : "2Fo-Fc";
+            // Label based on map sub_type: 1=normal (2Fo-Fc), 2=difference (Fo-Fc), 3=anomalous (Anom), 4=mask (Mask)
+            const shortName = mapSubType === 4 ? "Mask" : mapSubType === 3 ? "Anom" : mapSubType === 2 ? "Fo-Fc" : isDiff ? "Fo-Fc" : "2Fo-Fc";
 
             return (
               <Stack key={map.molNo ?? map.uniqueId} direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -65,9 +65,11 @@ import {
   SceneFileFetcher,
   SceneDictionaryFetcher,
   SceneDictionaryLoader,
+  SceneMapFetcher,
   SceneResolveResult,
 } from "../../lib/moorhen-scene-resolver";
 import { parseScene, serialiseScene } from "../../lib/moorhen-scene";
+import { applyMaskDefaults, isMaskSubType } from "../../lib/moorhen-map-file";
 import type { MoorhenScene, SceneFileRef } from "../../types/moorhen-scene";
 import { CampaignMoorhenTabbedPanel } from "./campaign-moorhen-tabbed-panel";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
@@ -409,6 +411,81 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     [],
   );
 
+  // Map fetcher: loads a scene maps[] entry. Real-space CCP4 map files
+  // (kind: "map", incl. masks) load via loadToCootFromMapData; MTZ refs via
+  // loadToCootFromMtzData with the column spec. applyMapState (in the resolver)
+  // then applies contour/style/colour, incl. the mask defaults.
+  const handleFetchSceneMap: SceneMapFetcher = useCallback(
+    async (ref, sceneMap) => {
+      if (!commandCentre.current) return null;
+      let bytes: ArrayBuffer | null = null;
+      let uniqueId: string | null = null;
+      if (ref.bundle) {
+        const buf = bundleAssetsRef.current.get(ref.bundle);
+        if (!buf) {
+          console.warn(`[scene] map bundle miss: ${ref.bundle}`);
+          return null;
+        }
+        bytes = buf;
+        uniqueId = `bundle:${ref.bundle}`;
+      } else {
+        let url: string | null = null;
+        if (ref.fileId !== undefined && ref.projectId) {
+          url = `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
+        } else if (ref.url) {
+          url = ref.url;
+        }
+        if (!url) return null;
+        try {
+          bytes = await apiArrayBuffer(url);
+          uniqueId = url;
+        } catch (err) {
+          console.warn(`[scene] map fetch failed for ${ref.name}:`, err);
+          return null;
+        }
+      }
+      try {
+        const newMap = new MoorhenMap(
+          commandCentre as RefObject<moorhen.CommandCentre>,
+          store as any,
+        );
+        if (ref.kind === "map") {
+          await newMap.loadToCootFromMapData(
+            new Uint8Array(bytes as ArrayBuffer),
+            sceneMap.name,
+            !!sceneMap.isDifference,
+          );
+          (newMap as any).isCcp4MapFile = true;
+          if (sceneMap.isMask) (newMap as any).isCcp4Mask = true;
+        } else {
+          const cols = sceneMap.columns ?? {};
+          await newMap.loadToCootFromMtzData(
+            new Uint8Array(bytes as ArrayBuffer),
+            sceneMap.name,
+            {
+              F: cols.F,
+              PHI: cols.PHI,
+              Fobs: cols.Fobs,
+              SigFobs: cols.SigFobs,
+              FreeR: cols.FreeR,
+              useWeight: !!cols.useWeight,
+              calcStructFact: !!cols.calcStructFact,
+              isDifference: !!sceneMap.isDifference,
+            } as moorhen.selectedMtzColumns,
+          );
+        }
+        if (newMap.molNo === -1) return null;
+        if (uniqueId) newMap.uniqueId = uniqueId;
+        dispatch(addMap(newMap));
+        return newMap;
+      } catch (err) {
+        console.warn(`[scene] failed to load map for ${ref.name}:`, err);
+        return null;
+      }
+    },
+    [commandCentre, store, dispatch],
+  );
+
   // Core apply: hand a parsed scene + bundle assets to the resolver.
   const runScene = useCallback(
     async (
@@ -424,6 +501,7 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
         fetcher: handleFetchSceneFile,
         dictionaryFetcher: handleFetchSceneDictionary,
         dictionaryLoader: handleLoadSceneDictionary,
+        mapFetcher: handleFetchSceneMap,
       });
       dispatch(setRequestDrawScene(true));
       return result;
@@ -435,6 +513,7 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       handleFetchSceneFile,
       handleFetchSceneDictionary,
       handleLoadSceneDictionary,
+      handleFetchSceneMap,
     ],
   );
 
@@ -493,6 +572,10 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       // subType: 1=normal, 2=difference, 3=anomalous difference
       const mapSubType = fileInfo.sub_type || 1;
       await fetchMap(url, molName, mapSubType);
+    } else if (fileInfo.type === "application/CCP4-map") {
+      const url = `/api/proxy/ccp4i2/files/${fileId}/download/`;
+      const molName = fileInfo.annotation || fileInfo.name || fileInfo.job_param_name;
+      await fetchMapFile(url, molName, { isMask: isMaskSubType(fileInfo.sub_type) });
     }
   };
 
@@ -550,7 +633,7 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       await fetchMolecule(url, molName);
     }
 
-    // STEP 3: Load map files
+    // STEP 3: Load map files (MTZ coefficients and real-space CCP4 maps / masks)
     for (const file of jobOutputFiles) {
       if (file.type === "application/CCP4-mtz-map") {
         const url = `/api/proxy/ccp4i2/files/${file.id}/download/`;
@@ -558,6 +641,10 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
         // subType: 1=normal, 2=difference, 3=anomalous difference
         const mapSubType = file.sub_type || 1;
         await fetchMap(url, molName, mapSubType);
+      } else if (file.type === "application/CCP4-map") {
+        const url = `/api/proxy/ccp4i2/files/${file.id}/download/`;
+        const molName = file.annotation || file.name || file.job_param_name;
+        await fetchMapFile(url, molName, { isMask: isMaskSubType(file.sub_type) });
       }
     }
   };
@@ -691,6 +778,37 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     } catch (err) {
       console.warn(err);
       console.warn(`Cannot fetch map from ${url}`);
+    }
+  };
+
+  // Load a real-space CCP4 map file (application/CCP4-map), e.g. a mask. Uses
+  // loadToCootFromMapData (not the MTZ path); masks get the shared translucent
+  // solid defaults and are never the active map.
+  const fetchMapFile = async (
+    url: string,
+    mapName: string,
+    opts: { isMask?: boolean } = {}
+  ) => {
+    if (!commandCentre.current) return;
+    const newMap = new MoorhenMap(
+      commandCentre as RefObject<moorhen.CommandCentre>,
+      store as any
+    );
+    try {
+      const mapData = await apiArrayBuffer(url);
+      await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
+      if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
+      newMap.uniqueId = url;
+      // Tag so the lifter captures it as a kind: "map" ref (not MTZ).
+      (newMap as any).isCcp4MapFile = true;
+      if (opts.isMask) (newMap as any).isCcp4Mask = true;
+      dispatch(addMap(newMap));
+      if (opts.isMask) {
+        applyMaskDefaults(dispatch, newMap.molNo);
+      }
+    } catch (err) {
+      console.warn(err);
+      console.warn(`Cannot fetch map file from ${url}`);
     }
   };
 

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -69,7 +69,7 @@ import {
   SceneResolveResult,
 } from "../../lib/moorhen-scene-resolver";
 import { parseScene, serialiseScene } from "../../lib/moorhen-scene";
-import { applyMaskDefaults, isMaskSubType, markMaskMap } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat } from "../../lib/moorhen-map-file";
 import type { MoorhenScene, SceneFileRef } from "../../types/moorhen-scene";
 import { CampaignMoorhenTabbedPanel } from "./campaign-moorhen-tabbed-panel";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
@@ -450,8 +450,9 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
           store as any,
         );
         if (ref.kind === "map") {
+          // mode-0 -> float so Moorhen reads sane stats (no-op if already float).
           await newMap.loadToCootFromMapData(
-            new Uint8Array(bytes as ArrayBuffer),
+            new Uint8Array(ccp4Mode0ToFloat(bytes as ArrayBuffer)),
             sceneMap.name,
             !!sceneMap.isDifference,
           );
@@ -795,7 +796,9 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       store as any
     );
     try {
-      const mapData = await apiArrayBuffer(url);
+      // Convert mode-0 (int8) CCP4 maps to float so Moorhen reads sane stats
+      // (no-op for maps that are already float).
+      const mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
       await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
       if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
       newMap.uniqueId = url;

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -69,7 +69,7 @@ import {
   SceneResolveResult,
 } from "../../lib/moorhen-scene-resolver";
 import { parseScene, serialiseScene } from "../../lib/moorhen-scene";
-import { applyMaskDefaults, isMaskSubType } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap } from "../../lib/moorhen-map-file";
 import type { MoorhenScene, SceneFileRef } from "../../types/moorhen-scene";
 import { CampaignMoorhenTabbedPanel } from "./campaign-moorhen-tabbed-panel";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
@@ -456,7 +456,7 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
             !!sceneMap.isDifference,
           );
           (newMap as any).isCcp4MapFile = true;
-          if (sceneMap.isMask) (newMap as any).isCcp4Mask = true;
+          if (sceneMap.isMask) markMaskMap(newMap);
         } else {
           const cols = sceneMap.columns ?? {};
           await newMap.loadToCootFromMtzData(
@@ -801,7 +801,9 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       newMap.uniqueId = url;
       // Tag so the lifter captures it as a kind: "map" ref (not MTZ).
       (newMap as any).isCcp4MapFile = true;
-      if (opts.isMask) (newMap as any).isCcp4Mask = true;
+      if (opts.isMask) {
+        markMaskMap(newMap);
+      }
       dispatch(addMap(newMap));
       if (opts.isMask) {
         applyMaskDefaults(dispatch, newMap.molNo);

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -69,7 +69,7 @@ import {
   SceneResolveResult,
 } from "../../lib/moorhen-scene-resolver";
 import { parseScene, serialiseScene } from "../../lib/moorhen-scene";
-import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp } from "../../lib/moorhen-map-file";
 import type { MoorhenScene, SceneFileRef } from "../../types/moorhen-scene";
 import { CampaignMoorhenTabbedPanel } from "./campaign-moorhen-tabbed-panel";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
@@ -450,9 +450,10 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
           store as any,
         );
         if (ref.kind === "map") {
-          // mode-0 -> float so Moorhen reads sane stats (no-op if already float).
+          // mode-0 -> float (sane stats); masks also dodge coot's EM cell-clamp.
+          const mapBytes = ccp4Mode0ToFloat(bytes as ArrayBuffer);
           await newMap.loadToCootFromMapData(
-            new Uint8Array(ccp4Mode0ToFloat(bytes as ArrayBuffer)),
+            new Uint8Array(sceneMap.isMask ? ccp4DodgeEmClamp(mapBytes) : mapBytes),
             sceneMap.name,
             !!sceneMap.isDifference,
           );
@@ -800,8 +801,10 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     );
     try {
       // Convert mode-0 (int8) CCP4 maps to float so Moorhen reads sane stats
-      // (no-op for maps that are already float).
-      const mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
+      // (no-op if already float). For masks, also nudge the P1/orthogonal cell
+      // off 90° so coot contours periodically instead of clamping to the cell box.
+      let mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
+      if (opts.isMask) mapData = ccp4DodgeEmClamp(mapData);
       await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
       if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
       newMap.uniqueId = url;

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -478,6 +478,9 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
         if (newMap.molNo === -1) return null;
         if (uniqueId) newMap.uniqueId = uniqueId;
         dispatch(addMap(newMap));
+        if (ref.kind === "map" && sceneMap.isMask) {
+          await applyMaskDefaults(dispatch, newMap as any);
+        }
         return newMap;
       } catch (err) {
         console.warn(`[scene] failed to load map for ${ref.name}:`, err);
@@ -809,7 +812,7 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       }
       dispatch(addMap(newMap));
       if (opts.isMask) {
-        applyMaskDefaults(dispatch, newMap.molNo);
+        await applyMaskDefaults(dispatch, newMap as any);
       }
     } catch (err) {
       console.warn(err);

--- a/client/renderer/components/moorhen/moorhen-control-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-control-panel.tsx
@@ -515,13 +515,15 @@ export const MoorhenControlPanel: React.FC<MoorhenControlPanelProps> = ({
 
               const sliderPosition = valueToSlider(level);
               const shortName =
-                mapSubType === 3
-                  ? "Anom"
-                  : mapSubType === 2
-                    ? "Fo-Fc"
-                    : isDiff
+                mapSubType === 4
+                  ? "Mask"
+                  : mapSubType === 3
+                    ? "Anom"
+                    : mapSubType === 2
                       ? "Fo-Fc"
-                      : "2Fo-Fc";
+                      : isDiff
+                        ? "Fo-Fc"
+                        : "2Fo-Fc";
 
               return (
                 <Stack

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -44,7 +44,7 @@ import {
 } from "../../lib/moorhen-scene-resolver";
 import type { SceneFileRef } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
-import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp } from "../../lib/moorhen-map-file";
 import {
   liftSceneToBundle,
   MapRenderState,
@@ -292,8 +292,10 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     );
     try {
       // Convert mode-0 (int8) CCP4 maps to float so Moorhen reads sane stats
-      // (no-op for maps that are already float).
-      const mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
+      // (no-op if already float). For masks, also nudge the P1/orthogonal cell
+      // off 90° so coot contours periodically instead of clamping to the cell box.
+      let mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
+      if (opts.isMask) mapData = ccp4DodgeEmClamp(mapData);
       await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
       if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
       newMap.uniqueId = url;
@@ -791,9 +793,10 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         );
         if (ref.kind === "map") {
           // Real-space CCP4 map file (incl. masks): load directly, no columns.
-          // mode-0 -> float so Moorhen reads sane stats (no-op if already float).
+          // mode-0 -> float (sane stats); masks also dodge coot's EM cell-clamp.
+          const mapBytes = ccp4Mode0ToFloat(bytes as ArrayBuffer);
           await newMap.loadToCootFromMapData(
-            new Uint8Array(ccp4Mode0ToFloat(bytes as ArrayBuffer)),
+            new Uint8Array(sceneMap.isMask ? ccp4DodgeEmClamp(mapBytes) : mapBytes),
             sceneMap.name,
             !!sceneMap.isDifference,
           );

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -304,7 +304,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       }
       dispatch(addMap(newMap));
       if (opts.isMask) {
-        applyMaskDefaults(dispatch, newMap.molNo);
+        await applyMaskDefaults(dispatch, newMap as any);
       }
     } catch (err) {
       console.warn(err);
@@ -819,6 +819,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         if (newMap.molNo === -1) return null;
         if (uniqueId) newMap.uniqueId = uniqueId;
         dispatch(addMap(newMap));
+        if (ref.kind === "map" && sceneMap.isMask) {
+          await applyMaskDefaults(dispatch, newMap as any);
+        }
         return newMap;
       } catch (err) {
         console.warn(`[scene] failed to load map for ${ref.name}:`, err);

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -5,6 +5,9 @@ import {
   addMap,
   setActiveMap,
   setContourLevel,
+  setMapStyle,
+  setMapAlpha,
+  setMapColours,
   setTheme,
   setBackgroundColor,
   setRequestDrawScene,
@@ -41,6 +44,7 @@ import {
 } from "../../lib/moorhen-scene-resolver";
 import type { SceneFileRef } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
+import { applyMaskDefaults, isMaskSubType } from "../../lib/moorhen-map-file";
 import {
   liftSceneToBundle,
   MapRenderState,
@@ -273,6 +277,38 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     return newMap;
   }, [commandCentre, store, dispatch]);
 
+  // Load a real-space CCP4 map file (application/CCP4-map), e.g. a mask. Unlike
+  // fetchMap (MTZ coefficients), this uses loadToCootFromMapData. Masks get the
+  // shared translucent-solid defaults and are never made the active map.
+  const fetchMapFile = useCallback(async (
+    url: string,
+    mapName: string,
+    opts: { isMask?: boolean } = {},
+  ) => {
+    if (!commandCentre.current) return;
+    const newMap = new MoorhenMap(
+      commandCentre as RefObject<moorhen.CommandCentre>,
+      store as any
+    );
+    try {
+      const mapData = await apiArrayBuffer(url);
+      await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
+      if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
+      newMap.uniqueId = url;
+      // Tag so the lifter captures it as a kind: "map" ref (not MTZ).
+      (newMap as any).isCcp4MapFile = true;
+      if (opts.isMask) (newMap as any).isCcp4Mask = true;
+      dispatch(addMap(newMap));
+      if (opts.isMask) {
+        applyMaskDefaults(dispatch, newMap.molNo);
+      }
+    } catch (err) {
+      console.warn(err);
+      console.warn(`Cannot fetch map file from ${url}`);
+    }
+    return newMap;
+  }, [commandCentre, store, dispatch]);
+
   const fetchDict = useCallback(async (url: string) => {
     if (!commandCentre.current) return;
     const fileContent = await apiText(url);
@@ -361,11 +397,15 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       const molName = fileInfo.name || fileInfo.job_param_name;
       const mapSubType = fileInfo.sub_type || 1;
       await fetchMap(url, molName, mapSubType);
+    } else if (fileInfo.type === "application/CCP4-map") {
+      const url = `/api/proxy/ccp4i2/files/${fileId}/download/`;
+      const molName = fileInfo.annotation || fileInfo.name || fileInfo.job_param_name;
+      await fetchMapFile(url, molName, { isMask: isMaskSubType(fileInfo.sub_type) });
     } else if (fileInfo.type === "application/refmac-dictionary") {
       const url = `/api/proxy/ccp4i2/files/${fileId}/download/`;
       await fetchDict(url);
     }
-  }, [fetchMolecule, fetchMap, fetchDict]);
+  }, [fetchMolecule, fetchMap, fetchMapFile, fetchDict]);
 
   /**
    * Load all output files from a job into Moorhen.
@@ -478,13 +518,17 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       }
     }
 
-    // STEP 3: Load all maps
+    // STEP 3: Load all maps (MTZ coefficients and real-space CCP4 maps / masks)
     for (const file of jobOutputFiles) {
       if (file.type === "application/CCP4-mtz-map") {
         const url = `/api/proxy/ccp4i2/files/${file.id}/download/`;
         const mapName = file.name || file.job_param_name;
         const mapSubType = file.sub_type || 1;
         await fetchMap(url, mapName, mapSubType);
+      } else if (file.type === "application/CCP4-map") {
+        const url = `/api/proxy/ccp4i2/files/${file.id}/download/`;
+        const mapName = file.annotation || file.name || file.job_param_name;
+        await fetchMapFile(url, mapName, { isMask: isMaskSubType(file.sub_type) });
       }
     }
 
@@ -498,7 +542,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       }
       dispatch(setRequestDrawScene(true));
     }
-  }, [commandCentre, store, monomerLibraryPath, backgroundColor, defaultBondSmoothness, dispatch, fetchMap, getOrigin]);
+  }, [commandCentre, store, monomerLibraryPath, backgroundColor, defaultBondSmoothness, dispatch, fetchMap, fetchMapFile, getOrigin]);
 
   // Handle map contour level changes from the control panel slider
   const handleMapContourLevelChange = useCallback(
@@ -741,26 +785,38 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
           commandCentre as RefObject<moorhen.CommandCentre>,
           store as any,
         );
-        await newMap.loadToCootFromMtzData(
-          new Uint8Array(bytes as ArrayBuffer),
-          sceneMap.name,
-          {
-            F: sceneMap.columns.F,
-            PHI: sceneMap.columns.PHI,
-            Fobs: sceneMap.columns.Fobs,
-            SigFobs: sceneMap.columns.SigFobs,
-            FreeR: sceneMap.columns.FreeR,
-            useWeight: !!sceneMap.columns.useWeight,
-            calcStructFact: !!sceneMap.columns.calcStructFact,
-            isDifference: !!sceneMap.isDifference,
-          } as moorhen.selectedMtzColumns,
-        );
+        if (ref.kind === "map") {
+          // Real-space CCP4 map file (incl. masks): load directly, no columns.
+          await newMap.loadToCootFromMapData(
+            new Uint8Array(bytes as ArrayBuffer),
+            sceneMap.name,
+            !!sceneMap.isDifference,
+          );
+          (newMap as any).isCcp4MapFile = true;
+          if (sceneMap.isMask) (newMap as any).isCcp4Mask = true;
+        } else {
+          const cols = sceneMap.columns ?? {};
+          await newMap.loadToCootFromMtzData(
+            new Uint8Array(bytes as ArrayBuffer),
+            sceneMap.name,
+            {
+              F: cols.F,
+              PHI: cols.PHI,
+              Fobs: cols.Fobs,
+              SigFobs: cols.SigFobs,
+              FreeR: cols.FreeR,
+              useWeight: !!cols.useWeight,
+              calcStructFact: !!cols.calcStructFact,
+              isDifference: !!sceneMap.isDifference,
+            } as moorhen.selectedMtzColumns,
+          );
+        }
         if (newMap.molNo === -1) return null;
         if (uniqueId) newMap.uniqueId = uniqueId;
         dispatch(addMap(newMap));
         return newMap;
       } catch (err) {
-        console.warn(`[scene] failed to load MTZ for ${ref.name}:`, err);
+        console.warn(`[scene] failed to load map for ${ref.name}:`, err);
         return null;
       }
     },

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -44,7 +44,7 @@ import {
 } from "../../lib/moorhen-scene-resolver";
 import type { SceneFileRef } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
-import { applyMaskDefaults, isMaskSubType, markMaskMap } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat } from "../../lib/moorhen-map-file";
 import {
   liftSceneToBundle,
   MapRenderState,
@@ -291,7 +291,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       store as any
     );
     try {
-      const mapData = await apiArrayBuffer(url);
+      // Convert mode-0 (int8) CCP4 maps to float so Moorhen reads sane stats
+      // (no-op for maps that are already float).
+      const mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
       await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
       if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
       newMap.uniqueId = url;
@@ -789,8 +791,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         );
         if (ref.kind === "map") {
           // Real-space CCP4 map file (incl. masks): load directly, no columns.
+          // mode-0 -> float so Moorhen reads sane stats (no-op if already float).
           await newMap.loadToCootFromMapData(
-            new Uint8Array(bytes as ArrayBuffer),
+            new Uint8Array(ccp4Mode0ToFloat(bytes as ArrayBuffer)),
             sceneMap.name,
             !!sceneMap.isDifference,
           );

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -44,7 +44,7 @@ import {
 } from "../../lib/moorhen-scene-resolver";
 import type { SceneFileRef } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
-import { applyMaskDefaults, isMaskSubType } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap } from "../../lib/moorhen-map-file";
 import {
   liftSceneToBundle,
   MapRenderState,
@@ -297,7 +297,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       newMap.uniqueId = url;
       // Tag so the lifter captures it as a kind: "map" ref (not MTZ).
       (newMap as any).isCcp4MapFile = true;
-      if (opts.isMask) (newMap as any).isCcp4Mask = true;
+      if (opts.isMask) {
+        markMaskMap(newMap);
+      }
       dispatch(addMap(newMap));
       if (opts.isMask) {
         applyMaskDefaults(dispatch, newMap.molNo);
@@ -793,7 +795,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
             !!sceneMap.isDifference,
           );
           (newMap as any).isCcp4MapFile = true;
-          if (sceneMap.isMask) (newMap as any).isCcp4Mask = true;
+          if (sceneMap.isMask) markMaskMap(newMap);
         } else {
           const cols = sceneMap.columns ?? {};
           await newMap.loadToCootFromMtzData(

--- a/client/renderer/lib/moorhen-map-file.ts
+++ b/client/renderer/lib/moorhen-map-file.ts
@@ -13,6 +13,7 @@ import type { Dispatch } from "redux";
 import {
   setMapStyle,
   setMapAlpha,
+  setMapRadius,
   setContourLevel,
   setMapColours,
 } from "moorhen/react-lib";
@@ -97,12 +98,13 @@ export function ccp4Mode0ToFloat(buffer: ArrayBuffer): ArrayBuffer {
   return out;
 }
 
-/** Default mask look: a translucent solid surface in a soft blue. */
+/** Default mask look: a translucent solid surface in a soft blue. NB Moorhen's
+ *  setMapColours expects 0-255 components (it divides by 255 internally) — 0-1
+ *  floats render as a near-black mesh. */
 export const MASK_STYLE = "solid" as const;
-export const MASK_ALPHA = 0.4;
-export const MASK_CONTOUR_LEVEL = 0.5;
+export const MASK_ALPHA = 0.45;
 export const MASK_COLOUR = "#7e9cd8";
-export const MASK_COLOUR_RGB = { r: 0.494, g: 0.612, b: 0.847 };
+export const MASK_COLOUR_RGB = { r: 126, g: 156, b: 216 };
 
 /** True if a DB file's sub_type marks it as a mask. */
 export function isMaskSubType(subType: number | null | undefined): boolean {
@@ -121,22 +123,51 @@ export function markMaskMap(map: unknown): void {
   const m = map as {
     isCcp4Mask?: boolean;
     mapSubType?: number;
-    isEM?: boolean;
   };
   m.isCcp4Mask = true;
   m.mapSubType = MASK_SUBTYPE;
-  m.isEM = true;
 }
 
 /**
- * Apply the default mask look to a freshly-loaded Moorhen map. Dispatched as
- * separate actions (mirroring the resolver's applyMapState) because the
- * Moorhen map-setting action typings have drifted across versions — the casts
- * keep this compatible with the installed shape.
+ * Apply the default mask look to a freshly-loaded Moorhen map.
+ *
+ * Crucially the contour LEVEL and RADIUS are taken from Coot's own
+ * getSuggestedSettings(), not hardcoded: Coot reads contour level in sigma
+ * units, and a mask (mostly 0, with 1s) has a tiny sigma, so a "sensible"
+ * absolute level clears nothing -> empty mesh -> undefined bounding sphere ->
+ * crash. We override only cosmetics (style / alpha / colour), then force a
+ * contour + colour flush so the GL buffers actually pick them up.
+ *
+ * (Lesson set distilled from the FragVol sub-volume work.)
  */
-export function applyMaskDefaults(dispatch: Dispatch, molNo: number): void {
+export async function applyMaskDefaults(
+  dispatch: Dispatch,
+  map: { molNo: number; suggestedContourLevel?: number; suggestedRadius?: number;
+         getSuggestedSettings?: () => Promise<void>;
+         drawMapContour?: () => Promise<void>;
+         fetchColourAndRedraw?: () => Promise<void>; },
+): Promise<void> {
+  const molNo = map.molNo;
+  try {
+    await map.getSuggestedSettings?.();
+  } catch {
+    /* fall back to whatever level Coot already has */
+  }
+  if (typeof map.suggestedContourLevel === "number") {
+    dispatch(setContourLevel({ molNo, contourLevel: map.suggestedContourLevel } as never));
+  }
+  if (typeof map.suggestedRadius === "number") {
+    dispatch(setMapRadius({ molNo, radius: map.suggestedRadius } as never));
+  }
+  // Cosmetics only.
   dispatch(setMapStyle({ molNo, style: MASK_STYLE } as never));
   dispatch(setMapAlpha({ molNo, alpha: MASK_ALPHA } as never));
-  dispatch(setContourLevel({ molNo, contourLevel: MASK_CONTOUR_LEVEL } as never));
   dispatch(setMapColours({ molNo, rgb: MASK_COLOUR_RGB } as never));
+  // The colour/level don't reach the GL buffers until a contour runs.
+  try {
+    await map.drawMapContour?.();
+    await map.fetchColourAndRedraw?.();
+  } catch {
+    /* best-effort flush */
+  }
 }

--- a/client/renderer/lib/moorhen-map-file.ts
+++ b/client/renderer/lib/moorhen-map-file.ts
@@ -1,0 +1,46 @@
+/**
+ * Helpers for rendering real-space CCP4 map files (application/CCP4-map) in
+ * Moorhen — including masks, which are the same FileType distinguished only by
+ * File.sub_type (CMapDataFile.SUBTYPE_MASK).
+ *
+ * Real-space maps load via MoorhenMap.loadToCootFromMapData (not the MTZ
+ * loadToCootFromMtzData path). A mask reads best as a translucent solid
+ * surface so it shows the *region* it covers over the model; these defaults
+ * are shared by the job/file/campaign viewers and the scene resolver so a
+ * mask looks the same however it's loaded.
+ */
+import type { Dispatch } from "redux";
+import {
+  setMapStyle,
+  setMapAlpha,
+  setContourLevel,
+  setMapColours,
+} from "moorhen/react-lib";
+
+/** File.sub_type marking a CCP4-map file as a mask (CMapDataFile.SUBTYPE_MASK). */
+export const MASK_SUBTYPE = 4;
+
+/** Default mask look: a translucent solid surface in a soft blue. */
+export const MASK_STYLE = "solid" as const;
+export const MASK_ALPHA = 0.4;
+export const MASK_CONTOUR_LEVEL = 0.5;
+export const MASK_COLOUR = "#7e9cd8";
+export const MASK_COLOUR_RGB = { r: 0.494, g: 0.612, b: 0.847 };
+
+/** True if a DB file's sub_type marks it as a mask. */
+export function isMaskSubType(subType: number | null | undefined): boolean {
+  return subType === MASK_SUBTYPE;
+}
+
+/**
+ * Apply the default mask look to a freshly-loaded Moorhen map. Dispatched as
+ * separate actions (mirroring the resolver's applyMapState) because the
+ * Moorhen map-setting action typings have drifted across versions — the casts
+ * keep this compatible with the installed shape.
+ */
+export function applyMaskDefaults(dispatch: Dispatch, molNo: number): void {
+  dispatch(setMapStyle({ molNo, style: MASK_STYLE } as never));
+  dispatch(setMapAlpha({ molNo, alpha: MASK_ALPHA } as never));
+  dispatch(setContourLevel({ molNo, contourLevel: MASK_CONTOUR_LEVEL } as never));
+  dispatch(setMapColours({ molNo, rgb: MASK_COLOUR_RGB } as never));
+}

--- a/client/renderer/lib/moorhen-map-file.ts
+++ b/client/renderer/lib/moorhen-map-file.ts
@@ -20,6 +20,83 @@ import {
 /** File.sub_type marking a CCP4-map file as a mask (CMapDataFile.SUBTYPE_MASK). */
 export const MASK_SUBTYPE = 4;
 
+// --------------------------------------------------------------------------
+// CCP4 map mode-0 -> float conversion
+//
+// dm's masks are written as mode-0 (signed int8) CCP4 maps — the natural mask
+// grid, and what dm reads back as NCSIN. coot/Moorhen, though, read mode-0
+// maps with degenerate statistics (zero range), which makes the map card crash
+// (toFixed on a bad digit count) and contour pathologically. Rather than change
+// the files dm consumes, we convert mode-0 -> mode-2 (float32) in the browser
+// before handing the bytes to Moorhen: a 0.0/1.0 float map with real header
+// stats renders cleanly. Other modes (incl. mode-2 float) pass through
+// untouched.
+// --------------------------------------------------------------------------
+
+// CCP4 map header layout (256 4-byte words). Byte offsets we touch:
+const OFF_NC = 0, OFF_NR = 4, OFF_NS = 8, OFF_MODE = 12;
+const OFF_DMIN = 76, OFF_DMAX = 80, OFF_DMEAN = 84, OFF_NSYMBT = 92;
+const OFF_MACHST = 212, OFF_RMS = 216;
+const CCP4_HEADER_BYTES = 1024;
+
+/** CCP4 map MODE word (0=int8, 1=int16, 2=float32, ...), or null if too short. */
+export function ccp4MapMode(buffer: ArrayBuffer, littleEndian = true): number | null {
+  if (buffer.byteLength < CCP4_HEADER_BYTES) return null;
+  return new DataView(buffer).getInt32(OFF_MODE, littleEndian);
+}
+
+/**
+ * Convert a mode-0 (signed int8) CCP4 map to mode-2 (float32), recomputing the
+ * DMIN/DMAX/DMEAN/RMS header stats. Returns a new ArrayBuffer. Any non-mode-0
+ * input (or a too-short buffer) is returned unchanged.
+ */
+export function ccp4Mode0ToFloat(buffer: ArrayBuffer): ArrayBuffer {
+  if (buffer.byteLength < CCP4_HEADER_BYTES) return buffer;
+  const src = new DataView(buffer);
+  // Endianness from the machine stamp (BE stamp starts 0x11); default little.
+  const le = src.getUint8(OFF_MACHST) !== 0x11;
+  if (src.getInt32(OFF_MODE, le) !== 0) return buffer; // only mode-0
+
+  const nc = src.getInt32(OFF_NC, le);
+  const nr = src.getInt32(OFF_NR, le);
+  const ns = src.getInt32(OFF_NS, le);
+  const nsymbt = src.getInt32(OFF_NSYMBT, le);
+  const n = nc * nr * ns;
+  const dataStart = CCP4_HEADER_BYTES + nsymbt;
+  if (n <= 0 || dataStart + n > buffer.byteLength) return buffer; // malformed
+
+  // Read int8 values -> float32, accumulating stats.
+  const i8 = new Int8Array(buffer, dataStart, n);
+  const floats = new Float32Array(n);
+  let min = Infinity, max = -Infinity, sum = 0, sumSq = 0;
+  for (let i = 0; i < n; i++) {
+    const v = i8[i];
+    floats[i] = v;
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+    sumSq += v * v;
+  }
+  const mean = n ? sum / n : 0;
+  const rms = n ? Math.sqrt(Math.max(0, sumSq / n - mean * mean)) : 0;
+
+  // New buffer: header + symmetry records (copied) + float32 data.
+  const out = new ArrayBuffer(dataStart + n * 4);
+  const outBytes = new Uint8Array(out);
+  outBytes.set(new Uint8Array(buffer, 0, dataStart)); // header + symmetry verbatim
+  const dst = new DataView(out);
+  dst.setInt32(OFF_MODE, 2, le);
+  dst.setFloat32(OFF_DMIN, min === Infinity ? 0 : min, le);
+  dst.setFloat32(OFF_DMAX, max === -Infinity ? 0 : max, le);
+  dst.setFloat32(OFF_DMEAN, mean, le);
+  dst.setFloat32(OFF_RMS, rms, le);
+  // Write float data in the file's byte order.
+  for (let i = 0; i < n; i++) {
+    dst.setFloat32(dataStart + i * 4, floats[i], le);
+  }
+  return out;
+}
+
 /** Default mask look: a translucent solid surface in a soft blue. */
 export const MASK_STYLE = "solid" as const;
 export const MASK_ALPHA = 0.4;

--- a/client/renderer/lib/moorhen-map-file.ts
+++ b/client/renderer/lib/moorhen-map-file.ts
@@ -36,15 +36,10 @@ export const MASK_SUBTYPE = 4;
 
 // CCP4 map header layout (256 4-byte words). Byte offsets we touch:
 const OFF_NC = 0, OFF_NR = 4, OFF_NS = 8, OFF_MODE = 12;
-const OFF_DMIN = 76, OFF_DMAX = 80, OFF_DMEAN = 84, OFF_NSYMBT = 92;
+const OFF_CELL_ALPHA = 52, OFF_CELL_BETA = 56, OFF_CELL_GAMMA = 60;
+const OFF_DMIN = 76, OFF_DMAX = 80, OFF_DMEAN = 84, OFF_ISPG = 88, OFF_NSYMBT = 92;
 const OFF_MACHST = 212, OFF_RMS = 216;
 const CCP4_HEADER_BYTES = 1024;
-
-/** CCP4 map MODE word (0=int8, 1=int16, 2=float32, ...), or null if too short. */
-export function ccp4MapMode(buffer: ArrayBuffer, littleEndian = true): number | null {
-  if (buffer.byteLength < CCP4_HEADER_BYTES) return null;
-  return new DataView(buffer).getInt32(OFF_MODE, littleEndian);
-}
 
 /**
  * Convert a mode-0 (signed int8) CCP4 map to mode-2 (float32), recomputing the
@@ -98,6 +93,53 @@ export function ccp4Mode0ToFloat(buffer: ArrayBuffer): ArrayBuffer {
   return out;
 }
 
+// --------------------------------------------------------------------------
+// Dodge coot's EM-map heuristic so a P1 mask contours periodically
+//
+// coot tags a CCP4 map IS_SLURPABLE_EM_MAP when (space group == 1 AND all three
+// cell angles == 90°) — which is exactly a crystallographic P1 mask in an
+// orthogonal cell. That flag drives two behaviours that break mask display
+// (traced in coot's slurp-map.cc / CIsoSurface.cpp):
+//   1. the marching-cubes output is CLAMPED to the [0, cell] box: every triangle
+//      whose midpoint falls outside a unit-cell face is discarded — so a domain
+//      that straddles a boundary is cut in half (the rest wraps to the far face);
+//   2. the contour is centred on the map's own box rather than following the view.
+// The underlying clipper Xmap is genuinely periodic; the clamp just deletes the
+// out-of-cell triangles.
+//
+// Fix: keep space group P1 (so there are NO symmetry mates) but set one cell
+// angle a hair off 90°. coot then reads it as triclinic-P1 — still no symmetry —
+// and contours it periodically across cell boundaries, so the mask follows the
+// model wherever the domain sits. The sub-0.1° tweak displaces the mask <0.1 Å
+// relative to the model. Display-only: the on-disk mask dm reads stays exactly
+// orthogonal P1.
+// --------------------------------------------------------------------------
+
+/** One cell angle (deg, off 90) that defeats coot's "all angles == 90°" EM test
+ *  while keeping the cell metrically orthogonal to <0.1 Å over the box. */
+export const EM_DODGE_ANGLE = 89.9;
+
+/**
+ * If `buffer` is a P1 + orthogonal CCP4 map (the case coot misreads as EM),
+ * return a copy with one cell angle nudged off 90° so coot contours it
+ * periodically instead of clamping to the unit cell. Anything else (non-P1,
+ * already non-orthogonal, too short) is returned unchanged. Apply only to masks.
+ */
+export function ccp4DodgeEmClamp(buffer: ArrayBuffer): ArrayBuffer {
+  if (buffer.byteLength < CCP4_HEADER_BYTES) return buffer;
+  const dv = new DataView(buffer);
+  const le = dv.getUint8(OFF_MACHST) !== 0x11;
+  let ispg = dv.getInt32(OFF_ISPG, le);
+  if (ispg === 0) ispg = 1;   // coot maps space group 0 -> 1 (EM/chimera)
+  const alpha = dv.getFloat32(OFF_CELL_ALPHA, le);
+  const beta = dv.getFloat32(OFF_CELL_BETA, le);
+  const gamma = dv.getFloat32(OFF_CELL_GAMMA, le);
+  if (!(ispg === 1 && alpha === 90 && beta === 90 && gamma === 90)) return buffer;
+  const out = buffer.slice(0);
+  new DataView(out).setFloat32(OFF_CELL_GAMMA, EM_DODGE_ANGLE, le);
+  return out;
+}
+
 /** Default mask look: a translucent solid surface in a soft blue. NB Moorhen's
  *  setMapColours expects 0-255 components (it divides by 255 internally) — 0-1
  *  floats render as a near-black mesh. */
@@ -114,10 +156,12 @@ export function isMaskSubType(subType: number | null | undefined): boolean {
 /**
  * Tag a freshly-loaded MoorhenMap as a mask. Sets:
  *  - `isCcp4Mask` — read by the lifter (with `isCcp4MapFile`) to emit isMask;
- *  - `mapSubType` — so the contour-slider label reads "Mask" (not "2Fo-Fc");
- *  - `isEM` — so Moorhen contours it in absolute (EM-style) mode rather than
- *    rmsd-relative: a mask holds 0..1 region values, not crystallographic
- *    density, so the rmsd path gives a degenerate histogram / contour range.
+ *  - `mapSubType` — so the contour-slider label reads "Mask" (not "2Fo-Fc").
+ *
+ * Note: we do NOT set `isEM`. coot's is_EM_map heuristic would otherwise flag a
+ * P1/orthogonal mask as EM and clamp its contour to the unit cell; ccp4DodgeEmClamp
+ * sidesteps that at load time (one cell angle nudged off 90°) so the mask contours
+ * periodically and follows the model across cell boundaries.
  */
 export function markMaskMap(map: unknown): void {
   const m = map as {

--- a/client/renderer/lib/moorhen-map-file.ts
+++ b/client/renderer/lib/moorhen-map-file.ts
@@ -33,6 +33,25 @@ export function isMaskSubType(subType: number | null | undefined): boolean {
 }
 
 /**
+ * Tag a freshly-loaded MoorhenMap as a mask. Sets:
+ *  - `isCcp4Mask` — read by the lifter (with `isCcp4MapFile`) to emit isMask;
+ *  - `mapSubType` — so the contour-slider label reads "Mask" (not "2Fo-Fc");
+ *  - `isEM` — so Moorhen contours it in absolute (EM-style) mode rather than
+ *    rmsd-relative: a mask holds 0..1 region values, not crystallographic
+ *    density, so the rmsd path gives a degenerate histogram / contour range.
+ */
+export function markMaskMap(map: unknown): void {
+  const m = map as {
+    isCcp4Mask?: boolean;
+    mapSubType?: number;
+    isEM?: boolean;
+  };
+  m.isCcp4Mask = true;
+  m.mapSubType = MASK_SUBTYPE;
+  m.isEM = true;
+}
+
+/**
  * Apply the default mask look to a freshly-loaded Moorhen map. Dispatched as
  * separate actions (mirroring the resolver's applyMapState) because the
  * Moorhen map-setting action typings have drifted across versions — the casts

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -631,32 +631,39 @@ function liftFileRef(mol: moorhen.Molecule, ctx: LiftCtx): SceneFileRef {
 // Maps
 // --------------------------------------------------------------------------
 
+/** True if a loaded MoorhenMap came from a real-space CCP4 map file (incl. a
+ *  mask), tagged at load by the wrapper map loaders, rather than from MTZ. */
+function isCcp4MapFile(map: moorhen.Map): boolean {
+  return !!(map as unknown as { isCcp4MapFile?: boolean }).isCcp4MapFile;
+}
+
 /**
- * Lift a SceneFileRef for an MTZ-loaded map. Mirrors liftFileRef for
- * coordinate molecules but tags the ref with kind: "mtz" and disambiguates
- * the name from any coord ref by suffixing with the map index.
+ * Lift a SceneFileRef for a loaded map. MTZ maps get kind: "mtz"; real-space
+ * CCP4 map files (incl. masks) get kind: "map". The name is disambiguated
+ * from any coord ref by a kind suffix.
  */
 function liftMapFileRef(map: moorhen.Map, ctx: LiftCtx, index: number): SceneFileRef {
+  const kind: SceneFileRef["kind"] = isCcp4MapFile(map) ? "map" : "mtz";
   const baseName = sanitiseName(map.name) || `map${index}`;
-  const name = `${baseName}__mtz`;
+  const name = `${baseName}__${kind}`;
 
   const fileId = extractFileIdFromUniqueId(map.uniqueId ?? "");
   if (fileId !== null && ctx.projectId) {
     return {
       name,
-      kind: "mtz",
+      kind,
       projectId: ctx.projectId,
       projectName: ctx.projectName,
       fileId,
     };
   }
   if (map.uniqueId && /^https?:\/\//.test(map.uniqueId)) {
-    return { name, kind: "mtz", url: map.uniqueId };
+    return { name, kind, url: map.uniqueId };
   }
   if (map.uniqueId) {
-    return { name, kind: "mtz", path: map.uniqueId };
+    return { name, kind, path: map.uniqueId };
   }
-  return { name, kind: "mtz", url: "TODO: MTZ URL for this map" };
+  return { name, kind, url: "TODO: URL for this map" };
 }
 
 /**
@@ -672,12 +679,14 @@ function liftSceneMap(
   mapName: string,
   mapState?: Record<number, MapRenderState>,
 ): SceneMap {
-  const columns = stripUndefinedColumns(map.selectedColumns);
-  const out: SceneMap = {
-    name: mapName,
-    file: fileName,
-    columns,
-  };
+  // Real-space CCP4 map files (incl. masks) carry no columns; MTZ maps do.
+  const mapFile = isCcp4MapFile(map);
+  const out: SceneMap = mapFile
+    ? { name: mapName, file: fileName }
+    : { name: mapName, file: fileName, columns: stripUndefinedColumns(map.selectedColumns) };
+  if (mapFile && (map as unknown as { isCcp4Mask?: boolean }).isCcp4Mask) {
+    out.isMask = true;
+  }
   if (map.isDifference) out.isDifference = true;
 
   const s = mapState?.[map.molNo];

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -63,12 +63,6 @@ import {
   isSceneNamedColour,
   isSceneRawColour,
 } from "../types/moorhen-scene";
-import {
-  MASK_STYLE,
-  MASK_ALPHA,
-  MASK_CONTOUR_LEVEL,
-  MASK_COLOUR,
-} from "./moorhen-map-file";
 
 // --------------------------------------------------------------------------
 // Result + log entries
@@ -586,27 +580,22 @@ function applyMapState(
   dispatch: Dispatch,
 ): void {
   const molNo = map.molNo;
-  // Masks default to a translucent solid surface, unless the scene overrides
-  // the individual fields. (For non-masks these resolve to the scene's own
-  // values, so behaviour is unchanged.)
-  const isMask = !!sceneMap.isMask;
-  const contourLevel = sceneMap.contourLevel ?? (isMask ? MASK_CONTOUR_LEVEL : undefined);
-  const alpha = sceneMap.alpha ?? (isMask ? MASK_ALPHA : undefined);
-  const style = sceneMap.style ?? (isMask ? MASK_STYLE : undefined);
-  const colour = sceneMap.colour ?? (isMask ? MASK_COLOUR : undefined);
-  if (contourLevel !== undefined) {
+  // Mask styling (incl. Coot's suggested contour level/radius) is applied by
+  // applyMaskDefaults at load time in the wrapper's map fetcher; here we apply
+  // only the scene's explicit overrides, for masks and ordinary maps alike.
+  if (sceneMap.contourLevel !== undefined) {
     // setContourLevel's typings have drifted across Moorhen versions;
     // cast keeps the resolver compatible with the installed shape.
-    dispatch(setContourLevel({ molNo, contourLevel } as never));
+    dispatch(setContourLevel({ molNo, contourLevel: sceneMap.contourLevel } as never));
   }
   if (sceneMap.radius !== undefined) {
     dispatch(setMapRadius({ molNo, radius: sceneMap.radius } as never));
   }
-  if (alpha !== undefined) {
-    dispatch(setMapAlpha({ molNo, alpha } as never));
+  if (sceneMap.alpha !== undefined) {
+    dispatch(setMapAlpha({ molNo, alpha: sceneMap.alpha } as never));
   }
-  if (style) {
-    dispatch(setMapStyle({ molNo, style } as never));
+  if (sceneMap.style) {
+    dispatch(setMapStyle({ molNo, style: sceneMap.style } as never));
   }
   if (sceneMap.isDifference) {
     if (sceneMap.positiveColour) {
@@ -617,8 +606,8 @@ function applyMapState(
       const rgb = hexToRgb01(sceneMap.negativeColour);
       if (rgb) dispatch(setNegativeMapColours({ molNo, rgb } as never));
     }
-  } else if (colour) {
-    const rgb = hexToRgb01(colour);
+  } else if (sceneMap.colour) {
+    const rgb = hexToRgb01(sceneMap.colour);
     if (rgb) dispatch(setMapColours({ molNo, rgb } as never));
   }
   if (sceneMap.visible === false) {

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -63,6 +63,12 @@ import {
   isSceneNamedColour,
   isSceneRawColour,
 } from "../types/moorhen-scene";
+import {
+  MASK_STYLE,
+  MASK_ALPHA,
+  MASK_CONTOUR_LEVEL,
+  MASK_COLOUR,
+} from "./moorhen-map-file";
 
 // --------------------------------------------------------------------------
 // Result + log entries
@@ -580,19 +586,27 @@ function applyMapState(
   dispatch: Dispatch,
 ): void {
   const molNo = map.molNo;
-  if (sceneMap.contourLevel !== undefined) {
+  // Masks default to a translucent solid surface, unless the scene overrides
+  // the individual fields. (For non-masks these resolve to the scene's own
+  // values, so behaviour is unchanged.)
+  const isMask = !!sceneMap.isMask;
+  const contourLevel = sceneMap.contourLevel ?? (isMask ? MASK_CONTOUR_LEVEL : undefined);
+  const alpha = sceneMap.alpha ?? (isMask ? MASK_ALPHA : undefined);
+  const style = sceneMap.style ?? (isMask ? MASK_STYLE : undefined);
+  const colour = sceneMap.colour ?? (isMask ? MASK_COLOUR : undefined);
+  if (contourLevel !== undefined) {
     // setContourLevel's typings have drifted across Moorhen versions;
     // cast keeps the resolver compatible with the installed shape.
-    dispatch(setContourLevel({ molNo, contourLevel: sceneMap.contourLevel } as never));
+    dispatch(setContourLevel({ molNo, contourLevel } as never));
   }
   if (sceneMap.radius !== undefined) {
     dispatch(setMapRadius({ molNo, radius: sceneMap.radius } as never));
   }
-  if (sceneMap.alpha !== undefined) {
-    dispatch(setMapAlpha({ molNo, alpha: sceneMap.alpha } as never));
+  if (alpha !== undefined) {
+    dispatch(setMapAlpha({ molNo, alpha } as never));
   }
-  if (sceneMap.style) {
-    dispatch(setMapStyle({ molNo, style: sceneMap.style } as never));
+  if (style) {
+    dispatch(setMapStyle({ molNo, style } as never));
   }
   if (sceneMap.isDifference) {
     if (sceneMap.positiveColour) {
@@ -603,8 +617,8 @@ function applyMapState(
       const rgb = hexToRgb01(sceneMap.negativeColour);
       if (rgb) dispatch(setNegativeMapColours({ molNo, rgb } as never));
     }
-  } else if (sceneMap.colour) {
-    const rgb = hexToRgb01(sceneMap.colour);
+  } else if (colour) {
+    const rgb = hexToRgb01(colour);
     if (rgb) dispatch(setMapColours({ molNo, rgb } as never));
   }
   if (sceneMap.visible === false) {

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -680,9 +680,7 @@ function validateMaps(
     return undefined;
   }
   const fileNames = new Set(files.map((f) => f.name));
-  const mtzFileNames = new Set(
-    files.filter((f) => f.kind === "mtz").map((f) => f.name),
-  );
+  const kindByName = new Map(files.map((f) => [f.name, f.kind ?? "coordinates"]));
   const seen = new Set<string>();
   const out: SceneMap[] = [];
   raw.forEach((entry, i) => {
@@ -701,6 +699,7 @@ function validateMaps(
     }
 
     const file = strField(entry, "file", "", errors, p);
+    const fileKind = file ? kindByName.get(file) : undefined;
     if (!file) {
       errors.push({ path: `${p}.file`, message: "required" });
     } else if (files.length > 0 && !fileNames.has(file)) {
@@ -708,16 +707,26 @@ function validateMaps(
         path: `${p}.file`,
         message: `unknown file "${file}" (not in top-level files block)`,
       });
-    } else if (fileNames.has(file) && !mtzFileNames.has(file)) {
+    } else if (fileNames.has(file) && fileKind !== "mtz" && fileKind !== "map") {
       errors.push({
         path: `${p}.file`,
-        message: `"${file}" must be a file with kind: "mtz"`,
+        message: `"${file}" must be a file with kind: "mtz" or "map"`,
       });
     }
 
+    // `kind: "map"` files (real-space CCP4 maps / masks) take no columns —
+    // they're read directly. Only `kind: "mtz"` files need a column spec.
+    const isMapFile = fileKind === "map";
     const columnsRaw = (entry as Record<string, unknown>).columns;
-    let columns: SceneMapColumns = {};
-    if (!isObject(columnsRaw)) {
+    let columns: SceneMapColumns | undefined;
+    if (isMapFile) {
+      if (columnsRaw !== undefined) {
+        errors.push({
+          path: `${p}.columns`,
+          message: `not allowed for kind: "map" file "${file}" (read directly, no columns)`,
+        });
+      }
+    } else if (!isObject(columnsRaw)) {
       errors.push({ path: `${p}.columns`, message: "required mapping (F + PHI minimum)" });
     } else {
       columns = {
@@ -731,7 +740,7 @@ function validateMaps(
       };
       // Drop undefined fields so the round-trip stays clean.
       (Object.keys(columns) as (keyof SceneMapColumns)[]).forEach((k) => {
-        if (columns[k] === undefined) delete columns[k];
+        if (columns![k] === undefined) delete columns![k];
       });
       // Need F + PHI unless calcStructFact (then Moorhen computes them
       // from Fobs/SigFobs/FreeR).
@@ -745,8 +754,11 @@ function validateMaps(
       }
     }
 
-    const map: SceneMap = { name, file, columns };
+    const map: SceneMap = columns ? { name, file, columns } : { name, file };
 
+    if ("isMask" in entry) {
+      map.isMask = optBool(entry, "isMask", `${p}.isMask`, errors);
+    }
     if ("isDifference" in entry) {
       map.isDifference = optBool(entry, "isDifference", `${p}.isDifference`, errors);
     }
@@ -945,12 +957,13 @@ function buildOrderedScene(scene: MoorhenScene): Record<string, unknown> {
       const out: Record<string, unknown> = {
         name: m.name,
         file: m.file,
-        columns: stripUndefined(m.columns),
       };
+      // columns only for MTZ-backed maps; real-space map/mask refs omit it.
+      if (m.columns !== undefined) out.columns = stripUndefined(m.columns);
       // Optional render-state fields: emit only the ones the lifter
       // (or hand-author) set, so the YAML stays small.
       const optional: (keyof SceneMap)[] = [
-        "isDifference", "contourLevel", "radius", "alpha", "style",
+        "isMask", "isDifference", "contourLevel", "radius", "alpha", "style",
         "colour", "positiveColour", "negativeColour", "visible",
       ];
       for (const k of optional) {

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -438,11 +438,13 @@ expose it; the schema may grow to include it in a later version.
 
 ## `maps`
 
-Electron-density (and difference) maps to contour. Each entry references
-an MTZ from the `files:` block — one declared with `kind: mtz` — and
-carries the column-label spec plus optional render state. The MTZ file
-ref itself is never loaded as a molecule; it exists only to be pointed
-at by a `maps:` entry.
+Maps to contour. Each entry references a file from the `files:` block —
+either an MTZ (`kind: mtz`, with a column-label spec) or a real-space
+CCP4 map / mask (`kind: map`, no columns; see
+[Real-space maps and masks](#real-space-maps-and-masks-kind-map)) — plus
+optional render state. The referenced file is never loaded as a
+molecule; it exists only to be pointed at by a `maps:` entry. The
+MTZ-based examples below cover electron-density and difference maps.
 
 ```yaml
 files:
@@ -519,15 +521,47 @@ map Moorhen should make active after apply. Moorhen refines against the
 active map, so this is normally the best/calculated map — never a
 difference map. The value must match a `name` in the `maps:` block.
 
+### Real-space maps and masks (`kind: map`)
+
+A `maps:` entry can also reference a **real-space CCP4 map file**
+(`application/CCP4-map`, a `.map`) instead of an MTZ — including a
+**mask** (e.g. an NCS-averaging or region mask). Declare the file with
+`kind: map` and **omit `columns`** (a `.map` is read directly, no
+column spec):
+
+```yaml
+files:
+  - { name: refined, fileId: 482, projectId: <uuid> }
+  - { name: ncsA,    kind: map, fileId: 540, projectId: <uuid> }   # a mask
+
+maps:
+  - name: domainA
+    file: ncsA
+    isMask: true          # translucent solid surface by default
+```
+
+`isMask: true` is advisory: when set and you haven't given `style` /
+`contourLevel` / `alpha` / `colour`, the resolver applies the mask
+defaults — a **solid, semi-transparent surface** (contour 0.5, alpha
+0.4, a soft blue) so the mask reads as the *region* it covers. Override
+any of those fields to taste; they apply to map-kind entries exactly as
+they do to MTZ maps. `columns` is **not allowed** on a `kind: map`
+entry.
+
+> A mask is the same FileType as a density map, distinguished by its
+> `subType` (`CMapDataFile.SUBTYPE_MASK`, gleaned to `File.sub_type`).
+> The Moorhen job/file/campaign viewers also render real-space CCP4 maps
+> automatically — masks load as a translucent solid surface, other
+> CCP4 maps with ordinary map defaults.
+
 ### Map resolution at apply-time
 
 Maps need a map-fetcher to be wired into the resolver (the Moorhen
 wrapper provides one). If the host hasn't supplied a fetcher, or the
-MTZ ref isn't fetchable, the map entry is **dropped with a log entry**
-and the rest of the scene still applies — coordinates and
-representations never fail just because a map couldn't load. Today only
-MTZ refs are supported; pre-computed CCP4 `.map` files and
-PDB-fetched maps are planned for a later schema version.
+ref isn't fetchable, the map entry is **dropped with a log entry** and
+the rest of the scene still applies — coordinates and representations
+never fail just because a map couldn't load. Both MTZ refs (`kind: mtz`)
+and real-space CCP4 map / mask refs (`kind: map`) are supported.
 
 ## `view`
 

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -61,10 +61,11 @@ export interface MoorhenScene {
   /** Per-file rendering instructions: representations and colour rules. */
   elements?: SceneElement[];
 
-  /** Map instances to render, each referencing an MTZ file from the
-   *  `files:` block (kind: "mtz") with a column-label spec and optional
-   *  contour/colour/style. v1 supports MTZ refs only — pre-computed
-   *  CCP4 map files and PDB-fetched maps will land in a later version. */
+  /** Map instances to render. Each references either an MTZ file from the
+   *  `files:` block (kind: "mtz") with a column-label spec, or a real-space
+   *  CCP4 map file (kind: "map", incl. masks) which needs no columns. Carries
+   *  optional contour/colour/style; masks default to a translucent solid
+   *  surface. */
   maps?: SceneMap[];
 
   /** Name of the map (from `maps:`) that should be Moorhen's active
@@ -114,8 +115,11 @@ export interface SceneFileRef {
    *  separate molecules; they're then scoped to specific molecules via
    *  the per-element `dictionaries:` list. "mtz" refs are reflection
    *  data — referenced by entries in the `maps:` block which carry the
-   *  column-label spec and contour/colour settings. */
-  kind?: "coordinates" | "dictionary" | "mtz";
+   *  column-label spec and contour/colour settings. "map" refs are
+   *  real-space CCP4 map files (application/CCP4-map), including masks —
+   *  also referenced by `maps:` entries, but loaded directly (no columns)
+   *  via loadToCootFromMapData. */
+  kind?: "coordinates" | "dictionary" | "mtz" | "map";
 
   /** PDB ID (4-letter or extended). Fetched via the PDBe proxy on apply
    *  if not already loaded. The most portable, share-friendly form for
@@ -364,11 +368,19 @@ export interface SceneMap {
    *  the scene root and as a join key for the lifter/promoter. */
   name: string;
 
-  /** Name of an entry in `files:` (must have `kind: "mtz"`). */
+  /** Name of an entry in `files:` (kind: "mtz" or "map"). */
   file: string;
 
-  /** Column-label spec for reading the referenced MTZ. */
-  columns: SceneMapColumns;
+  /** Column-label spec for reading the referenced MTZ. Required for
+   *  `kind: "mtz"` files; omitted for `kind: "map"` (real-space CCP4 maps
+   *  / masks are read directly, no columns). */
+  columns?: SceneMapColumns;
+
+  /** Mark this entry as a mask (a real-space region map). Advisory: when
+   *  set and style/contour/alpha are not otherwise specified, the resolver
+   *  applies the translucent solid-surface mask defaults. Only meaningful
+   *  for `kind: "map"` files. */
+  isMask?: boolean;
 
   /** Difference-map flag. Maps with this set render both positive and
    *  negative contour lobes using `positiveColour` / `negativeColour`. */

--- a/server/ccp4i2/core/cdata_stubs/CCP4XtalData.py
+++ b/server/ccp4i2/core/cdata_stubs/CCP4XtalData.py
@@ -3674,6 +3674,16 @@ class CMapDataFileStub(CDataFile):
     to add methods and implementation-specific functionality.
     """
 
+    # Subtype constants -- what kind of real-space map this CCP4-map file holds.
+    # Persisted to File.sub_type by the gleaner and read by the Moorhen viewers
+    # and the scene format to render each kind appropriately. MASK lets a mask
+    # (e.g. dm_multidomain's per-body NCS averaging masks) be distinguished from
+    # an ordinary density map, which is otherwise the same FileType.
+    SUBTYPE_NORMAL = 1           # normal (electron density) map
+    SUBTYPE_DIFFERENCE = 2       # difference map (Fo-Fc)
+    SUBTYPE_ANOM_DIFFERENCE = 3  # anomalous difference map
+    SUBTYPE_MASK = 4             # real-space mask (mode-0 region map)
+
     project: Optional[CProjectIdStub] = None
     baseName: Optional[CFilePathStub] = None
     relPath: Optional[CFilePathStub] = None

--- a/server/ccp4i2/tests/unit/plugins/test_dm_ncs_lib.py
+++ b/server/ccp4i2/tests/unit/plugins/test_dm_ncs_lib.py
@@ -1,10 +1,12 @@
 """Unit tests for dm_multidomain's gemmi-only NCS helpers (no CCP4 binaries).
 
-Guards the mask/operator frame-consistency bug: the AHIR reference DARPIN sits
-OUTSIDE the primary unit cell (fractional y<0), so a naive set_points_around
-PBC-wraps the averaging mask ~118 A away from where the operators point, and dm
-then reports spurious ~0 NCS correlation. write_domain_mask and
-operator_ref_to_copy must bring the reference into the cell with the SAME shift.
+Guards mask/operator frame consistency: the AHIR reference DARPIN sits OUTSIDE
+the primary unit cell (fractional y<0). The averaging mask carries a single
+CONTIGUOUS copy of the domain at its real position as a signed-NSTART sub-volume
+(write_domain_mask / write_partitioned_masks) -- not a PBC-wrapped image -- and
+operator_ref_to_copy maps the real reference onto each copy. Mask and operator
+share the crystal frame; if they ever diverged by a lattice vector dm would
+report spurious ~0 NCS correlation.
 """
 import os
 
@@ -36,6 +38,28 @@ def test_reference_darpin_is_outside_cell(model):
     assert min(f.y for f in fr) < 0.0   # DARPIN reaches outside [0,1)
 
 
+def _subvolume_world_points(mask_path, cell):
+    """Real-space (crystal-frame) positions of a sub-volume mask's set voxels.
+
+    The mask is a contiguous NSTART sub-volume: voxel (i,j,k) of the written
+    block sits at parent grid index (NSTART + (i,j,k)), i.e. fractional
+    ((NSTART_x+i)/MX, ...) in the crystal cell. We reconstruct that explicitly
+    (gemmi's get_position would use the block's box-local cell, not the crystal
+    frame the NSTART/MX header encodes)."""
+    mp = gemmi.read_ccp4_map(mask_path)
+    arr = np.array(mp.grid, copy=False)
+    NS = [mp.header_i32(5), mp.header_i32(6), mp.header_i32(7)]
+    M = [mp.header_i32(8), mp.header_i32(9), mp.header_i32(10)]
+    idx = np.argwhere(arr > 0)
+    out = []
+    for i, j, k in idx:
+        f = gemmi.Fractional((NS[0] + i) / M[0], (NS[1] + j) / M[1],
+                             (NS[2] + k) / M[2])
+        p = cell.orthogonalize(f)
+        out.append([p.x, p.y, p.z])
+    return np.array(out), idx
+
+
 def test_mask_lands_on_domain_not_lattice_image(model, tmp_path):
     m = model[0]
     cell, sg = model.cell, model.find_spacegroup()
@@ -43,20 +67,22 @@ def test_mask_lands_on_domain_not_lattice_image(model, tmp_path):
     n = L.write_domain_mask(m, "A", 13, 139, cell, sg, mask, radius=2.5)
     assert n > 1000
 
-    # reference atoms shifted into the cell with the SAME shift the mask used
-    s = L._lattice_shift(list(L.ca_positions(m, "A", 13, 139).values()), cell)
-    ref = np.array([list(L._shift(p, s, cell))
+    # reference atoms at their REAL position (no lattice shift) -- the mask now
+    # carries a contiguous copy there, via signed NSTART
+    ref = np.array([[p.x, p.y, p.z]
                     for p in L.all_atom_positions(m, "A", 13, 139)])
 
-    grid = gemmi.read_ccp4_mask(mask).grid
-    idx = np.argwhere(np.array(grid, copy=False) > 0)[:3000]
-    pos = np.array([list(grid.get_position(int(i), int(j), int(k)))
-                    for i, j, k in idx])
-    # every mask point must sit within ~ (radius + a grid step) of the domain,
-    # NOT a lattice vector (~100 A) away
+    pos, _ = _subvolume_world_points(mask, cell)
+    # every mask point must sit within ~ (radius + a grid step) of the domain at
+    # its real position, NOT a lattice vector (~100 A) away
     from scipy.spatial import cKDTree
-    d = cKDTree(ref).query(pos)[0]
+    d = cKDTree(ref).query(pos[:3000])[0]
     assert d.mean() < 3.0, f"mask displaced from domain (mean {d.mean():.1f} A)"
+
+    # the header places it at the domain's REAL cell, which reaches y<0: a
+    # negative NSTART proves it is NOT wrapped into the primary cell
+    mp = gemmi.read_ccp4_map(mask)
+    assert mp.header_i32(6) < 0   # NSTART_y negative (DARPIN reaches outside [0,1))
 
 
 def test_operator_targets_intended_copy(model):
@@ -139,23 +165,31 @@ def test_partitioned_masks_are_disjoint(model, tmp_path):
     segs_a = [("_", 140, 339)]
     segs_b = [("_", 340, 485)]
 
+    # Each body is written as its own NSTART sub-volume, so disjointness/union
+    # are checked in the shared PARENT grid frame (NSTART + local index), not by
+    # overlaying differently-sized blocks.
+    def parent_voxels(mask_path):
+        mp = gemmi.read_ccp4_map(mask_path)
+        arr = np.array(mp.grid, copy=False)
+        NS = (mp.header_i32(5), mp.header_i32(6), mp.header_i32(7))
+        return {(NS[0] + i, NS[1] + j, NS[2] + k)
+                for i, j, k in np.argwhere(arr > 0)}
+
     # precondition: independent masks DO overlap at the shared boundary
     ma, mb = str(tmp_path / "a.msk"), str(tmp_path / "b.msk")
     L.write_body_mask(m, {"_": "A"}, segs_a, cell, sg, ma, radius=2.5)
     L.write_body_mask(m, {"_": "A"}, segs_b, cell, sg, mb, radius=2.5)
-    ga = np.array(gemmi.read_ccp4_mask(ma).grid, copy=False) > 0
-    gb = np.array(gemmi.read_ccp4_mask(mb).grid, copy=False) > 0
-    assert int(np.count_nonzero(ga & gb)) > 0
+    ga, gb = parent_voxels(ma), parent_voxels(mb)
+    assert len(ga & gb) > 0
 
     # partitioned masks are disjoint, and their union == the independent union
     pa, pb = str(tmp_path / "pa.msk"), str(tmp_path / "pb.msk")
     nsets, n_contested = L.write_partitioned_masks(
         m, {"_": "A"}, [segs_a, segs_b], cell, sg, [pa, pb], radius=2.5)
     assert n_contested > 0
-    qa = np.array(gemmi.read_ccp4_mask(pa).grid, copy=False) > 0
-    qb = np.array(gemmi.read_ccp4_mask(pb).grid, copy=False) > 0
-    assert int(np.count_nonzero(qa & qb)) == 0
-    assert int(np.count_nonzero(qa | qb)) == int(np.count_nonzero(ga | gb))
+    qa, qb = parent_voxels(pa), parent_voxels(pb)
+    assert len(qa & qb) == 0
+    assert (qa | qb) == (ga | gb)
 
 
 def test_body_operators_skips_partial_instance(model):

--- a/server/ccp4i2/wrappers/dm_multidomain/script/dm_multidomain.def.xml
+++ b/server/ccp4i2/wrappers/dm_multidomain/script/dm_multidomain.def.xml
@@ -69,6 +69,7 @@
           <className>CMapDataFile</className>
           <qualifiers>
             <saveToDb>True</saveToDb>
+            <default><subType>4</subType></default>
           </qualifiers>
         </subItem>
       </content>

--- a/server/ccp4i2/wrappers/dm_multidomain/script/dm_multidomain.py
+++ b/server/ccp4i2/wrappers/dm_multidomain/script/dm_multidomain.py
@@ -266,6 +266,9 @@ class dm_multidomain(CPluginScript):
             if os.path.exists(path):
                 maskout.append(maskout.makeItem())
                 maskout[-1].setFullPath(path)
+                # Mark as a mask (not a density map): gleaned to File.sub_type
+                # so the Moorhen viewers / scene format render it as a mask.
+                maskout[-1].subType.set(maskout[-1].SUBTYPE_MASK)
                 maskout[-1].annotation = \
                     self.jobNumberString() + f' NCS averaging mask: {name}'
 

--- a/server/ccp4i2/wrappers/dm_multidomain/script/dm_ncs_lib.py
+++ b/server/ccp4i2/wrappers/dm_multidomain/script/dm_ncs_lib.py
@@ -248,20 +248,19 @@ def operator_ref_to_copy_body(model, ref_inst, copy_inst, segments, cell=None):
 
     Raises ValueError if fewer than 3 common CA atoms are available.
 
-    If `cell` is given, the reference is first brought into the primary unit
-    cell (rigid lattice shift) so the operator shares the frame of the
-    PBC-wrapped averaging mask -- otherwise, for a reference copy outside
-    [0,1), dm would average density displaced by a lattice vector and report
-    spurious ~0 NCS correlation.
+    T maps the reference at its REAL position (no lattice shift) onto the copy,
+    so it shares the frame of the averaging mask -- which now carries a
+    contiguous copy of the domain at its real place via a signed NSTART
+    sub-volume (see write_partitioned_masks), not a PBC-wrapped image. Mask and
+    operator move together in the crystal frame; dm averages along the operator
+    from the masked region with no spurious lattice-vector displacement. `cell`
+    is accepted for back-compat but no longer used.
     """
     ref_pts, cp_pts = body_ca_correspondence(model, ref_inst, copy_inst, segments)
     if len(ref_pts) < 3:
         raise ValueError(
             f"<3 common CA atoms for body {body_name(segments)} between "
             f"{instance_label(ref_inst)} and {instance_label(copy_inst)}")
-    if cell is not None:
-        s = _lattice_shift(ref_pts, cell)
-        ref_pts = [_shift(p, s, cell) for p in ref_pts]
     return _superpose_ref_to_copy(ref_pts, cp_pts)
 
 
@@ -335,6 +334,136 @@ def body_all_atom_positions(model, instance, segments):
     return pts
 
 
+def _parent_sampling(cell, spacegroup, spacing):
+    """Symmetry-compatible full-cell sampling (MX, MY, MZ) -- the grid dm's
+    working map uses. Sub-volume masks share this sampling (and the crystal cell)
+    so they overlay that map voxel-for-voxel."""
+    g = gemmi.Int8Grid()
+    g.unit_cell = cell
+    g.spacegroup = spacegroup
+    g.set_size_from_spacing(spacing, gemmi.GridSizeRounding.Up)
+    return (g.nu, g.nv, g.nw)
+
+
+def _build_disjoint_box(model, ref_inst, segments_list, cell, spacegroup,
+                        spacing, radius):
+    """Build per-body masks on a SHARED padded sub-volume box and resolve their
+    overlaps, returning (arrs, NS, M, sp, n_contested).
+
+    The box is a contiguous parallelepiped in the parent grid (sampling M, signed
+    origin NS in voxels) padded by enough voxels that the `radius` dilation never
+    reaches a face -- so set_points_around's PBC wrap is a no-op and each body is
+    placed at its REAL position (no lattice shift). All bodies share this one box
+    so the nearest-atom overlap competition runs in a single index frame; arrs[b]
+    is body b's disjoint int8 mask on that box.
+    """
+    M = _parent_sampling(cell, spacegroup, spacing)
+    sp = (cell.a / M[0], cell.b / M[1], cell.c / M[2])
+    body_atoms = [body_all_atom_positions(model, ref_inst, segs)
+                  for segs in segments_list]
+
+    # Box bounds in parent-voxel coords (frac * M), padded for the dilation shell
+    # + a closure margin. min(sp) over-pads coarser axes, which is safe.
+    pad = int(np.ceil(radius / min(sp))) + 2
+    allv = np.array([[(lambda f: (f.x * M[0], f.y * M[1], f.z * M[2]))(
+        cell.fractionalize(p))] for b in body_atoms for p in b]).reshape(-1, 3)
+    NS = (np.floor(allv.min(0)) - pad).astype(int)
+    NC = (np.ceil(allv.max(0)) + pad - NS + 1).astype(int)
+
+    # Box-local cell preserves the parent per-voxel metric + angles, so a 2.5 A
+    # set_points_around radius means the same physical distance as in the crystal.
+    box_cell = gemmi.UnitCell(NC[0] * sp[0], NC[1] * sp[1], NC[2] * sp[2],
+                              cell.alpha, cell.beta, cell.gamma)
+
+    def to_box(pts):
+        out = []
+        for p in pts:
+            f = cell.fractionalize(p)
+            out.append(box_cell.orthogonalize(gemmi.Fractional(
+                (f.x * M[0] - NS[0]) / NC[0], (f.y * M[1] - NS[1]) / NC[1],
+                (f.z * M[2] - NS[2]) / NC[2])))
+        return out
+
+    grids, box_atoms = [], []
+    for pts in body_atoms:
+        g = gemmi.Int8Grid(int(NC[0]), int(NC[1]), int(NC[2]))
+        g.set_unit_cell(box_cell)
+        g.spacegroup = gemmi.SpaceGroup('P 1')
+        bp = to_box(pts)
+        for q in bp:
+            g.set_points_around(q, radius=radius, value=1)
+        grids.append(g)
+        box_atoms.append(np.array([[q.x, q.y, q.z] for q in bp]) if bp
+                         else np.empty((0, 3)))
+
+    arrs = [np.array(g, copy=False) for g in grids]   # views: edits write through
+    claimed = np.stack([a > 0 for a in arrs])         # (nbody, ni, nj, nk)
+    overlap = claimed.sum(0) > 1
+    n_contested = int(np.count_nonzero(overlap))
+    if n_contested and len(grids) > 1:
+        idx = np.argwhere(overlap)                    # (P, 3) box indices
+        cellpos = np.array([list(grids[0].get_position(int(i), int(j), int(k)))
+                            for i, j, k in idx])       # (P, 3) box-local orthogonal
+        BIG = 1e30
+        dists = np.full((len(grids), idx.shape[0]), BIG)
+        contest = claimed[:, overlap]                  # (nbody, P)
+        for b, ab in enumerate(box_atoms):
+            if ab.shape[0] == 0 or not contest[b].any():
+                continue
+            d = np.sqrt(((cellpos[:, None, :] - ab[None, :, :]) ** 2)
+                        .sum(-1)).min(1)               # (P,)
+            dists[b] = np.where(contest[b], d, BIG)
+        winner = dists.argmin(0)                       # (P,)
+        for b in range(len(grids)):
+            lose = (winner != b) & contest[b]
+            for (i, j, k) in idx[lose]:
+                arrs[b][int(i), int(j), int(k)] = 0
+    return arrs, NS, M, sp, n_contested
+
+
+def _write_subvolume_mask(arr, NS, M, sp, cell, path):
+    """Extract the tight set-voxel sub-box of `arr` (+1 voxel closure margin) and
+    write it as a mode-0, P1 CCP4 mask whose NSTART / MX-MY-MZ / cell place the
+    contiguous domain copy at its REAL position in the parent grid.
+
+    The header re-stamp happens AFTER update_ccp4_header (which resets NSTART to 0
+    and MX/MY/MZ to the written block's own dims): we then set NSTART = the box
+    origin in the parent grid, MX/MY/MZ = the parent sampling, and the crystal
+    cell -- so gridding/origin match the map dm averages while NSTART + extent
+    define the parallelepiped. Returns voxels set.
+    """
+    NSv = np.asarray(NS, dtype=int)
+    sv = np.argwhere(arr > 0)
+    if len(sv) == 0:
+        tNS = NSv
+        tarr = np.zeros((1, 1, 1), np.int8)
+    else:
+        dims = np.array(arr.shape)
+        lo = np.maximum(sv.min(0) - 1, 0)             # 1-voxel zero margin for
+        hi = np.minimum(sv.max(0) + 1, dims - 1)      # iso-surface closure
+        tarr = np.ascontiguousarray(
+            arr[lo[0]:hi[0] + 1, lo[1]:hi[1] + 1, lo[2]:hi[2] + 1]).astype(np.int8)
+        tNS = NSv + lo
+    tN = tarr.shape
+    tcell = gemmi.UnitCell(tN[0] * sp[0], tN[1] * sp[1], tN[2] * sp[2],
+                           cell.alpha, cell.beta, cell.gamma)
+    tg = gemmi.Int8Grid(int(tN[0]), int(tN[1]), int(tN[2]))
+    tg.set_unit_cell(tcell)
+    tg.spacegroup = gemmi.SpaceGroup('P 1')
+    np.array(tg, copy=False)[:] = tarr
+    ccp4 = gemmi.Ccp4Mask()
+    ccp4.grid = tg
+    ccp4.update_ccp4_header()
+    for w, v in [(5, int(tNS[0])), (6, int(tNS[1])), (7, int(tNS[2])),
+                 (8, int(M[0])), (9, int(M[1])), (10, int(M[2]))]:
+        ccp4.set_header_i32(w, v)
+    for w, v in [(11, cell.a), (12, cell.b), (13, cell.c),
+                 (14, cell.alpha), (15, cell.beta), (16, cell.gamma)]:
+        ccp4.set_header_float(w, float(v))
+    ccp4.write_ccp4_map(path)
+    return int(np.count_nonzero(tarr))
+
+
 def write_body_mask(model, ref_inst, segments, cell, spacegroup, path,
                     spacing=1.0, radius=2.5):
     """Write a CCP4 mode-0 mask covering the reference rigid body (union of its
@@ -342,26 +471,14 @@ def write_body_mask(model, ref_inst, segments, cell, spacegroup, path,
     a sub-range belongs to a different body, e.g. the C-helix excised from the
     CDK N-lobe).
 
-    No symmetry expansion: the mask covers a single copy, as `dm` expects for an
-    NCS averaging mask. A single lattice shift (from the body's combined CA
-    centroid) keeps the mask in the operators' frame. Returns the number of grid
-    points set.
+    No symmetry expansion: the mask carries a single, CONTIGUOUS copy of the
+    domain at its real position, as an NSTART sub-volume (see
+    _write_subvolume_mask) -- the shape dm expects for an NCS averaging mask.
+    Returns the number of grid points set.
     """
-    g = gemmi.Int8Grid()
-    g.unit_cell = cell
-    g.spacegroup = spacegroup
-    g.set_size_from_spacing(spacing, gemmi.GridSizeRounding.Up)
-    # Bring the reference into the cell with the SAME shift the operators use
-    # (computed from the body's combined CA centroid), so set_points_around's PBC
-    # wrap cannot displace the mask relative to the operators.
-    s = _lattice_shift(body_ca_positions(model, ref_inst, segments), cell)
-    for p in body_all_atom_positions(model, ref_inst, segments):
-        g.set_points_around(_shift(p, s, cell), radius=radius, value=1)
-    ccp4 = gemmi.Ccp4Mask()
-    ccp4.grid = g
-    ccp4.update_ccp4_header()
-    ccp4.write_ccp4_map(path)
-    return int(np.count_nonzero(np.array(g, copy=False)))
+    arrs, NS, M, sp, _ = _build_disjoint_box(
+        model, ref_inst, [segments], cell, spacegroup, spacing, radius)
+    return _write_subvolume_mask(arrs[0], NS, M, sp, cell, path)
 
 
 def write_domain_mask(model, ref, lo, hi, cell, spacegroup, path,
@@ -387,69 +504,26 @@ def write_partitioned_masks(model, ref_inst, segments_list, cell, spacegroup,
 
     Resolution is a nearest-atom competition: every contested grid point is kept
     only for the body whose reference atoms are closest, so the masks tile the
-    molecule envelope without overlap. Each body still uses its own lattice shift
-    (so its mask stays in its operators' frame); competition is computed in
-    orthogonal space, where contested cells -- being co-located by definition --
-    need no minimum-image correction.
+    molecule envelope without overlap. All bodies are masked on ONE shared,
+    padded sub-volume box (so the competition runs in a single index frame, where
+    contested cells -- being co-located by definition -- need no minimum-image
+    correction); each body's disjoint result is then written as its own tight
+    NSTART sub-volume placing a contiguous copy of the domain at its REAL
+    position (no lattice shift, no PBC wrap). The masks and the operators
+    (operator_ref_to_copy_body) thus share the crystal frame and move together.
+
+    An NCS averaging mask is a shape that does not obey crystallographic symmetry
+    (dm takes the crystal symmetry from the MTZ, not the mask), so each is written
+    P1 -- only the NSTART/extent and parent sampling tie it back to the working
+    map's grid.
 
     segments_list and paths are parallel (same order). Returns
     (nset_per_body, n_contested_points).
     """
-    grids, atoms = [], []
-    for segs in segments_list:
-        g = gemmi.Int8Grid()
-        g.unit_cell = cell
-        g.spacegroup = spacegroup
-        g.set_size_from_spacing(spacing, gemmi.GridSizeRounding.Up)
-        s = _lattice_shift(body_ca_positions(model, ref_inst, segs), cell)
-        pts = [_shift(p, s, cell)
-               for p in body_all_atom_positions(model, ref_inst, segs)]
-        for p in pts:
-            g.set_points_around(p, radius=radius, value=1)
-        grids.append(g)
-        atoms.append(np.array([[p.x, p.y, p.z] for p in pts]) if pts
-                     else np.empty((0, 3)))
-
-    arrs = [np.array(g, copy=False) for g in grids]   # views: edits write through
-    claimed = np.stack([a > 0 for a in arrs])         # (nbody, ni, nj, nk)
-    overlap = claimed.sum(0) > 1
-    n_contested = int(np.count_nonzero(overlap))
-    if n_contested and len(grids) > 1:
-        idx = np.argwhere(overlap)                    # (P, 3) grid indices
-        cellpos = np.array([list(grids[0].get_position(int(i), int(j), int(k)))
-                            for i, j, k in idx])       # (P, 3) orthogonal
-        BIG = 1e30
-        dists = np.full((len(grids), idx.shape[0]), BIG)
-        contest = claimed[:, overlap]                  # (nbody, P)
-        for b, ab in enumerate(atoms):
-            if ab.shape[0] == 0 or not contest[b].any():
-                continue
-            d = np.sqrt(((cellpos[:, None, :] - ab[None, :, :]) ** 2)
-                        .sum(-1)).min(1)               # (P,)
-            dists[b] = np.where(contest[b], d, BIG)
-        winner = dists.argmin(0)                       # (P,)
-        for b in range(len(grids)):
-            lose = (winner != b) & contest[b]
-            for (i, j, k) in idx[lose]:
-                arrs[b][int(i), int(j), int(k)] = 0
-
-    nsets = []
-    for g, arr, path in zip(grids, arrs, paths):
-        # Stamp the header spacegroup to P1, AFTER sizing/filling/competition.
-        # An NCS averaging mask is a shape that does not obey crystallographic
-        # symmetry (dm takes the crystal symmetry from the MTZ, not the mask);
-        # the crystal spacegroup in the header only makes viewers draw spurious
-        # symmetry mates. set_points_around is spacegroup-agnostic, so this is
-        # data- and grid-dimension-identical -- the build above keeps the
-        # crystal spacegroup so the sampling stays the symmetry-compatible grid
-        # dm expects; we change only ISPG here. (The PBC wrap into [0,1) and the
-        # lattice shift -- which the operators share -- are left untouched.)
-        g.spacegroup = gemmi.SpaceGroup('P 1')
-        ccp4 = gemmi.Ccp4Mask()
-        ccp4.grid = g
-        ccp4.update_ccp4_header()
-        ccp4.write_ccp4_map(path)
-        nsets.append(int(np.count_nonzero(arr)))
+    arrs, NS, M, sp, n_contested = _build_disjoint_box(
+        model, ref_inst, segments_list, cell, spacegroup, spacing, radius)
+    nsets = [_write_subvolume_mask(arr, NS, M, sp, cell, path)
+             for arr, path in zip(arrs, paths)]
     return nsets, n_contested
 
 

--- a/server/ccp4i2/wrappers/dm_multidomain/script/dm_ncs_lib.py
+++ b/server/ccp4i2/wrappers/dm_multidomain/script/dm_ncs_lib.py
@@ -435,6 +435,16 @@ def write_partitioned_masks(model, ref_inst, segments_list, cell, spacegroup,
 
     nsets = []
     for g, arr, path in zip(grids, arrs, paths):
+        # Stamp the header spacegroup to P1, AFTER sizing/filling/competition.
+        # An NCS averaging mask is a shape that does not obey crystallographic
+        # symmetry (dm takes the crystal symmetry from the MTZ, not the mask);
+        # the crystal spacegroup in the header only makes viewers draw spurious
+        # symmetry mates. set_points_around is spacegroup-agnostic, so this is
+        # data- and grid-dimension-identical -- the build above keeps the
+        # crystal spacegroup so the sampling stays the symmetry-compatible grid
+        # dm expects; we change only ISPG here. (The PBC wrap into [0,1) and the
+        # lattice shift -- which the operators share -- are left untouched.)
+        g.spacegroup = gemmi.SpaceGroup('P 1')
         ccp4 = gemmi.Ccp4Mask()
         ccp4.grid = g
         ccp4.update_ccp4_header()


### PR DESCRIPTION
End-to-end support for **NCS averaging masks** from `dm_multidomain` — correct generation, a data-model discriminator, and faithful rendering in Moorhen views and scenes.

## dm mask generation (server)
- `write_partitioned_masks` now emits each mask as a **contiguous NSTART sub-volume**: a single copy of the domain at its **real crystal position** (mode-0, P1, parent sampling MX/MY/MZ + signed NSTART/extent), replacing the previous full-cell PBC-wrap. The disjoint nearest-atom NCS-overlap competition is preserved (built on one shared box, then tight per-domain extraction).
- Operators coupled to match: the lattice shift is dropped from `operator_ref_to_copy_body`, so mask and operator share the crystal frame and move together.
- **Validated on a real dm run** (AHIR, 6 NCS copies): end-of-averaging inter-copy correlations rose **+0.17** (domain 2) and **+0.26** (domain 3); the domain that never straddled the cell is unchanged. Previously a boundary-straddling domain was PBC-split, desyncing mask from operator → spurious ~0 NCS correlation.
- `test_dm_ncs_lib.py` rewritten for the NSTART design; 10/10 pass.

## Data model (server)
- `CMapDataFile.SUBTYPE_MASK = 4` so a mask is distinguishable from a density map; `dm_multidomain` stamps it on each `MASKOUT`.

## Rendering (client)
- Render real-space `application/CCP4-map` files (incl. masks) in the job/file/campaign Moorhen viewers and describe them in scenes (`kind: "map"`, `isMask`).
- mode-0 (int8) → float32 conversion client-side for sane contour stats.
- Mask look: translucent solid surface; contour-slider labelled **"Mask"**.
- **`ccp4DodgeEmClamp`**: coot's `is_EM_map` heuristic (P1 + all-90° → EM) misreads a crystallographic P1 mask and clamps its contour to the unit-cell box, splitting a domain that straddles a cell face. We nudge one cell angle <0.1° off 90° at load time (a legitimate non-orthorhombic P1 cell, <0.1 Å displacement, no extra copies) so coot contours it periodically and the mask follows the model across boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)