### PR TITLE
moorhen: fix viewer overflowing viewport under toolbar (Moorhen 1.0)

### DIFF
--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -156,14 +156,26 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
 
   const hasInitializedReps = useRef(false);
 
-  // Container ref for measuring available height below the AppBar
+  // Container ref for measuring available height below the AppBar.
+  // Moorhen 1.0 no longer accepts a setMoorhenDimensions callback; it takes a
+  // static `size` prop and otherwise defaults to the full window.innerHeight,
+  // which overflows the viewport because the viewer renders under a toolbar.
+  // So we measure the container's offset and feed Moorhen an explicit size,
+  // keeping it in sync on window resize.
   const moorhenContainerRef = useRef<HTMLDivElement>(null);
-  const setMoorhenDimensions = useCallback((): [number, number] => {
-    if (moorhenContainerRef.current) {
-      const top = moorhenContainerRef.current.getBoundingClientRect().top;
-      return [window.innerWidth, window.innerHeight - top];
-    }
-    return [window.innerWidth, window.innerHeight];
+  const [size, setSize] = useState<[number, number]>(() =>
+    typeof window === "undefined"
+      ? [0, 0]
+      : [window.innerWidth, window.innerHeight]
+  );
+  useEffect(() => {
+    const measure = () => {
+      const top = moorhenContainerRef.current?.getBoundingClientRect().top ?? 0;
+      setSize([window.innerWidth, window.innerHeight - top]);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
   }, []);
 
   const glRef: RefObject<webGL.MGWebGL | null> = useRef(null);
@@ -1138,7 +1150,7 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     store,
     viewOnly: false,
     extraSidePanels,
-    setMoorhenDimensions,
+    size,
   };
 
   // Show Safari advisory as a non-blocking snackbar

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -79,14 +79,26 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     viewParam: viewParam ?? null,
     onViewRestored: () => {},
   });
-  // Container ref for measuring available height below the AppBar
+  // Container ref for measuring available height below the AppBar.
+  // Moorhen 1.0 no longer accepts a setMoorhenDimensions callback; it takes a
+  // static `size` prop and otherwise defaults to the full window.innerHeight,
+  // which overflows the viewport because the viewer renders under a toolbar.
+  // So we measure the container's offset and feed Moorhen an explicit size,
+  // keeping it in sync on window resize.
   const moorhenContainerRef = useRef<HTMLDivElement>(null);
-  const setMoorhenDimensions = useCallback((): [number, number] => {
-    if (moorhenContainerRef.current) {
-      const top = moorhenContainerRef.current.getBoundingClientRect().top;
-      return [window.innerWidth, window.innerHeight - top];
-    }
-    return [window.innerWidth, window.innerHeight];
+  const [size, setSize] = useState<[number, number]>(() =>
+    typeof window === "undefined"
+      ? [0, 0]
+      : [window.innerWidth, window.innerHeight]
+  );
+  useEffect(() => {
+    const measure = () => {
+      const top = moorhenContainerRef.current?.getBoundingClientRect().top ?? 0;
+      setSize([window.innerWidth, window.innerHeight - top]);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
   }, []);
 
   const glRef: RefObject<webGL.MGWebGL | null> = useRef(null);
@@ -1002,8 +1014,8 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     store,
     viewOnly: false,
     extraSidePanels,
-    setMoorhenDimensions,
-  }), [urlPrefix, store, extraSidePanels, setMoorhenDimensions]);
+    size,
+  }), [urlPrefix, store, extraSidePanels, size]);
 
   useEffect(() => {
     if (fileIds && cootInitialized) {


### PR DESCRIPTION
## Problem

Since the Moorhen 1.0.0-alpha migration, the Moorhen viewer (job view, campaign view) rendered at full `window.innerHeight`. Because it sits below the app toolbar, total page height exceeded the viewport, forcing the whole page to scroll — a poor UX for an interactive viewer.

## Root cause

Moorhen 1.0 removed the `setMoorhenDimensions` **callback** prop in favour of a static `size: [number, number]` prop. The container's sizing logic only honours `size` when present, otherwise defaulting to the full window height:

```js
let [w, h] = [window.innerWidth, window.innerHeight];
n.size && ([w, h] = n.size);
```

Both wrappers still passed the now-ignored `setMoorhenDimensions`, so they fell through to the full-height default.

## Fix

In `moorhen-wrapper.tsx` and `campaign-moorhen-wrapper.tsx`, replace the dead callback with a `size` state that measures the container offset (`innerHeight - top`) and feeds it via the new prop, re-measuring on window resize. This restores the pre-1.0 dimension math through the new prop name. SSR-guarded for Next.js server render.

## Testing

- `npx tsc --noEmit -p renderer/tsconfig.json` — 0 errors
- Visual confirmation in the running app (job/campaign view fills exactly the space under the toolbar, no page scroll) still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)