### PR TITLE
moorhen scenes: lift ligand dicts as fileId refs, omit library monomers

### DIFF
--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -327,6 +327,58 @@ describe("liftScene", () => {
   });
 });
 
+describe("liftScene — dictionary provenance", () => {
+  it("emits a fileId dict ref (deduped, scoped) when the dict has a project source", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 7,
+          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+          ligands: [{ resName: "LIG" }],
+          dicts: { LIG: "data_comp_LIG\n# would-be cifText" },
+          representations: [
+            { style: "ligands", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+      projectId: "proj-uuid",
+      dictSources: new Map([[7, new Map([["LIG", { fileId: 100 }]])]]),
+    });
+    const dictRef = scene.files!.find((f) => f.kind === "dictionary");
+    expect(dictRef).toMatchObject({
+      name: "dict-file-100",
+      kind: "dictionary",
+      fileId: 100,
+      projectId: "proj-uuid",
+    });
+    expect(dictRef!.cifText).toBeUndefined(); // not inlined
+    expect(scene.elements![0].dictionaries).toEqual(["dict-file-100"]);
+  });
+
+  it("falls back to inline cifText when the dict has no project source", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m",
+          molNo: 7,
+          uniqueId: "x",
+          ligands: [{ resName: "XYZ" }],
+          dicts: { XYZ: "data_comp_XYZ\nstuff" },
+          representations: [
+            { style: "ligands", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const dictRef = scene.files!.find((f) => f.kind === "dictionary");
+    expect(dictRef).toMatchObject({ kind: "dictionary", cifText: "data_comp_XYZ\nstuff" });
+    expect(dictRef!.fileId).toBeUndefined();
+  });
+});
+
 describe("serialiseSceneWithComments", () => {
   it("attaches a per-file comment above the corresponding entry", () => {
     const { scene, hints } = liftSceneWithHints({

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -225,6 +225,65 @@ describe("Moorhen scene — domain selection (CID) + legacy chain+range", () => 
 });
 
 // --------------------------------------------------------------------------
+// Campaign summary scene shape (regression).
+//
+// The campaign summary scene is built SERVER-SIDE (server/.../campaign_scene.py
+// build_summary_scene), serialised to YAML, and loaded through this exact
+// parse/validate/resolve path. The Python builder is a SEPARATE implementation
+// of the format, so nothing couples it to these TS types — pin its shape here so
+// a format change that would break the summary scene fails loudly in CI.
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — campaign summary scene shape", () => {
+  // Mirrors build_summary_scene output: fileId coords, a fileId dictionary, an
+  // inline-cifText dictionary (disk-only acedrg fallback), a hex-coloured parent
+  // ribbon, an uncoloured member-ligand CBs rep with a scoped dict, resolver +
+  // view, and crucially NO domains block.
+  const SUMMARY_YAML = `
+scene: My Campaign - fragment summary
+version: 1
+authoredIn:
+  projectName: My Campaign
+files:
+  - { name: reference, kind: coordinates, fileId: 10, projectId: parent-uuid }
+  - { name: x0034, kind: coordinates, fileId: 20, projectId: x0034-uuid }
+  - { name: x0034_dict, kind: dictionary, fileId: 21, projectId: x0034-uuid }
+  - name: x0099_dict
+    kind: dictionary
+    cifText: |
+      data_comp_list
+      data_comp_DRG
+elements:
+  - file: reference
+    representations:
+      - { style: CRs, selection: "/*/*/*/*", colour: "#b0bec5" }
+  - file: x0034
+    dictionaries: [x0034_dict]
+    representations:
+      - { style: CBs, selection: "//*/(LIG)||//*/(DRG)" }
+resolver:
+  onMissingResidues: clamp-and-log
+view:
+  origin: [1, 2, 3]
+  quat: [0, 0, 0, -1]
+  zoom: 2.5
+`;
+
+  it("parses, validates, and round-trips", () => {
+    const scene = parseScene(SUMMARY_YAML);
+    expect(scene.files).toHaveLength(4);
+    expect(scene.files![0]).toMatchObject({ name: "reference", kind: "coordinates", fileId: 10 });
+    expect(scene.files![2]).toMatchObject({ name: "x0034_dict", kind: "dictionary", fileId: 21 });
+    expect(scene.files![3].cifText).toContain("data_comp_DRG");
+    expect(scene.elements![0].representations![0].colour).toBe("#b0bec5");
+    expect(scene.elements![1].representations![0].colour).toBeUndefined(); // coot default
+    expect(scene.elements![1].dictionaries).toEqual(["x0034_dict"]);
+    expect(scene.domains).toBeUndefined(); // builder emits no domains, by design
+    expect(parseScene(serialiseScene(scene))).toEqual(scene); // stable round-trip
+  });
+});
+
+// --------------------------------------------------------------------------
 // Validation: each error class.
 // --------------------------------------------------------------------------
 

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -46,7 +46,7 @@ import type { SceneFileRef } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
 import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp } from "../../lib/moorhen-map-file";
 import {
-  liftSceneWithHints,
+  liftSceneStraight,
   MapRenderState,
   promoteSceneToPortable,
   SceneLiftHints,
@@ -65,6 +65,18 @@ export interface MoorhenWrapperProps {
   fileIds?: number[];
   viewParam?: string | null;
   jobId?: number | null;
+}
+
+/** comp_ids defined by a refmac/coot dictionary CIF (its `data_comp_<X>`
+ *  blocks, excluding the `data_comp_list` header). */
+function extractDictCompIds(cifText: string): string[] {
+  const out: string[] = [];
+  const re = /^data_comp_(\S+)/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(cifText)) !== null) {
+    if (m[1] !== "list") out.push(m[1]);
+  }
+  return out;
 }
 
 const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, jobId }) => {
@@ -107,6 +119,10 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   const mapsRef = useRef<null | moorhen.Map[]>(null);
   const activeMapRef = useRef<moorhen.Map>(null);
   const lastHoveredAtom = useRef<null | moorhen.HoveredAtom>(null);
+  // Per-molecule dictionary provenance: molNo → (comp_id → source project file).
+  // Populated when a job's dicts + coords load together; read by Capture so the
+  // lifter can emit terse fileId dict refs instead of inlining cifText.
+  const dictSourcesRef = useRef<Map<number, Map<string, { fileId: number; projectId?: string }>>>(new Map());
   const prevActiveMoleculeRef = useRef<null | moorhen.Molecule>(null);
   const timeCapsuleRef = useRef(null);
   const cootInitialized = useSelector(
@@ -450,6 +466,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       (f: { type: string }) => f.type === "application/refmac-dictionary"
     );
     const dictContents: string[] = [];
+    // Track which project dict file provides each comp_id, so Capture can emit
+    // terse fileId dict refs (scoped per-molecule once the molNo is known below).
+    const jobDictSources = new Map<string, { fileId: number; projectId?: string }>();
     for (const dictFile of dictFiles) {
       const dictUrl = `/api/proxy/ccp4i2/files/${dictFile.id}/download/`;
       try {
@@ -465,6 +484,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
           false
         );
         dictContents.push(content);
+        for (const compId of extractDictCompIds(content)) {
+          jobDictSources.set(compId, { fileId: dictFile.id, projectId: projectInfo?.id });
+        }
       } catch (err) {
         console.warn("[fetchJobFiles] Failed to load dictionary:", err);
       }
@@ -531,6 +553,12 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         dispatch(addMolecule(newMolecule));
         dispatch(showMolecule({ molNo: newMolecule.molNo } as any));
         loadedMolecule = newMolecule;
+        // Scope this job's dict provenance to THIS molecule's molNo (so two
+        // molecules whose ligands are both called LIG, from different dict
+        // files, stay distinct at capture time).
+        if (newMolecule.molNo != null && jobDictSources.size > 0) {
+          dictSourcesRef.current.set(newMolecule.molNo, jobDictSources);
+        }
       } catch (err) {
         console.warn("[fetchJobFiles] Failed to load coordinates:", err);
       }
@@ -957,8 +985,10 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     // explicit "Save self-contained" action (handlePromoteSceneToPortable),
     // which fetches the bytes into a .scene.zip. Eager-bundling on capture would
     // hide provenance and, if the edited YAML is re-applied, load duplicate
-    // copies of each molecule.
-    const { scene, hints } = liftSceneWithHints({
+    // copies of each molecule. liftSceneStraight also drops dict refs the
+    // receiver's monomer library already has (library monomers travel as
+    // nothing; project ligand dicts travel as terse fileId refs).
+    const { scene, hints } = await liftSceneStraight({
       molecules,
       glRef: glRefState,
       projectId: projectInfo?.id,
@@ -970,6 +1000,8 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       maps,
       mapState,
       activeMapMolNo: typeof activeMapMolNo === "number" ? activeMapMolNo : undefined,
+      // Per-molecule dict provenance gathered at load time.
+      dictSources: dictSourcesRef.current,
     });
     return { scene, hints, assets: new Map() as SceneBundleAssets };
   }, [store, molecules, maps, projectInfo]);

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -80,6 +80,13 @@ export interface LiftCtx {
   /** molNo of the currently-active map (state.generalStates.activeMap.molNo).
    *  Drives scene.activeMap. */
   activeMapMolNo?: number;
+  /** Per-molecule dictionary provenance: molNo → (comp_id → source project
+   *  file). When a ligand's dict came from a project file, the lifter emits a
+   *  `kind: dictionary` ref by `fileId` (terse, re-fetchable) instead of inlining
+   *  cifText. Keyed by molNo (NOT comp_id alone) so two molecules that both call
+   *  their ligand LIG, with different chemistry from different dict files, stay
+   *  distinct and per-molecule-scoped. */
+  dictSources?: Map<number, Map<string, { fileId: number; projectId?: string }>>;
 }
 
 /**
@@ -140,7 +147,11 @@ export function liftScene(ctx: LiftCtx): MoorhenScene {
   const liftedDicts: { mol: moorhen.Molecule; molFileName: string; refs: { name: string; comp_id: string }[] }[] = [];
   ctx.molecules.forEach((mol, i) => {
     const molFileName = scene.files?.[i]?.name ?? `mol${i}`;
-    const liftedRefs = liftDictionariesForMolecule(mol, molFileName, scene.files!);
+    const liftedRefs = liftDictionariesForMolecule(
+      mol, molFileName, scene.files!,
+      mol.molNo != null ? ctx.dictSources?.get(mol.molNo) : undefined,
+      ctx.projectId,
+    );
     if (liftedRefs.length > 0) {
       liftedDicts.push({ mol, molFileName, refs: liftedRefs });
     }
@@ -208,6 +219,8 @@ function liftDictionariesForMolecule(
   mol: moorhen.Molecule,
   molFileName: string,
   allFiles: SceneFileRef[],
+  sources?: Map<string, { fileId: number; projectId?: string }>,
+  fallbackProjectId?: string,
 ): { name: string; comp_id: string }[] {
   const ligands = mol.ligands ?? [];
   // Dedupe by comp_id — multiple instances of the same ligand share a dict.
@@ -216,26 +229,40 @@ function liftDictionariesForMolecule(
 
   for (const comp_id of compIds) {
     if (STANDARD_MONOMERS.has(comp_id)) continue;
+
+    // Preferred: the dict came from a project file → emit a terse, re-fetchable
+    // `fileId` ref instead of inlining cifText. Deduped by fileId (a multi-comp
+    // dict shared by several ligands becomes ONE ref); per-molecule scoping is
+    // preserved by listing it in THIS molecule's `dictionaries:`.
+    const source = sources?.get(comp_id);
+    if (source) {
+      const name = `dict-file-${source.fileId}`;
+      if (!allFiles.some((f) => f.name === name)) {
+        allFiles.push({
+          name,
+          kind: "dictionary",
+          fileId: source.fileId,
+          projectId: source.projectId ?? fallbackProjectId,
+        });
+      }
+      out.push({ name, comp_id });
+      continue;
+    }
+
+    // No project source → inline cifText. dropLibraryDicts() may later remove
+    // it if the comp_id resolves in the receiver's monomer library.
     let dictText = "";
     try {
       dictText = mol.getDict(comp_id) || "";
     } catch {
-      // getDict may throw for comp_ids without a stored dict — that's
-      // fine, just skip them.
+      // getDict may throw for comp_ids without a stored dict — skip them.
       continue;
     }
     if (!dictText) continue;
 
     const name = `dict-${molFileName}-${comp_id}`;
-    // Skip if a ref with this name already exists (shouldn't happen but
-    // defensive against pathological dupe-suppression).
     if (allFiles.some((f) => f.name === name)) continue;
-
-    allFiles.push({
-      name,
-      kind: "dictionary",
-      cifText: dictText,
-    });
+    allFiles.push({ name, kind: "dictionary", cifText: dictText });
     out.push({ name, comp_id });
   }
   return out;
@@ -292,6 +319,56 @@ export function liftSceneWithHints(ctx: LiftCtx): {
 }
 
 /**
+ * STRAIGHT lift for Capture: real provenance + hints, NO bundling — but it DOES
+ * drop dict refs the receiver's monomer library already has, so library monomers
+ * (CL, ATP, …) aren't carried; the receiving Moorhen resolves those itself. Custom
+ * ligand dicts stay — as terse `fileId` refs when the project supplied them, or
+ * inline `cifText` otherwise. Async because the library check is a HEAD probe.
+ */
+export async function liftSceneStraight(ctx: LiftCtx): Promise<{
+  scene: MoorhenScene;
+  hints: SceneLiftHints;
+}> {
+  const { scene, hints } = liftSceneWithHints(ctx);
+  if (ctx.monomerLibraryPath) {
+    await dropLibraryDicts(scene, ctx.molecules, ctx.monomerLibraryPath);
+  }
+  return { scene, hints };
+}
+
+/**
+ * Remove INLINE (cifText) dictionary refs whose comp_id resolves in the
+ * receiver's monomer library — the receiving Moorhen fetches the same dict from
+ * the same library when it loads the coords, so carrying our copy only bloats the
+ * YAML (and risks a stale variant). `fileId`/`url`/`bundle` dict refs are NEVER
+ * dropped: a project explicitly supplied that dict, so it must travel and win
+ * even if its comp_id name collides with a library entry.
+ */
+async function dropLibraryDicts(
+  scene: MoorhenScene,
+  molecules: moorhen.Molecule[],
+  monomerLibraryPath: string,
+): Promise<void> {
+  const libraryHas = await probeMonomerLibrary(molecules, monomerLibraryPath);
+  if (libraryHas.size === 0) return;
+  const dropNames = new Set<string>();
+  for (const ref of scene.files ?? []) {
+    if (ref.kind !== "dictionary" || !ref.cifText) continue; // only inline dicts
+    // Names are `dict-<molFileName>-<COMP_ID>`; take the trailing comp_id (the
+    // molFileName may itself contain hyphens).
+    const m = /^dict-.*-([A-Za-z0-9]+)$/.exec(ref.name);
+    if (m && libraryHas.has(m[1].toUpperCase())) dropNames.add(ref.name);
+  }
+  if (dropNames.size === 0) return;
+  scene.files = (scene.files ?? []).filter((f) => !dropNames.has(f.name));
+  for (const el of scene.elements ?? []) {
+    if (!el.dictionaries) continue;
+    el.dictionaries = el.dictionaries.filter((n) => !dropNames.has(n));
+    if (el.dictionaries.length === 0) delete el.dictionaries;
+  }
+}
+
+/**
  * Lift a scene AND a parallel asset map suitable for bundling into a
  * `.scene.zip`. Compared to liftScene/liftSceneWithHints, this:
  *
@@ -313,37 +390,10 @@ export async function liftSceneToBundle(ctx: LiftCtx): Promise<{
   const { scene, hints } = liftSceneWithHints(ctx);
   const assets = new Map<string, ArrayBuffer>();
 
-  // 0. Drop dict refs whose comp_id is already in Moorhen's monomer
-  //    library: when the receiving Moorhen loads coords, its
-  //    loadMissingMonomer machinery will fetch the same dict from the
-  //    same library, so carrying our copy in the scene only bloats the
-  //    YAML and risks shipping a stale variant. The probe is keyed off
-  //    the comp_id, which we rebuild by mirroring liftDictionariesForMolecule.
+  // 0. Drop inline dict refs the receiver's monomer library already has (shared
+  //    with the straight-lift path).
   if (ctx.monomerLibraryPath) {
-    const libraryHas = await probeMonomerLibrary(
-      ctx.molecules,
-      ctx.monomerLibraryPath,
-    );
-    if (libraryHas.size > 0) {
-      const dropNames = new Set<string>();
-      for (const ref of scene.files ?? []) {
-        if (ref.kind !== "dictionary") continue;
-        // Names are `dict-<molFileName>-<COMP_ID>` from liftDictionariesForMolecule.
-        // Pull the trailing comp_id off rather than slicing on first hyphen
-        // (the molFileName may itself contain hyphens).
-        const m = /^dict-.*-([A-Za-z0-9]+)$/.exec(ref.name);
-        if (!m) continue;
-        if (libraryHas.has(m[1].toUpperCase())) dropNames.add(ref.name);
-      }
-      if (dropNames.size > 0) {
-        scene.files = (scene.files ?? []).filter((f) => !dropNames.has(f.name));
-        for (const el of scene.elements ?? []) {
-          if (!el.dictionaries) continue;
-          el.dictionaries = el.dictionaries.filter((n) => !dropNames.has(n));
-          if (el.dictionaries.length === 0) delete el.dictionaries;
-        }
-      }
-    }
+    await dropLibraryDicts(scene, ctx.molecules, ctx.monomerLibraryPath);
   }
 
   // 1. Replace each coord file ref with a bundle: ref carrying the

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -451,6 +451,26 @@ elements:
 For dictionaries that should apply to *every* molecule (cofactors,
 common ions), use the top-level `globalDictionaries:` block instead.
 
+**What the lifter emits.** When you capture a scene, each ligand dict is
+recorded in the most portable form available, in this order:
+
+1. **Library monomers are omitted entirely.** If the comp_id resolves in the
+   receiver's CCP4 monomer library (`CL`, `ATP`, standard residues, …), no dict
+   ref is written — the consuming Moorhen fetches it from its own library. Keeps
+   captures terse.
+2. **Project ligand dicts become `fileId` refs.** A dict that came from a project
+   file (e.g. an AceDRG output) is emitted as
+   `{ kind: dictionary, fileId, projectId }` — one ref per source file (deduped),
+   listed in the owning molecule's `dictionaries:`. This makes a many-ligand
+   campaign capture compact while staying per-molecule-scoped: two molecules
+   whose ligand is both called `LIG` reference *different* `fileId`s.
+3. **`cifText` is the fallback.** Only when a non-library dict has no project
+   source does the lifter inline it.
+
+(The omission in (1) is safe precisely because the receiver has the library;
+custom ligands never get omitted, because a project-supplied dict always travels
+— even if its comp_id name collides with a library entry.)
+
 ## `superpose`
 
 Alignments to apply after fetching but before rendering. Each entry


### PR DESCRIPTION
Capturing a scene inlined **every** non-standard ligand dict as `cifText:`, which makes many-ligand (campaign-style) captures unwieldy:
```yaml
- name: dict-...-CL
  kind: dictionary
  cifText: |
    data_comp_list
    … 30 lines …
```
The format and resolver already support `kind: dictionary` refs by `fileId` (loaded globally, then re-associated per molecule) — the lifter just wasn't using them.

## Now: dicts lifted in the most portable form, in order
1. **Library monomers omitted entirely.** If the comp_id resolves in the receiver's CCP4 monomer library (`CL`, `ATP`, standard residues), no ref is written — the consuming Moorhen fetches it from its own library. (This restores the monomer-library HEAD-probe that Capture lost in #207 when it stopped going through `liftSceneToBundle`.)
2. **Project ligand dicts → `{ kind: dictionary, fileId, projectId }`** — one ref per source file (deduped), listed in the owning molecule's `dictionaries:`.
3. **`cifText`** only as a fallback (non-library dict with no project source).

## Per-molecule scoping preserved (the LIG/DRG problem)
`dictSources` is keyed `molNo → (comp_id → {fileId})`, **not** a global `comp_id → fileId` map. So two molecules whose ligand is both called `LIG`, from different dict files, reference **different** `fileId`s — and the resolver's existing load-globally-then-re-associate-per-`molNo` keeps their chemistry distinct. A project-supplied dict always travels (never omitted) even if its name collides with a library entry.

## Changes
- **lifter:** `LiftCtx.dictSources`; `liftDictionariesForMolecule` emits `fileId` refs when sourced; new async `liftSceneStraight` (real provenance, no bundling, drops library dicts via the factored-out `dropLibraryDicts`, shared with `liftSceneToBundle`).
- **wrapper:** `fetchJobFiles` records `comp_id → dict fileId` per loaded molecule; Capture uses `liftSceneStraight`.
- docs + lifter tests (fileId-ref + cifText-fallback paths). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)