### PR TITLE
gitignore: ignore *.sqlite (not just *.sqlite3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Docker/azure-uksouth/.env.*
 
 # Database
 *.sqlite3
+*.sqlite
 *.db
 
 # Logs


### PR DESCRIPTION
`.gitignore` already ignores `*.sqlite3` and `*.db`, but not `*.sqlite` — so loose SQLite databases produced by the test suite and dev runs (e.g. the api/i2run fixtures' `project.sqlite`, and a stray `DATABASE.db.sqlite` that appears next to the `tests/db` fixtures) show up as untracked noise in the source tree.

Add `*.sqlite` to close the gap. No `*.sqlite` file is tracked, so nothing is removed from version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)