### PR TITLE
moorhen scenes: view.clip — intent-level clip/fog (auto / lock / field depths)

### DIFF
--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -287,6 +287,38 @@ view:
 // view.centre — selection-based camera centring.
 // --------------------------------------------------------------------------
 
+describe("Moorhen scene — view.clip", () => {
+  const withClip = (clip: string) =>
+    `scene: x\nversion: 1\nview:\n  clip: ${clip}\n`;
+
+  it("accepts auto / lock and round-trips", () => {
+    expect(parseScene(withClip("auto")).view!.clip).toBe("auto");
+    const locked = parseScene(withClip("lock"));
+    expect(locked.view!.clip).toBe("lock");
+    expect(parseScene(serialiseScene(locked))).toEqual(locked);
+  });
+
+  it("accepts field depths { front, back } and round-trips", () => {
+    const scene = parseScene(withClip("{ front: 8, back: 21 }"));
+    expect(scene.view!.clip).toEqual({ front: 8, back: 21 });
+    expect(parseScene(serialiseScene(scene))).toEqual(scene);
+  });
+
+  it("rejects an unknown string", () => {
+    expect(() => parseScene(withClip("wide"))).toThrow(/"auto", "lock", or/);
+  });
+
+  it("rejects field depths missing a side", () => {
+    expect(() => parseScene(withClip("{ front: 8 }"))).toThrow(/clip\.back.*required/);
+  });
+
+  it("rejects an unknown field-depth key", () => {
+    expect(() => parseScene(withClip("{ front: 8, back: 21, side: 5 }"))).toThrow(
+      /unknown key "side"/,
+    );
+  });
+});
+
 describe("Moorhen scene — view.centre", () => {
   const withView = (view: string) =>
     `scene: x\nversion: 1\nfiles:\n  - { name: apo, pdb: 1m17 }\nview:\n${view}`;

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -889,11 +889,17 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       // non-bundled apply.
       bundleAssetsRef.current = assets;
       const scene = parseScene(yamlText);
+      // Live glRef snapshot for view.clip: { front, back } (clip = zoom*depth,
+      // fog offset by fogClipOffset).
+      const gl = (store.getState() as moorhen.State).glRef as unknown as {
+        zoom: number; fogClipOffset: number;
+      };
       return applyScene({
         scene,
         molecules,
         maps,
         dispatch,
+        glRef: { zoom: gl.zoom, fogClipOffset: gl.fogClipOffset },
         fetcher: handleFetchSceneFile,
         dictionaryFetcher: handleFetchSceneDictionary,
         dictionaryLoader: handleLoadSceneDictionary,
@@ -901,6 +907,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       });
     },
     [
+      store,
       molecules,
       maps,
       dispatch,

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -25,6 +25,7 @@ import {
   setClipEnd,
   setFogStart,
   setFogEnd,
+  setResetClippingFogging,
   setBackgroundColor,
   setRequestDrawScene,
   addCustomRepresentation,
@@ -160,6 +161,10 @@ interface ResolveCtx {
   /** Optional. Required for scene.maps[] to be applied. Without it,
    *  map entries are dropped with a log entry. */
   mapFetcher?: SceneMapFetcher;
+  /** Live glRef snapshot (zoom, fogClipOffset). Used by `view.clip:
+   *  { front, back }` to derive clip/fog the way coot does (clip = zoom*depth,
+   *  fog offset by fogClipOffset). Falls back to sane defaults if absent. */
+  glRef?: { zoom: number; fogClipOffset: number };
 }
 
 /**
@@ -483,10 +488,37 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
     }
     if (scene.view.quat) dispatch(setQuat(scene.view.quat));
     if (scene.view.zoom !== undefined) dispatch(setZoom(scene.view.zoom));
-    if (scene.view.clipStart !== undefined) dispatch(setClipStart(scene.view.clipStart));
-    if (scene.view.clipEnd !== undefined) dispatch(setClipEnd(scene.view.clipEnd));
-    if (scene.view.fogStart !== undefined) dispatch(setFogStart(scene.view.fogStart));
-    if (scene.view.fogEnd !== undefined) dispatch(setFogEnd(scene.view.fogEnd));
+
+    // Clip & fog. Coot derives both from zoom and a shared pair of field depths
+    // (Å in front of / behind the centre, default 8/21) and recomputes them on
+    // zoom UNLESS resetClippingFogging is off. So a scene that sets clip/fog also
+    // pins that flag, and `clip` gives intent-level control over the depths.
+    const clip = scene.view.clip;
+    const zoom = scene.view.zoom ?? ctx.glRef?.zoom ?? 1;
+    const fco = ctx.glRef?.fogClipOffset ?? 250;
+    if (clip === "auto") {
+      dispatch(setResetClippingFogging(true)); // let coot recompute from zoom
+    } else if (clip && typeof clip === "object") {
+      // Field depths in Å; clip = zoom*depth, fog offset by fogClipOffset —
+      // coot's own formula with author depths. Drives clip AND fog together.
+      dispatch(setClipStart(zoom * clip.front));
+      dispatch(setClipEnd(zoom * clip.back));
+      dispatch(setFogStart(fco - zoom * clip.front));
+      dispatch(setFogEnd(fco + zoom * clip.back));
+      dispatch(setResetClippingFogging(false));
+    } else {
+      // Explicit numbers (or `clip: "lock"`): set what's given and freeze, so
+      // coot doesn't recompute them away on the next zoom.
+      const setAny =
+        scene.view.clipStart !== undefined || scene.view.clipEnd !== undefined ||
+        scene.view.fogStart !== undefined || scene.view.fogEnd !== undefined;
+      if (scene.view.clipStart !== undefined) dispatch(setClipStart(scene.view.clipStart));
+      if (scene.view.clipEnd !== undefined) dispatch(setClipEnd(scene.view.clipEnd));
+      if (scene.view.fogStart !== undefined) dispatch(setFogStart(scene.view.fogStart));
+      if (scene.view.fogEnd !== undefined) dispatch(setFogEnd(scene.view.fogEnd));
+      if (clip === "lock" || setAny) dispatch(setResetClippingFogging(false));
+    }
+
     if (scene.view.background) {
       const rgba = hexToRgba01(scene.view.background);
       if (rgba) dispatch(setBackgroundColor(rgba));

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -23,6 +23,7 @@ import {
   SceneMapColumns,
   SceneRepresentation,
   SceneCentre,
+  SceneClip,
   SceneColour,
   SceneColourSelection,
   SceneSuperpose,
@@ -186,6 +187,7 @@ export function validateScene(raw: unknown): {
         clipEnd: optNum(v, "clipEnd", "view.clipEnd", errors),
         fogStart: optNum(v, "fogStart", "view.fogStart", errors),
         fogEnd: optNum(v, "fogEnd", "view.fogEnd", errors),
+        clip: validateClip(v.clip, errors),
         background: optStr(v, "background", "view.background", errors),
       };
     } else {
@@ -855,6 +857,35 @@ function validateRepresentation(
     }
   }
   return rep;
+}
+
+function validateClip(
+  raw: unknown,
+  errors: SceneValidationError[],
+): SceneClip | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === "auto" || raw === "lock") return raw;
+  if (typeof raw === "string" || !isObject(raw)) {
+    errors.push({
+      path: "view.clip",
+      message: `must be "auto", "lock", or { front, back }`,
+    });
+    return undefined;
+  }
+  for (const k of Object.keys(raw as Record<string, unknown>)) {
+    if (k !== "front" && k !== "back") {
+      errors.push({
+        path: `view.clip.${k}`,
+        message: `unknown key "${k}" — field-depth clip takes only "front" and "back"`,
+      });
+    }
+  }
+  const front = optNum(raw, "front", "view.clip.front", errors);
+  const back = optNum(raw, "back", "view.clip.back", errors);
+  if (front === undefined) errors.push({ path: "view.clip.front", message: "required" });
+  if (back === undefined) errors.push({ path: "view.clip.back", message: "required" });
+  if (front === undefined || back === undefined) return undefined;
+  return { front, back };
 }
 
 function validateCentre(

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -653,6 +653,31 @@ view:
   background: "#ffffff"                  # hex
 ```
 
+### `clip` — clip/fog intent
+
+Coot derives both the clip slab and the fog from zoom and a shared pair of
+**field depths** (Å in front of / behind the view centre, default 8 and 21), and
+recomputes them on every zoom *unless told not to*. So a raw `clipStart: 8` is a
+zoom- and size-specific number that coot will overwrite. `clip` is the stable,
+intent-level control:
+
+```yaml
+view:
+  clip: auto                  # let coot recompute clip+fog from zoom (its default)
+  # clip: lock                # freeze the current clip+fog; zoom won't change them
+  # clip: { front: 6, back: 12 }   # set the field depths (Å) and lock; drives fog too
+```
+
+- `auto` — defer to coot's zoom-coupled behaviour.
+- `lock` — pin the current clip+fog so a later zoom leaves them alone.
+- `{ front, back }` — set the depth of field (Å) in front of and behind the
+  centre, and lock. Clip **and** fog follow, the way coot computes them — you
+  don't author fog separately.
+
+Any explicit `clipStart/clipEnd/fogStart/fogEnd` are also locked on apply, so a
+scene's clip sticks instead of being recomputed on the next zoom. Like the rest
+of the view, the lifter captures the resolved numbers; `clip` is an input form.
+
 ### `centre` — centre on a selection
 
 Instead of an explicit `origin:`, you can centre the camera on the **centroid

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -461,7 +461,34 @@ export interface SceneView {
   clipEnd?: number;
   fogStart?: number;
   fogEnd?: number;
+  /** Clip/fog intent. Coot derives clip and fog from zoom and a shared pair of
+   *  field depths, and recomputes them on zoom unless told not to. This is the
+   *  stable, intent-level control over that. See SceneClip. When present it
+   *  drives clip/fog (and the lock); the raw clipStart/End/fogStart/End above
+   *  stay as an escape hatch. */
+  clip?: SceneClip;
   background?: string;        // hex
+}
+
+/**
+ * Clip/fog intent:
+ *
+ *   - `"auto"`              — let coot recompute clip+fog from zoom (its default).
+ *   - `"lock"`             — freeze the current clip+fog so zoom won't change them.
+ *   - `{ front, back }`    — set coot's field depths (zoom-independent depth of
+ *                            field, in front of / behind the centre) and lock.
+ *                            Drives clip AND fog together, the way coot does.
+ *
+ * Any explicit `clipStart/End/fogStart/End` are also locked on apply, so a
+ * scene's clip sticks instead of being recomputed away on the next zoom.
+ */
+export type SceneClip = "auto" | "lock" | SceneClipFieldDepth;
+
+export interface SceneClipFieldDepth {
+  /** Depth of field in front of the view centre (coot default 8). */
+  front: number;
+  /** Depth of field behind the view centre (coot default 21). */
+  back: number;
 }
 
 /** Selection whose centroid the camera centres on (see SceneView.centre). */


### PR DESCRIPTION
Coot derives clip **and** fog from zoom and a shared pair of field depths (Å in front of / behind the centre, default 8/21), and recomputes them on zoom unless `resetClippingFogging` is off. So a captured `clipStart: 8` is a zoom- and size-specific number that coot overwrites — fragile by construction. `view.clip` is the stable, intent-level control:

```yaml
view:
  clip: auto                     # let coot recompute clip+fog from zoom (its default)
  # clip: lock                   # freeze the current clip+fog; zoom won't change them
  # clip: { front: 6, back: 12 } # set field depths (Å) and lock; fog follows
```

- **`auto`** → `resetClippingFogging = true`.
- **`lock`** → `resetClippingFogging = false` (freeze).
- **`{ front, back }`** → applies coot's own formula with the author's depths: `clip = zoom·depth`, `fog = fogClipOffset ∓ zoom·depth`, then locks. Clip and fog move together, so you never author fog separately.
- Any explicit `clipStart/End/fogStart/End` **also lock on apply**, so a scene's clip sticks instead of being recomputed on the next zoom (fixes the "scene clip doesn't hold" annoyance on its own).

Verified the formula and the lock flag against the Moorhen source (`MoorhenWebMG.setClipFogByZoom`, `mgWebGL.set_clip_range`, `glRefSlice.fogClipOffset = 250`), so field depths are genuinely Å.

### Changes
- **types**: `SceneView.clip?: SceneClip` (`"auto" | "lock" | { front, back }`).
- **validate**: string must be auto/lock; field-depth needs both numbers; unknown keys rejected.
- **resolve**: dispatch `setResetClippingFogging` + clip/fog; live glRef snapshot (`zoom`, `fogClipOffset`) threaded from the wrapper.
- docs + parse/validate tests. `tsc` clean.

`slab: { selection }` (clip to a selection's bounding sphere — orientation-independent) is the planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)