### PR TITLE
moorhen scenes: view.centre — centre the camera on a selection's centroid

### DIFF
--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -284,6 +284,41 @@ view:
 });
 
 // --------------------------------------------------------------------------
+// view.centre — selection-based camera centring.
+// --------------------------------------------------------------------------
+
+describe("Moorhen scene — view.centre", () => {
+  const withView = (view: string) =>
+    `scene: x\nversion: 1\nfiles:\n  - { name: apo, pdb: 1m17 }\nview:\n${view}`;
+
+  it("accepts file + selection and round-trips", () => {
+    const scene = parseScene(
+      withView(`  centre: { file: apo, selection: "//A" }\n  zoom: 1\n`),
+    );
+    expect(scene.view!.centre).toEqual({ file: "apo", selection: "//A" });
+    expect(parseScene(serialiseScene(scene))).toEqual(scene); // parse→serialise→parse
+  });
+
+  it("accepts a centre with no selection (whole molecule)", () => {
+    expect(
+      parseScene(withView(`  centre: { file: apo }\n`)).view!.centre,
+    ).toEqual({ file: "apo" });
+  });
+
+  it("rejects a centre referencing an unknown file", () => {
+    expect(() => parseScene(withView(`  centre: { file: nope }\n`))).toThrow(
+      /unknown file "nope"/,
+    );
+  });
+
+  it("rejects a centre with no file", () => {
+    expect(() =>
+      parseScene(withView(`  centre: { selection: "//A" }\n`)),
+    ).toThrow(/centre\.file.*required/);
+  });
+});
+
+// --------------------------------------------------------------------------
 // Validation: each error class.
 // --------------------------------------------------------------------------
 

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -316,6 +316,12 @@ describe("Moorhen scene — view.centre", () => {
       parseScene(withView(`  centre: { selection: "//A" }\n`)),
     ).toThrow(/centre\.file.*required/);
   });
+
+  it("rejects an unknown key (catches typos like -selection)", () => {
+    expect(() =>
+      parseScene(withView(`  centre: { file: apo, "-selection": "//A" }\n`)),
+    ).toThrow(/unknown key "-selection"/);
+  });
 });
 
 // --------------------------------------------------------------------------

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -454,7 +454,33 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
 
   // 3. Camera. Mirror PasteViewLinkField exactly so behaviour matches.
   if (scene.view) {
-    if (scene.view.origin) dispatch(setOrigin(scene.view.origin));
+    // Selection-based centre takes precedence over an explicit origin: Moorhen
+    // computes the selection's centroid and sets the origin, so "centre on
+    // chain A" needs no coordinates.
+    if (scene.view.centre) {
+      const { file, selection } = scene.view.centre;
+      const cid = selection ?? "/*/*/*/*";
+      const mol = fileBindings.get(file);
+      if (!mol) {
+        result.log.push({
+          file,
+          domain: "view.centre",
+          message: `cannot centre: file "${file}" not bound to a loaded molecule`,
+        });
+      } else {
+        try {
+          await mol.centreOn(cid, false, false); // no animate, don't touch zoom
+        } catch (e) {
+          result.log.push({
+            file,
+            domain: "view.centre",
+            message: `centre on "${cid}" failed: ${e instanceof Error ? e.message : "unknown error"}`,
+          });
+        }
+      }
+    } else if (scene.view.origin) {
+      dispatch(setOrigin(scene.view.origin));
+    }
     if (scene.view.quat) dispatch(setQuat(scene.view.quat));
     if (scene.view.zoom !== undefined) dispatch(setZoom(scene.view.zoom));
     if (scene.view.clipStart !== undefined) dispatch(setClipStart(scene.view.clipStart));

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -867,6 +867,17 @@ function validateCentre(
     errors.push({ path: "view.centre", message: "must be a mapping { file, selection? }" });
     return undefined;
   }
+  // centre takes only file + selection. Reject anything else loudly — it's a
+  // typo (e.g. "-selection"), and silently dropping it gives a wrong-but-quiet
+  // centre (the whole molecule instead of the intended selection).
+  for (const k of Object.keys(raw as Record<string, unknown>)) {
+    if (k !== "file" && k !== "selection") {
+      errors.push({
+        path: `view.centre.${k}`,
+        message: `unknown key "${k}" — centre takes only "file" and "selection"`,
+      });
+    }
+  }
   const file = strField(raw, "file", "", errors, "view.centre");
   if (!file) {
     errors.push({ path: "view.centre.file", message: "required" });

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -22,6 +22,7 @@ import {
   SceneMap,
   SceneMapColumns,
   SceneRepresentation,
+  SceneCentre,
   SceneColour,
   SceneColourSelection,
   SceneSuperpose,
@@ -178,6 +179,7 @@ export function validateScene(raw: unknown): {
     if (isObject(v)) {
       out.view = {
         origin: tupleField<3>(v, "origin", 3, "view.origin", errors),
+        centre: validateCentre(v.centre, out.files ?? [], errors),
         quat: tupleField<4>(v, "quat", 4, "view.quat", errors),
         zoom: optNum(v, "zoom", "view.zoom", errors),
         clipStart: optNum(v, "clipStart", "view.clipStart", errors),
@@ -853,6 +855,36 @@ function validateRepresentation(
     }
   }
   return rep;
+}
+
+function validateCentre(
+  raw: unknown,
+  files: SceneFileRef[],
+  errors: SceneValidationError[],
+): SceneCentre | undefined {
+  if (raw === undefined) return undefined;
+  if (!isObject(raw)) {
+    errors.push({ path: "view.centre", message: "must be a mapping { file, selection? }" });
+    return undefined;
+  }
+  const file = strField(raw, "file", "", errors, "view.centre");
+  if (!file) {
+    errors.push({ path: "view.centre.file", message: "required" });
+    return undefined;
+  }
+  if (files.length > 0 && !files.some((f) => f.name === file)) {
+    errors.push({
+      path: "view.centre.file",
+      message: `unknown file "${file}" (not in top-level files block)`,
+    });
+    return undefined;
+  }
+  const centre: SceneCentre = { file };
+  if ("selection" in (raw as Record<string, unknown>)) {
+    const sel = optStr(raw, "selection", "view.centre.selection", errors);
+    if (sel) centre.selection = sel;
+  }
+  return centre;
 }
 
 function validateColour(

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -653,6 +653,28 @@ view:
   background: "#ffffff"                  # hex
 ```
 
+### `centre` — centre on a selection
+
+Instead of an explicit `origin:`, you can centre the camera on the **centroid
+of a selection**, computed at apply-time. This is the natural form for an
+authored or generated scene: "centred on chain A" needs no coordinates.
+
+```yaml
+view:
+  centre: { file: apo, selection: "//A" }   # whole chain A
+  # selection: omitted ⇒ the whole molecule
+  zoom: 1.5
+```
+
+- `file`: required — a name from the top-level `files:` block.
+- `selection`: optional CID; omitted means the whole molecule.
+
+`centre` takes **precedence over `origin`** when both are present. If the file
+isn't loaded or the selection matches nothing, the resolver logs it and leaves
+the camera where it is (it does not fail). The lifter still captures the
+resolved Cartesian `origin:` — `centre:` is an input convenience, so a captured
+scene records the concrete point.
+
 ## `resolver`
 
 Apply-time policy. Currently one option:

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -449,7 +449,12 @@ export interface SceneMap {
 // --------------------------------------------------------------------------
 
 export interface SceneView {
+  /** Camera centre as an explicit Cartesian point. */
   origin?: [number, number, number];
+  /** Camera centre derived from a selection's centroid — the resolver computes
+   *  it at apply-time, so "centred on chain A" needs no coordinates. Takes
+   *  precedence over `origin` when both are present. */
+  centre?: SceneCentre;
   quat?: [number, number, number, number];
   zoom?: number;
   clipStart?: number;
@@ -457,6 +462,14 @@ export interface SceneView {
   fogStart?: number;
   fogEnd?: number;
   background?: string;        // hex
+}
+
+/** Selection whose centroid the camera centres on (see SceneView.centre). */
+export interface SceneCentre {
+  /** Name of a file from the top-level `files:` block. */
+  file: string;
+  /** CID selection within that file; omitted ⇒ the whole molecule. */
+  selection?: string;
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Adds a selection-based alternative to `view.origin: [x, y, z]`:

```yaml
view:
  centre: { file: apo, selection: "//A" }   # selection optional ⇒ whole molecule
  zoom: 1.5
```

The resolver resolves `file` to its loaded molecule and calls `molecule.centreOn(cid, false, false)` — Moorhen computes the selection's centroid and sets the origin with the correct sign, so **"centred on chain A" needs no coordinates**. This is the natural form for a generated or hand-written scene.

- `centre` takes **precedence over `origin`** when both are present.
- A file that isn't loaded, or a selection that matches nothing, is **logged, not fatal** — the camera is left where it is.
- The **lifter still captures the resolved Cartesian `origin:`**, so a captured scene records the concrete point; `centre:` is purely an input convenience.

### Changes
- **types**: `SceneView.centre?: SceneCentre { file, selection? }`.
- **validate**: `view.centre` — `file` required and cross-checked against the `files:` block; `selection` optional.
- **resolve**: apply via `centreOn` in the view block.
- docs (`view` section) + parse/validate tests. `tsc` clean.

First of the "view geometry derived from selections" ideas; `orient` (principal-axis alignment) is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)