### PR TITLE
moorhen scenes: representation fidelity — transparency (alpha) + concise per-chain colouring

### DIFF
--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -172,6 +172,36 @@ describe("liftScene", () => {
     expect(scene.elements![0].representations![0].colour).toBe("#2ecc71");
   });
 
+  it("captures a non-default nonCustomOpacity as alpha", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [
+            {
+              style: "MolecularSurface",
+              visible: true,
+              colourRules: [],
+              nonCustomOpacity: 0.4,
+            } as Partial<moorhen.MoleculeRepresentation>,
+            // Fully opaque (default) → alpha omitted.
+            {
+              style: "CRs",
+              visible: true,
+              colourRules: [],
+              nonCustomOpacity: 1,
+            } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.elements![0].representations![0].alpha).toBe(0.4);
+    expect(scene.elements![0].representations![1].alpha).toBeUndefined();
+  });
+
   it("recognises by-domain pipe-delimited args", () => {
     const scene = liftScene({
       molecules: [

--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -172,6 +172,33 @@ describe("liftScene", () => {
     expect(scene.elements![0].representations![0].colour).toBe("#2ecc71");
   });
 
+  it("captures coot's per-chain default (many single rules) as a colour list", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 0,
+          uniqueId: "x",
+          representations: [
+            {
+              style: "CRs",
+              visible: true,
+              colourRules: [
+                { ruleType: "molecule", cid: "//A", color: "#a08766", isMultiColourRule: false } as unknown as moorhen.ColourRule,
+                { ruleType: "molecule", cid: "//B", color: "#7e9cd8", isMultiColourRule: false } as unknown as moorhen.ColourRule,
+              ],
+            } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    expect(scene.elements![0].representations![0].colour).toEqual([
+      { selection: "//A", colour: "#a08766" },
+      { selection: "//B", colour: "#7e9cd8" },
+    ]);
+  });
+
   it("captures a non-default nonCustomOpacity as alpha", () => {
     const scene = liftScene({
       molecules: [

--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -193,10 +193,10 @@ describe("liftScene", () => {
       ],
       glRef: fakeGlRef,
     });
-    // per-chain colouring is stated once in domains: (range-less = whole chain)…
+    // per-chain colouring is stated once in domains: (whole-chain CID selection)…
     expect(scene.domains).toEqual([
-      { name: "A", chain: "A", color: "#a08766" },
-      { name: "B", chain: "B", color: "#7e9cd8" },
+      { name: "A", selection: "//A", color: "#a08766" },
+      { name: "B", selection: "//B", color: "#7e9cd8" },
     ]);
     // …and the representation adopts it.
     expect(scene.elements![0].representations![0].colour).toBe("by-domain");

--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -172,7 +172,7 @@ describe("liftScene", () => {
     expect(scene.elements![0].representations![0].colour).toBe("#2ecc71");
   });
 
-  it("captures coot's per-chain default (many single rules) as a colour list", () => {
+  it("hoists coot's per-chain default into domains: + colour: by-domain", () => {
     const scene = liftScene({
       molecules: [
         fakeMol({
@@ -193,10 +193,13 @@ describe("liftScene", () => {
       ],
       glRef: fakeGlRef,
     });
-    expect(scene.elements![0].representations![0].colour).toEqual([
-      { selection: "//A", colour: "#a08766" },
-      { selection: "//B", colour: "#7e9cd8" },
+    // per-chain colouring is stated once in domains: (range-less = whole chain)…
+    expect(scene.domains).toEqual([
+      { name: "A", chain: "A", color: "#a08766" },
+      { name: "B", chain: "B", color: "#7e9cd8" },
     ]);
+    // …and the representation adopts it.
+    expect(scene.elements![0].representations![0].colour).toBe("by-domain");
   });
 
   it("captures a non-default nonCustomOpacity as alpha", () => {

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -178,6 +178,35 @@ describe("Moorhen scene — per-selection colour list", () => {
 });
 
 // --------------------------------------------------------------------------
+// Whole-chain domains (range omitted ⇒ the whole chain; what coot's per-chain
+// colouring hoists to, adopted via colour: by-domain).
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — whole-chain domains", () => {
+  it("accepts a range-less domain and round-trips it", () => {
+    const scene = parseScene(
+      `scene: x\nversion: 1\ndomains:\n  - { name: A, chain: A, color: "#a08766" }\n`,
+    );
+    expect(scene.domains![0]).toEqual({ name: "A", chain: "A", color: "#a08766" });
+    expect(scene.domains![0].range).toBeUndefined();
+    expect(parseScene(serialiseScene(scene))).toEqual(scene); // parse→serialise→parse
+  });
+
+  it("still validates a range when one IS given", () => {
+    expect(
+      parseScene(
+        `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: A, range: "1-50", color: "#fff000" }\n`,
+      ).domains![0].range,
+    ).toBe("1-50");
+    expect(() =>
+      parseScene(
+        `scene: x\nversion: 1\ndomains:\n  - { name: d, chain: A, range: "1to50", color: "#fff000" }\n`,
+      ),
+    ).toThrow(/start-end/);
+  });
+});
+
+// --------------------------------------------------------------------------
 // Validation: each error class.
 // --------------------------------------------------------------------------
 

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -182,14 +182,32 @@ describe("Moorhen scene — per-selection colour list", () => {
 // colouring hoists to, adopted via colour: by-domain).
 // --------------------------------------------------------------------------
 
-describe("Moorhen scene — whole-chain domains", () => {
-  it("accepts a range-less domain and round-trips it", () => {
+describe("Moorhen scene — domain selection (CID) + legacy chain+range", () => {
+  it("accepts a CID selection domain and round-trips it", () => {
     const scene = parseScene(
+      `scene: x\nversion: 1\ndomains:\n  - { name: F, selection: "//F/32-64", color: "#a06695" }\n`,
+    );
+    expect(scene.domains![0]).toEqual({
+      name: "F",
+      selection: "//F/32-64",
+      color: "#a06695",
+    });
+    expect(parseScene(serialiseScene(scene))).toEqual(scene); // parse→serialise→parse
+  });
+
+  it("still accepts the legacy chain+range form (whole chain too)", () => {
+    const whole = parseScene(
       `scene: x\nversion: 1\ndomains:\n  - { name: A, chain: A, color: "#a08766" }\n`,
     );
-    expect(scene.domains![0]).toEqual({ name: "A", chain: "A", color: "#a08766" });
-    expect(scene.domains![0].range).toBeUndefined();
-    expect(parseScene(serialiseScene(scene))).toEqual(scene); // parse→serialise→parse
+    expect(whole.domains![0]).toEqual({ name: "A", chain: "A", color: "#a08766" });
+    expect(whole.domains![0].range).toBeUndefined();
+    expect(parseScene(serialiseScene(whole))).toEqual(whole);
+  });
+
+  it("requires selection or chain", () => {
+    expect(() =>
+      parseScene(`scene: x\nversion: 1\ndomains:\n  - { name: d, color: "#ffffff" }\n`),
+    ).toThrow(/required \(or use .selection.\)/);
   });
 
   it("still validates a range when one IS given", () => {

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -108,6 +108,42 @@ describe("Moorhen scene — worked kinase example", () => {
 });
 
 // --------------------------------------------------------------------------
+// Representation alpha (per-representation opacity → nonCustomOpacity).
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — representation alpha", () => {
+  const withAlpha = (alpha: string) =>
+    `scene: x\nversion: 1\nfiles:\n  - name: p\n    pdb: 1m17\n` +
+    `elements:\n  - file: p\n    representations:\n` +
+    `      - style: MolecularSurface\n        selection: //A\n` +
+    `        colour: "#9bbcd8"\n        alpha: ${alpha}\n`;
+
+  it("accepts alpha in [0,1] and round-trips it", () => {
+    const scene = parseScene(withAlpha("0.4"));
+    expect(scene.elements![0].representations![0].alpha).toBe(0.4);
+    expect(parseScene(serialiseScene(scene))).toEqual(scene); // parse→serialise→parse
+  });
+
+  it("omits alpha when absent (default opaque)", () => {
+    const yaml =
+      `scene: x\nversion: 1\nfiles:\n  - name: p\n    pdb: 1m17\n` +
+      `elements:\n  - file: p\n    representations:\n      - style: CRs\n`;
+    expect(
+      parseScene(yaml).elements![0].representations![0].alpha,
+    ).toBeUndefined();
+  });
+
+  it("rejects alpha outside [0,1]", () => {
+    expect(() => parseScene(withAlpha("1.5"))).toThrow(/in \[0, 1\]/);
+    expect(() => parseScene(withAlpha("-0.2"))).toThrow(/in \[0, 1\]/);
+  });
+
+  it("rejects non-numeric alpha", () => {
+    expect(() => parseScene(withAlpha('"opaque"'))).toThrow(/must be a number/);
+  });
+});
+
+// --------------------------------------------------------------------------
 // Validation: each error class.
 // --------------------------------------------------------------------------
 

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -144,6 +144,40 @@ describe("Moorhen scene — representation alpha", () => {
 });
 
 // --------------------------------------------------------------------------
+// Per-selection colour list (the general "colour these CIDs these colours"
+// form; what coot's default per-chain colouring lifts to).
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — per-selection colour list", () => {
+  const repWith = (colour: string) =>
+    `scene: x\nversion: 1\nfiles:\n  - name: p\n    pdb: 1m17\n` +
+    `elements:\n  - file: p\n    representations:\n      - style: CRs\n        colour: ${colour}\n`;
+
+  it("accepts a per-chain colour list and round-trips it", () => {
+    const scene = parseScene(
+      repWith(`[{ selection: "//A", colour: "#a08766" }, { selection: "//B", colour: "#7e9cd8" }]`),
+    );
+    expect(scene.elements![0].representations![0].colour).toEqual([
+      { selection: "//A", colour: "#a08766" },
+      { selection: "//B", colour: "#7e9cd8" },
+    ]);
+    expect(parseScene(serialiseScene(scene))).toEqual(scene); // parse→serialise→parse
+  });
+
+  it("rejects a list entry with no colour", () => {
+    expect(() => parseScene(repWith(`[{ selection: "//A" }]`))).toThrow(
+      /colour.*required/,
+    );
+  });
+
+  it("rejects a list entry with a bad hex", () => {
+    expect(() =>
+      parseScene(repWith(`[{ selection: "//A", colour: "notahex" }]`)),
+    ).toThrow(/must be hex/);
+  });
+});
+
+// --------------------------------------------------------------------------
 // Validation: each error class.
 // --------------------------------------------------------------------------
 

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -27,6 +27,7 @@ import {
   MoorhenScene,
   SCENE_SCHEMA_VERSION,
   SceneColour,
+  SceneColourSelection,
   SceneDomain,
   SceneElement,
   SceneFileRef,
@@ -792,26 +793,32 @@ const NAMED_MULTI_RULES = new Set([
   "mol-symm",
 ]);
 
+const HEX_RE = /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/;
+
+/** A single-colour rule with a hex colour (Moorhen "molecule" ruleType etc.). */
+function isSingleHexRule(r: moorhen.ColourRule): boolean {
+  return !r.isMultiColourRule && typeof r.color === "string" && HEX_RE.test(r.color);
+}
+
 function liftColour(rules: moorhen.ColourRule[]): SceneColour | undefined {
   if (rules.length === 0) return undefined;
 
-  // We only attempt to lift the *first* rule. Multiple rules per
-  // representation is rare in normal Moorhen UI flows; if we see it,
-  // the safer thing is to emit the first one and drop the rest rather
-  // than invent some lossy merge. (A future v2 could lift a sequence.)
+  // All single-colour rules → a single hex (one rule) or a per-selection list
+  // (many). The list is the faithful capture of coot's default per-chain
+  // colouring: one entry per chain with the colour coot assigned — instead of
+  // mistaking the first chain's hex for the whole representation. Whole-chain
+  // and residue-range CIDs are the same shape, so by-domain re-applies through
+  // the same path.
+  if (rules.every(isSingleHexRule)) {
+    if (rules.length === 1) return rules[0].color;
+    return rules.map((r) => ({ selection: r.cid, colour: r.color }));
+  }
+
   const r = rules[0];
 
   // 1. Named multi-rule scheme (b-factor, etc.).
   if (NAMED_MULTI_RULES.has(r.ruleType)) {
     return r.ruleType as SceneColour;
-  }
-
-  // 2. Single-colour rule with a hex colour (Moorhen's "molecule" ruleType
-  //    or anything with isMultiColourRule=false).
-  // Accept 6-hex (#rrggbb) and 8-hex with alpha (#rrggbbaa) — Moorhen's
-  // default per-chain rules typically come out as 8-hex.
-  if (!r.isMultiColourRule && typeof r.color === "string" && /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(r.color)) {
-    return r.color;
   }
 
   // 3. by-domain shape: a single multi-rule whose args[0] is a string

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -186,6 +186,10 @@ export function liftScene(ctx: LiftCtx): MoorhenScene {
     if (maps.length > 0) scene.maps = maps;
   }
 
+  // Fold any whole-chain colour lists into domains: + colour: by-domain, so a
+  // molecule's per-chain colouring is stated once rather than inline per rep.
+  hoistPerChainColours(scene);
+
   return scene;
 }
 
@@ -821,6 +825,24 @@ function liftColour(rules: moorhen.ColourRule[]): SceneColour | undefined {
     return r.ruleType as SceneColour;
   }
 
+  // 2. A compiled WHOLE-CHAIN per-selection rule: one multi-rule whose args[0]
+  //    is `//chain^#hex|...` (no residue range). This is what applying a
+  //    hoisted per-chain colouring (domains: + by-domain) produces, so decompose
+  //    it back to the list — hoistPerChainColours then re-folds it into
+  //    domains: + by-domain, keeping capture→apply→capture stable.
+  if (
+    r.isMultiColourRule &&
+    typeof r.args?.[0] === "string" &&
+    /^\/\/[^/^|]+\^#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?(\|\/\/[^/^|]+\^#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?)*$/.test(
+      r.args[0] as string,
+    )
+  ) {
+    return (r.args[0] as string).split("|").map((seg) => {
+      const ix = seg.lastIndexOf("^");
+      return { selection: seg.slice(0, ix), colour: seg.slice(ix + 1) };
+    });
+  }
+
   // 3. by-domain shape: a single multi-rule whose args[0] is a string
   //    of `//chain/start-end^#rrggbb|...` segments. Recognise and emit
   //    as `by-domain` (the calling code can reconstitute domains from
@@ -845,6 +867,55 @@ function liftColour(rules: moorhen.ColourRule[]): SceneColour | undefined {
       applyColourToNonCarbonAtoms: r.applyColourToNonCarbonAtoms,
     },
   };
+}
+
+/** Chain id of a whole-chain CID ("//A", "/1/A"), else null (has residue/atom
+ *  parts, or is a wildcard). */
+function chainOfWholeChainCid(cid: string): string | null {
+  const parts = cid.split("/"); // "//A" -> ["","","A"]; "/1/A" -> ["","1","A"]
+  if (parts.length === 3 && parts[2] !== "" && parts[2] !== "*") return parts[2];
+  return null;
+}
+
+/**
+ * Hoist whole-chain colour lists into the shared `domains:` block + `colour:
+ * by-domain` on the representations, so a molecule's per-chain colouring is
+ * stated ONCE instead of repeated inline on every representation — the same
+ * "define a colour map once, representations adopt it" pattern by-domain already
+ * uses, at whole-chain granularity.
+ *
+ * Conservative: only fires when every adopting rep's colour list is entirely
+ * whole-chain CIDs, the chain→colour mapping is consistent across reps, and the
+ * `domains:` block is empty (so authored domains are never disturbed). Anything
+ * else (residue-range lists, conflicting per-chain colours) is left inline.
+ */
+function hoistPerChainColours(scene: MoorhenScene): void {
+  if (!scene.elements || (scene.domains && scene.domains.length > 0)) return;
+  const chainColour = new Map<string, string>();
+  const adopters: SceneRepresentation[] = [];
+  let conflict = false;
+  for (const el of scene.elements) {
+    for (const rep of el.representations ?? []) {
+      const c = rep.colour;
+      if (!Array.isArray(c) || c.length === 0) continue;
+      const chains = c.map((e) => chainOfWholeChainCid(e.selection));
+      if (chains.some((ch) => ch === null)) continue; // not all whole-chain
+      adopters.push(rep);
+      c.forEach((e, i) => {
+        const ch = chains[i] as string;
+        const prev = chainColour.get(ch);
+        if (prev !== undefined && prev !== e.colour) conflict = true;
+        chainColour.set(ch, e.colour);
+      });
+    }
+  }
+  if (conflict || chainColour.size === 0 || adopters.length === 0) return;
+  scene.domains = [...chainColour.entries()].map(([chain, color]) => ({
+    name: chain,
+    chain,
+    color,
+  }));
+  for (const rep of adopters) rep.colour = "by-domain";
 }
 
 // --------------------------------------------------------------------------

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -912,7 +912,7 @@ function hoistPerChainColours(scene: MoorhenScene): void {
   if (conflict || chainColour.size === 0 || adopters.length === 0) return;
   scene.domains = [...chainColour.entries()].map(([chain, color]) => ({
     name: chain,
-    chain,
+    selection: `//${chain}`, // whole chain, CID form
     color,
   }));
   for (const rep of adopters) rep.colour = "by-domain";

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -771,6 +771,11 @@ function liftRepresentation(rep: moorhen.MoleculeRepresentation): SceneRepresent
   const colour = liftColour(rep.colourRules ?? []);
   if (colour !== undefined) out.colour = colour;
 
+  // Per-representation opacity (Moorhen `nonCustomOpacity`); only emit a
+  // non-default value (default 1 = opaque ⇒ omit, matching the map `alpha`).
+  const a = (rep as { nonCustomOpacity?: number }).nonCustomOpacity;
+  if (typeof a === "number" && a < 1) out.alpha = round(a, 3);
+
   return out;
 }
 

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -930,11 +930,6 @@ function buildByDomainPendingRule(
 
   const segments: string[] = [];
   for (const d of domains) {
-    const m = /^(-?\d+)-(-?\d+)$/.exec(d.range);
-    if (!m) continue;
-    const start = parseInt(m[1], 10);
-    const end = parseInt(m[2], 10);
-
     // Resolve the domain's chain selector into concrete chain ids.
     // - "*"      → every chain present in the structure
     // - "A"      → exactly chain A (legacy single-chain form)
@@ -951,6 +946,19 @@ function buildByDomainPendingRule(
       });
       continue;
     }
+
+    // Range-less domain ⇒ the WHOLE chain: one `//chain` segment per chain, no
+    // residue range (so a molecule's per-chain colouring is a set of whole-chain
+    // "domains" adopted via colour: by-domain, the same path as range domains).
+    if (!d.range) {
+      for (const chainId of targetChains) segments.push(`//${chainId}^${d.color}`);
+      continue;
+    }
+
+    const m = /^(-?\d+)-(-?\d+)$/.exec(d.range);
+    if (!m) continue;
+    const start = parseInt(m[1], 10);
+    const end = parseInt(m[2], 10);
 
     for (const chainId of targetChains) {
       const present = presentByChain.get(chainId);

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -762,6 +762,11 @@ async function applyRepresentation(ctx: ApplyRepCtx): Promise<boolean> {
         true, // isCustom — keeps it under our control to clear later
       );
       if (!created) continue;
+      // Per-representation opacity (Moorhen `nonCustomOpacity`, 0..1, 1=opaque).
+      // Applies to surfaces as well as ribbons/sticks. Set before the redraw so
+      // the buffers pick up the transparent flag; absent ⇒ left at the default 1.
+      const hasAlpha = typeof rep.alpha === "number" && rep.alpha < 1;
+      if (hasAlpha) created.setNonCustomOpacity(rep.alpha as number);
       if (pendingRules.length > 0) {
         for (const r of pendingRules) {
           // Colour rule CID stays as authored — the rule's CID and the
@@ -777,6 +782,10 @@ async function applyRepresentation(ctx: ApplyRepCtx): Promise<boolean> {
             r.applyColourToNonCarbonAtoms ?? false,
           );
         }
+      }
+      // Redraw if we changed colour rules or opacity (either needs the buffers
+      // rebuilt to reach the GL state).
+      if (pendingRules.length > 0 || hasAlpha) {
         await molecule.redrawRepresentation(created.uniqueId);
       }
       dispatch(addCustomRepresentation(created));

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -53,6 +53,7 @@ import { extractFileIdFromUniqueId } from "./moorhen-view-state";
 import {
   MoorhenScene,
   SceneColour,
+  SceneColourSelection,
   SceneDomain,
   SceneFileRef,
   SceneMap,
@@ -840,6 +841,20 @@ function extractRepError(e: unknown): string {
 function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] {
   const { molecule, rep, domains, fileName, log, policy } = ctx;
   if (!rep.colour) return [];
+
+  if (Array.isArray(rep.colour)) {
+    // Per-selection colour list: one single-colour rule per entry. A whole-chain
+    // CID ("//A") and a residue range ("//A/121-130") apply identically here —
+    // it's the general form by-domain compiles to, and what coot's default
+    // per-chain colouring round-trips through.
+    return rep.colour.map((c) => ({
+      ruleType: "molecule",
+      cid: c.selection,
+      color: c.colour,
+      args: [c.selection, c.colour],
+      isMultiColourRule: false,
+    }));
+  }
 
   if (isSceneHexColour(rep.colour)) {
     // libcoot's add_colour_rule reads cid+colour from args, not from

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -911,6 +911,55 @@ function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] 
 // by-domain compilation: clamp ranges, build pipe-delimited args
 // --------------------------------------------------------------------------
 
+/**
+ * Turn a domain CID `selection` into colour-rule segments. When the CID is the
+ * `//chain/start-end` shape (a concrete chain + numeric range) it is clamped to
+ * the residues present and warned about — diagnostic parity with the legacy
+ * chain+range form. Any other CID (whole chain `//F`, residue names, atoms,
+ * wildcard chains) passes straight through to Coot.
+ */
+function selectionToSegments(
+  selection: string,
+  color: string,
+  domainName: string,
+  presentByChain: Map<string, Set<number>>,
+  log: SceneResolveLogEntry[],
+  fileName: string,
+  policy: "clamp-and-log" | "strict",
+): string[] {
+  const m = /^(\/[^/]*\/([^/*]+))\/(-?\d+)-(-?\d+)$/.exec(selection);
+  if (!m) return [`${selection}^${color}`];
+  const prefix = m[1];
+  const chainId = m[2];
+  const start = parseInt(m[3], 10);
+  const end = parseInt(m[4], 10);
+  const present = presentByChain.get(chainId);
+  if (!present) {
+    log.push({ file: fileName, domain: domainName, message: `chain ${chainId} not present in molecule; skipped` });
+    return [];
+  }
+  const subRanges = clampRangeToPresent(start, end, present);
+  if (subRanges.length === 0) {
+    log.push({ file: fileName, domain: domainName, message: `range ${start}-${end} has no present residues in chain ${chainId}; skipped` });
+    return [];
+  }
+  if (subRanges.length > 1 || subRanges[0][0] !== start || subRanges[0][1] !== end) {
+    log.push({
+      file: fileName,
+      domain: domainName,
+      message: `chain ${chainId}: range ${start}-${end} resolved to ${subRanges
+        .map(([s, e]) => `${s}-${e}`)
+        .join(", ")} after clamping to present residues`,
+    });
+    if (policy === "strict") {
+      throw new Error(
+        `Scene resolver in strict mode: domain "${domainName}" range ${start}-${end} not fully present in chain ${chainId}`,
+      );
+    }
+  }
+  return subRanges.map(([s, e]) => `${prefix}/${s}-${e}^${color}`);
+}
+
 function buildByDomainPendingRule(
   molecule: moorhen.Molecule,
   domains: SceneDomain[],
@@ -930,7 +979,19 @@ function buildByDomainPendingRule(
 
   const segments: string[] = [];
   for (const d of domains) {
-    // Resolve the domain's chain selector into concrete chain ids.
+    // Preferred CID form: clamp the //chain/start-end shape (diagnostic parity
+    // with chain+range), pass any other CID straight through.
+    if (d.selection) {
+      segments.push(
+        ...selectionToSegments(
+          d.selection, d.color, d.name, presentByChain, log, fileName, policy,
+        ),
+      );
+      continue;
+    }
+    if (!d.chain) continue; // neither selection nor chain (invalid; validated upstream)
+
+    // Legacy: resolve the chain selector into concrete chain ids.
     // - "*"      → every chain present in the structure
     // - "A"      → exactly chain A (legacy single-chain form)
     // - ["A","B"] → exactly those chains

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -827,6 +827,16 @@ function validateRepresentation(
     const c = (raw as Record<string, unknown>).colour;
     rep.colour = validateColour(c, `${path}.colour`, errors) ?? undefined;
   }
+  if ("alpha" in raw) {
+    const a = optNum(raw, "alpha", `${path}.alpha`, errors);
+    if (a !== undefined) {
+      if (a < 0 || a > 1) {
+        errors.push({ path: `${path}.alpha`, message: "must be in [0, 1]" });
+      } else {
+        rep.alpha = a;
+      }
+    }
+  }
   return rep;
 }
 

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -23,6 +23,7 @@ import {
   SceneMapColumns,
   SceneRepresentation,
   SceneColour,
+  SceneColourSelection,
   SceneSuperpose,
   isSceneHexColour,
   isSceneNamedColour,
@@ -845,6 +846,27 @@ function validateColour(
   path: string,
   errors: SceneValidationError[],
 ): SceneColour | null {
+  if (Array.isArray(raw)) {
+    // Per-selection colour list: [{ selection, colour }, ...].
+    const list: SceneColourSelection[] = [];
+    raw.forEach((entry, i) => {
+      const ep = `${path}[${i}]`;
+      if (!isObject(entry)) {
+        errors.push({ path: ep, message: "must be a mapping { selection, colour }" });
+        return;
+      }
+      const selection = strField(entry, "selection", "", errors, ep);
+      if (!selection) errors.push({ path: `${ep}.selection`, message: "required" });
+      const colour = strField(entry, "colour", "", errors, ep);
+      if (!colour) {
+        errors.push({ path: `${ep}.colour`, message: "required" });
+      } else if (!isHexColor(colour)) {
+        errors.push({ path: `${ep}.colour`, message: "must be hex (#rrggbb or #rrggbbaa)" });
+      }
+      if (selection && colour && isHexColor(colour)) list.push({ selection, colour });
+    });
+    return list.length > 0 ? list : null;
+  }
   if (typeof raw === "string") {
     if (isHexColor(raw)) return raw;
     if (isSceneNamedColour(raw as SceneColour)) return raw as SceneColour;
@@ -883,7 +905,11 @@ function validateColour(
       },
     };
   }
-  errors.push({ path, message: "must be a hex string, named scheme, or { raw: ... }" });
+  errors.push({
+    path,
+    message:
+      "must be a hex string, named scheme, per-selection list, or { raw: ... }",
+  });
   return null;
 }
 

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -578,26 +578,28 @@ function validateDomains(
     }
     const name = strField(entry, "name", "", errors, p);
     const chain = parseChainField(entry, `${p}.chain`, errors);
-    const range = rangeField(entry, "range", errors, p) ?? "";
+    // range OMITTED ⇒ whole chain (a //chain "domain"). Only validate if present.
+    const hasRange = "range" in (entry as Record<string, unknown>);
+    const range = hasRange ? rangeField(entry, "range", errors, p) ?? "" : undefined;
     const color = strField(entry, "color", "", errors, p);
     if (!name) errors.push({ path: `${p}.name`, message: "required" });
     if (chain === undefined) errors.push({ path: `${p}.chain`, message: "required" });
-    if (!range) {
-      errors.push({ path: `${p}.range`, message: "required" });
-    } else if (!RANGE_RE.test(range)) {
-      errors.push({
-        path: `${p}.range`,
-        message: `must be "start-end", got "${range}"`,
-      });
-    } else {
-      const m = RANGE_RE.exec(range)!;
-      const start = parseInt(m[1], 10);
-      const end = parseInt(m[2], 10);
-      if (end < start) {
+    if (hasRange) {
+      if (!range || !RANGE_RE.test(range)) {
         errors.push({
           path: `${p}.range`,
-          message: `end (${end}) must be >= start (${start})`,
+          message: `must be "start-end", got "${range}"`,
         });
+      } else {
+        const m = RANGE_RE.exec(range)!;
+        const start = parseInt(m[1], 10);
+        const end = parseInt(m[2], 10);
+        if (end < start) {
+          errors.push({
+            path: `${p}.range`,
+            message: `end (${end}) must be >= start (${start})`,
+          });
+        }
       }
     }
     if (!color) {
@@ -614,7 +616,9 @@ function validateDomains(
       }
       seen.add(name);
     }
-    out.push({ name, chain: chain ?? "", range, color });
+    const domain: SceneDomain = { name, chain: chain ?? "", color };
+    if (range) domain.range = range;
+    out.push(domain);
   });
   return out;
 }

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -576,32 +576,10 @@ function validateDomains(
       errors.push({ path: p, message: "must be a mapping" });
       return;
     }
+    const e = entry as Record<string, unknown>;
     const name = strField(entry, "name", "", errors, p);
-    const chain = parseChainField(entry, `${p}.chain`, errors);
-    // range OMITTED ⇒ whole chain (a //chain "domain"). Only validate if present.
-    const hasRange = "range" in (entry as Record<string, unknown>);
-    const range = hasRange ? rangeField(entry, "range", errors, p) ?? "" : undefined;
     const color = strField(entry, "color", "", errors, p);
     if (!name) errors.push({ path: `${p}.name`, message: "required" });
-    if (chain === undefined) errors.push({ path: `${p}.chain`, message: "required" });
-    if (hasRange) {
-      if (!range || !RANGE_RE.test(range)) {
-        errors.push({
-          path: `${p}.range`,
-          message: `must be "start-end", got "${range}"`,
-        });
-      } else {
-        const m = RANGE_RE.exec(range)!;
-        const start = parseInt(m[1], 10);
-        const end = parseInt(m[2], 10);
-        if (end < start) {
-          errors.push({
-            path: `${p}.range`,
-            message: `end (${end}) must be >= start (${start})`,
-          });
-        }
-      }
-    }
     if (!color) {
       errors.push({ path: `${p}.color`, message: "required" });
     } else if (!isHexColor(color)) {
@@ -616,8 +594,40 @@ function validateDomains(
       }
       seen.add(name);
     }
-    const domain: SceneDomain = { name, chain: chain ?? "", color };
-    if (range) domain.range = range;
+
+    const domain: SceneDomain = { name, color };
+    if ("selection" in e) {
+      // Preferred CID form.
+      const sel = strField(entry, "selection", "", errors, p);
+      if (!sel) {
+        errors.push({ path: `${p}.selection`, message: "must be a non-empty CID string" });
+      } else {
+        domain.selection = sel;
+      }
+    } else {
+      // Legacy chain + optional range (omitted ⇒ whole chain).
+      const chain = parseChainField(entry, `${p}.chain`, errors);
+      if (chain === undefined) {
+        errors.push({ path: `${p}.chain`, message: "required (or use `selection`)" });
+      } else {
+        domain.chain = chain;
+      }
+      if ("range" in e) {
+        const range = rangeField(entry, "range", errors, p) ?? "";
+        if (!range || !RANGE_RE.test(range)) {
+          errors.push({ path: `${p}.range`, message: `must be "start-end", got "${range}"` });
+        } else {
+          const m = RANGE_RE.exec(range)!;
+          const start = parseInt(m[1], 10);
+          const end = parseInt(m[2], 10);
+          if (end < start) {
+            errors.push({ path: `${p}.range`, message: `end (${end}) must be >= start (${start})` });
+          } else {
+            domain.range = range;
+          }
+        }
+      }
+    }
     out.push(domain);
   });
   return out;

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -117,44 +117,44 @@ files:
 
 ## `domains`
 
-Reusable named residue blocks, referenced from `colour: by-domain`
+Reusable named colour blocks, referenced from `colour: by-domain`
 inside an element. Hoisted to the top level so a multi-structure scene
 doesn't duplicate them per element.
 
 ```yaml
 domains:
-  - { name: CARD, chain: A, range: 1-92,    color: "#4b8bbe" }
-  - { name: NBD,  chain: A, range: 104-260, color: "#2ecc71" }
-  - { name: HD1,  chain: A, range: 261-330, color: "#9b59b6" }
+  - { name: CARD, selection: "//A/1-92",    color: "#4b8bbe" }
+  - { name: NBD,  selection: "//A/104-260", color: "#2ecc71" }
+  - { name: HD1,  selection: "//A/261-330", color: "#9b59b6" }
 ```
 
 Fields:
 
 - `name`: required.
-- `chain`: required. Three forms:
-  - `"A"` — a single chain.
-  - `"*"` — every chain present in the structure (useful for symmetric
-    assemblies like the apoptosome heptamer).
-  - `["A", "B", "C"]` — explicit list, applied to each chain in turn.
-- `range`: **optional**. Forms:
-  - `"start-end"` (string) — inclusive range, e.g. `"100-200"`.
-  - `<integer>` (bare int) — single residue; the validator normalises
-    `115` to `"115-115"` so downstream code only sees one shape.
-  - **omitted ⇒ the whole chain** — the domain is just `//chain`. This is
-    how a molecule's per-chain colouring is expressed: one range-less entry
-    per chain. (A whole chain is just a coarse domain — same `by-domain`
-    application path as residue ranges.)
+- `selection`: a Coot **CID** — the preferred, general form. Any valid CID:
+  - `"//F"` — the whole of chain F.
+  - `"//F/32-64"` — residues 32-64 of chain F.
+  - a wildcard chain — that residue range across every chain.
+  - `"//A/(ALA,GLY)"`, `"//A/55/CA[C]"` — residue names, atoms, … things
+    `chain`+`range` can't express.
+
+  When the CID is the `//chain/start-end` shape the resolver still clamps the
+  range to present residues and warns (parity with the legacy form, see
+  `resolver.onMissingResidues`); any other CID is passed straight to Coot.
 - `color`: required hex `#rrggbb`.
 
-The resolver clamps each range to the residues actually present in the
-loaded structure (see `resolver.onMissingResidues`); a range-less
-(whole-chain) domain needs no clamping.
+**Legacy (deprecated, accepted for a short migration window — prefer
+`selection`):** instead of `selection` you may give `chain` + optional `range`:
+
+- `chain`: `"A"` (single), `"*"` (every chain present), or `["A","B","C"]`.
+- `range`: `"start-end"`, a bare int (single residue), or **omitted ⇒ whole
+  chain**.
 
 ```yaml
 # Per-chain colouring, stated once and adopted by representations:
 domains:
-  - { name: A, chain: A, color: "#a08766" }   # whole chain A
-  - { name: B, chain: B, color: "#6ca066" }   # whole chain B
+  - { name: A, selection: "//A", color: "#a08766" }   # whole chain A
+  - { name: B, selection: "//B", color: "#6ca066" }   # whole chain B
 elements:
   - file: my_structure
     representations:
@@ -162,8 +162,8 @@ elements:
 ```
 
 This is exactly what coot's default per-chain colouring **lifts to** — the
-lifter folds it into `domains:` + `colour: by-domain` so it isn't repeated
-inline on every representation.
+lifter folds it into `domains:` (whole-chain `selection`) + `colour: by-domain`
+so it isn't repeated inline on every representation.
 
 ## `elements`
 

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -354,13 +354,16 @@ row today. The practical advice:
 
 ### `colour`
 
-Four forms:
+Five forms:
 
 ```yaml
 colour: "#4b8bbe"             # 1. Hex literal (#rrggbb or #rrggbbaa)
 colour: by-domain             # 2. Compile from the domains: block
 colour: b-factor              # 3. Named Moorhen scheme
-colour:                       # 4. Raw escape hatch (lossless, ugly)
+colour:                       # 4. Per-selection list (general; see below)
+  - { selection: "//A", colour: "#a08766" }
+  - { selection: "//B", colour: "#7e9cd8" }
+colour:                       # 5. Raw escape hatch (lossless, ugly)
   raw:
     ruleType: <string>
     args: [...]
@@ -378,6 +381,17 @@ Named schemes available out of the box:
 `by-domain` compiles to a single multi-residue colour rule built from
 the top-level `domains:` block. So one element with `colour: by-domain`
 on a ribbon gives you the whole domain-coloured protein in one rep.
+
+**Per-selection list** is the general "colour these CIDs these colours"
+form: one `{ selection, colour }` entry per CID, each applied as a single
+colour rule. A whole chain (`//A`) and a residue range (`//A/121-130`)
+are the same shape at different granularities — `by-domain` is just the
+named shortcut that compiles the `domains:` block into this. Crucially,
+**this is what coot's default per-chain colouring lifts to** — one entry
+per chain with the colour coot assigned — so a captured scene records the
+real per-chain colours instead of a single misleading hex. (`alpha` is a
+separate field, so you can always add it to make a per-chain-coloured
+surface translucent.)
 
 ### `alpha`
 

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -136,14 +136,34 @@ Fields:
   - `"*"` — every chain present in the structure (useful for symmetric
     assemblies like the apoptosome heptamer).
   - `["A", "B", "C"]` — explicit list, applied to each chain in turn.
-- `range`: required. Two forms:
+- `range`: **optional**. Forms:
   - `"start-end"` (string) — inclusive range, e.g. `"100-200"`.
   - `<integer>` (bare int) — single residue; the validator normalises
     `115` to `"115-115"` so downstream code only sees one shape.
+  - **omitted ⇒ the whole chain** — the domain is just `//chain`. This is
+    how a molecule's per-chain colouring is expressed: one range-less entry
+    per chain. (A whole chain is just a coarse domain — same `by-domain`
+    application path as residue ranges.)
 - `color`: required hex `#rrggbb`.
 
 The resolver clamps each range to the residues actually present in the
-loaded structure (see `resolver.onMissingResidues`).
+loaded structure (see `resolver.onMissingResidues`); a range-less
+(whole-chain) domain needs no clamping.
+
+```yaml
+# Per-chain colouring, stated once and adopted by representations:
+domains:
+  - { name: A, chain: A, color: "#a08766" }   # whole chain A
+  - { name: B, chain: B, color: "#6ca066" }   # whole chain B
+elements:
+  - file: my_structure
+    representations:
+      - { style: CRs, colour: by-domain, alpha: 0.5 }
+```
+
+This is exactly what coot's default per-chain colouring **lifts to** — the
+lifter folds it into `domains:` + `colour: by-domain` so it isn't repeated
+inline on every representation.
 
 ## `elements`
 

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -379,6 +379,25 @@ Named schemes available out of the box:
 the top-level `domains:` block. So one element with `colour: by-domain`
 on a ribbon gives you the whole domain-coloured protein in one rep.
 
+### `alpha`
+
+Opacity in `[0, 1]` (1 = fully opaque). Omitted ⇒ opaque, so existing
+scenes are unchanged. Maps to Moorhen's per-representation
+`nonCustomOpacity`, so it applies to **surfaces** (`MolecularSurface`,
+`VdWSurface`, `gaussian`, `MetaBalls`) as well as ribbons and sticks —
+a translucent molecular surface over a cartoon is the canonical use.
+
+```yaml
+representations:
+  - { style: CRs,              selection: "//A", colour: secondary-structure }
+  - { style: MolecularSurface, selection: "//A", colour: "#9bbcd8", alpha: 0.4 }
+```
+
+This is the opacity used when colour is scene-driven (rules / hex /
+named schemes). A colour hand-picked with Moorhen's colour-picker
+instead carries its alpha in the colour's own RGBA; scenes don't author
+those, so `alpha` is the single lever here.
+
 ### `dictionaries`
 
 A list of dictionary file names (from `files:` with `kind: dictionary`).

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -174,25 +174,27 @@ export interface SceneDomain {
   /** Free-text name used in `colour: by-domain` and in the resolver log. */
   name: string;
 
-  /** Chain selector. Three forms:
+  /** CID selection — the preferred, general form. Any valid Coot CID:
    *
-   *   - `"A"` (or any non-`*` string) — single chain.
-   *   - `"*"` — every chain present in the structure (useful for symmetric
-   *     assemblies like the apoptosome heptamer).
-   *   - `["A", "B", "C"]` — explicit list, applied to each chain in turn.
+   *   - `"//F"`        — the whole of chain F.
+   *   - `"//F/32-64"`  — residues 32-64 of chain F.
+   *   - a wildcard chain (`//<star>/32-64`) — that range across every chain.
+   *   - `"//A/(ALA,GLY)"`, `"//A/55/CA[C]"` — residue names, atoms, … things
+   *     the chain+range form can't express.
    *
-   *  At apply-time the resolver fans the domain out across the resolved
-   *  chain list and clamps the range per-chain. */
-  chain: string | string[];
+   *  When the CID is the `//chain/start-end` shape the resolver still clamps the
+   *  range to present residues and warns (parity with `chain`+`range`); any other
+   *  CID is passed straight to Coot. Use this in preference to `chain`+`range`. */
+  selection?: string;
 
-  /** Inclusive residue range "start-end", e.g. "1-120". The resolver
-   *  clamps this to the residues actually present in each loaded
-   *  structure (see SceneResolverOptions.onMissingResidues).
-   *
-   *  OMITTED ⇒ the whole chain — a "domain" that is just `//chain`. This is
-   *  how a molecule's per-chain colouring is stated once (one range-less
-   *  entry per chain) and adopted by representations via `colour: by-domain`,
-   *  the same path as residue-range domains at a coarser granularity. */
+  /** @deprecated Legacy chain selector — use `selection`. Kept for a short
+   *  migration window. Forms: `"A"` (single chain), `"*"` (every chain present),
+   *  `["A","B","C"]` (explicit list). The resolver fans out across the resolved
+   *  chains and clamps the range per-chain. */
+  chain?: string | string[];
+
+  /** @deprecated Legacy inclusive residue range "start-end" — use `selection`.
+   *  Omitted ⇒ the whole chain. Clamped to present residues by the resolver. */
   range?: string;
 
   /** Hex colour, e.g. "#4b8bbe". */

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -302,18 +302,35 @@ export interface SceneRepresentation {
 }
 
 /**
- * Colour specification. Three v0 shapes:
+ * Colour specification. Shapes:
  *
- *   1. Hex literal:        colour: "#4b8bbe"
- *   2. Named scheme:       colour: by-domain | b-factor | af2-plddt | ...
- *   3. Raw escape hatch:   colour: { raw: { ruleType, args } }
+ *   1. Hex literal:           colour: "#4b8bbe"
+ *   2. Named scheme:          colour: by-domain | b-factor | af2-plddt | ...
+ *   3. Per-selection list:    colour: [ { selection: "//A", colour: "#a08766" }, ... ]
+ *   4. Raw escape hatch:      colour: { raw: { ruleType, args } }
  *
- * `by-domain` compiles to a single multi-rule built from the top-level
- * `domains:` block. Named schemes map 1:1 to Moorhen's existing multi-rule
- * ruleTypes. The raw form preserves anything we can't lift to a higher
- * abstraction (lossless but ugly).
+ * The per-selection list is the general "colour these CIDs these colours" form:
+ * one entry per selection, each compiled to a single colour rule. A whole chain
+ * (`//A`) and a residue range (`//A/121-130`) are the same shape at different
+ * granularities — so this is what coot's default per-chain colouring lifts to
+ * (one entry per chain, the colour coot assigned), instead of a single
+ * misleading hex. `by-domain` is the named shortcut that compiles the top-level
+ * `domains:` block into this same form. Named schemes map 1:1 to Moorhen's
+ * multi-rule ruleTypes. The raw form preserves anything we can't lift.
  */
-export type SceneColour = string | SceneNamedColour | SceneRawColour;
+export type SceneColour =
+  | string
+  | SceneNamedColour
+  | SceneColourSelection[]
+  | SceneRawColour;
+
+/** One entry of a per-selection colour list: a CID and the hex it gets. */
+export interface SceneColourSelection {
+  /** CID, e.g. "//A" (whole chain) or "//A/121-130" (residue range). */
+  selection: string;
+  /** Hex colour (#rrggbb or #rrggbbaa). */
+  colour: string;
+}
 
 export type SceneNamedColour =
   | "by-domain"

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -292,6 +292,13 @@ export interface SceneRepresentation {
 
   /** Colour specification — see SceneColour for the variants. */
   colour?: SceneColour;
+
+  /** Opacity in [0, 1] (1 = fully opaque). Maps to Moorhen's per-representation
+   *  `nonCustomOpacity`; applies to surfaces (MolecularSurface, VdWSurface,
+   *  gaussian, MetaBalls) as well as ribbons/sticks. Omitted ⇒ opaque. This is
+   *  the opacity used when colour is scene-driven (rules / hex / named schemes);
+   *  a hand-picked colour-picker colour would instead carry alpha in its RGBA. */
+  alpha?: number;
 }
 
 /**

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -187,8 +187,13 @@ export interface SceneDomain {
 
   /** Inclusive residue range "start-end", e.g. "1-120". The resolver
    *  clamps this to the residues actually present in each loaded
-   *  structure (see SceneResolverOptions.onMissingResidues). */
-  range: string;
+   *  structure (see SceneResolverOptions.onMissingResidues).
+   *
+   *  OMITTED ⇒ the whole chain — a "domain" that is just `//chain`. This is
+   *  how a molecule's per-chain colouring is stated once (one range-less
+   *  entry per chain) and adopted by representations via `colour: by-domain`,
+   *  the same path as residue-range domains at a coarser granularity. */
+  range?: string;
 
   /** Hex colour, e.g. "#4b8bbe". */
   color: string;


### PR DESCRIPTION
Two related improvements to how scene **representations** capture and apply look — both additive and backward-compatible (existing scenes render identically).

## 1. Per-representation transparency (`alpha`)
Optional `alpha` (0–1, 1 = opaque) on a representation → Moorhen's `nonCustomOpacity`. Applies to **surfaces** (`MolecularSurface`, `VdWSurface`, `gaussian`, `MetaBalls`) as well as ribbons/sticks — a translucent surface over a cartoon being the canonical use. It's a **field independent of `colour`**, so any representation (including a default-coloured one) can override the implicit 1.

## 2. Per-chain colouring, stated once (whole-chain by-domain)
A multi-chain molecule adopts coot's **default per-chain colouring** (N single-colour rules, one per chain). The lifter previously read only `rules[0]`, emitting a single misleading hex. The fix uses the **by-domain pattern** — state the colour map once, representations adopt it — at whole-chain granularity:

- **`domains:` `range` is now optional** — omitted ⇒ the whole chain (a `//chain` "domain"). The resolver compiles a range-less domain to `//chain^colour`, the same multi-rule path as residue-range domains.
- The lifter **folds** coot's per-chain colouring into `domains:` + `colour: by-domain` on the reps, so it's stated once:
  ```yaml
  domains:
    - { name: A, chain: A, color: "#a08766" }   # whole chain A
    - { name: B, chain: B, color: "#6ca066" }
  elements:
    - file: my_structure
      representations:
        - { style: CRs, colour: by-domain, alpha: 0.5 }
  ```
- Round-trip stable: capture → `domains:` + by-domain → apply (`//chain^hex` rule) → re-capture decomposes and re-folds.
- A general per-selection colour list `colour: [{ selection, colour }, …]` is the underlying form (also valid for residue-range / mixed colouring); the lifter prefers the hoisted by-domain shape.

### Changes
- **types** — `SceneRepresentation.alpha`; `SceneDomain.range` optional; `SceneColour` gains `SceneColourSelection[]`.
- **validate** — alpha ∈ [0,1]; range optional (validated when present); per-selection list entries.
- **resolve** — `setNonCustomOpacity(alpha)`; range-less domain → `//chain^colour`; per-selection list → one rule per entry.
- **lift** — alpha capture; fold per-chain colouring into `domains:` + by-domain.
- Serialiser round-trips all of it via `stripUndefined`. Docs + parse/validate/lift tests.

`tsc` clean. (Tests type-check; local vitest is blocked by a pre-existing stray `~/node_modules` shadowing `vitest`, unrelated — they run in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)