### PR TITLE
moorhen scenes: view.slab — isolate a selection (centre + bounding-sphere clip)

### DIFF
--- a/client/renderer/MOORHEN_SCENES.md
+++ b/client/renderer/MOORHEN_SCENES.md
@@ -190,6 +190,36 @@ because they don't translate meaningfully across structures and they
 bloat the YAML. PyMOL-derived clip values (often ±10000+ Å) should
 be stripped at author time — the doc warns about this.
 
+### Intent directives: centre, clip, slab
+
+Alongside the raw `origin`/`quat`/`zoom`, `view:` takes *intent* forms
+that resolve against the loaded structure at apply-time, so a scene can
+say what to look at rather than where the camera sits:
+
+- **`centre: { file?, selection? }`** — centre on a selection's
+  centroid. `file` is optional when one molecule is loaded.
+- **`clip: "auto" | "lock" | { front, back }`** — `auto` hands clip/fog
+  back to coot's zoom-coupled recompute (`resetClippingFogging`);
+  `lock` freezes the current planes; `{ front, back }` sets coot's
+  *field depths* (pre-zoom Å, multiplied by zoom — the same knobs the
+  default 8/21 use).
+- **`slab: { file?, selection?, pad? }`** — centre on a selection *and*
+  clip/fog to its bounding sphere. Walks the selection's atoms over the
+  molecule's cached gemmi structure (`window.CCP4Module`) for a centroid
+  and radius `R`, centres, and sets clip/fog to an **absolute** half-
+  thickness of `R + pad` Å. Note the asymmetry with `clip`: clip's
+  field depths are zoom-multiplied (coot semantics), but the slab depth
+  is an absolute world-Å distance, so it is *not* multiplied by zoom —
+  the eye-space z is never scaled by zoom (only x/y are). `slab` drives
+  both centre and clip, so it pre-empts `centre`/`origin` and `clip`.
+
+These are input-only conveniences: the lifter still captures the
+resolved numeric `origin`/`clip`, so a captured scene records concrete
+values and round-trips without re-deriving from the structure. The
+bounding sphere is orientation-independent (correct from any angle, not
+minimal); once an `orient` directive lands, slab can tighten to the
+selection's depth along the view axis.
+
 ## Known limitations
 
 These are things the format or implementation explicitly does not

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -333,6 +333,12 @@ describe("Moorhen scene — view.slab", () => {
     expect(parseScene(withSlab(`{ file: apo }`)).view!.slab).toEqual({ file: "apo" });
   });
 
+  it("accepts slab with no file (defaults to the sole molecule at apply)", () => {
+    expect(parseScene(withSlab(`{ selection: "//A" }`)).view!.slab).toEqual({
+      selection: "//A",
+    });
+  });
+
   it("rejects an unknown file", () => {
     expect(() => parseScene(withSlab(`{ file: nope }`))).toThrow(/unknown file "nope"/);
   });
@@ -372,10 +378,10 @@ describe("Moorhen scene — view.centre", () => {
     );
   });
 
-  it("rejects a centre with no file", () => {
-    expect(() =>
-      parseScene(withView(`  centre: { selection: "//A" }\n`)),
-    ).toThrow(/centre\.file.*required/);
+  it("accepts a centre with no file (defaults to the sole molecule at apply)", () => {
+    expect(
+      parseScene(withView(`  centre: { selection: "//A" }\n`)).view!.centre,
+    ).toEqual({ selection: "//A" });
   });
 
   it("rejects an unknown key (catches typos like -selection)", () => {

--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -319,6 +319,35 @@ describe("Moorhen scene — view.clip", () => {
   });
 });
 
+describe("Moorhen scene — view.slab", () => {
+  const withSlab = (slab: string) =>
+    `scene: x\nversion: 1\nfiles:\n  - { name: apo, pdb: 1m17 }\nview:\n  slab: ${slab}\n`;
+
+  it("accepts file + selection + pad and round-trips", () => {
+    const scene = parseScene(withSlab(`{ file: apo, selection: "//A", pad: 2 }`));
+    expect(scene.view!.slab).toEqual({ file: "apo", selection: "//A", pad: 2 });
+    expect(parseScene(serialiseScene(scene))).toEqual(scene); // parse→serialise→parse
+  });
+
+  it("accepts slab with just a file (whole molecule, no pad)", () => {
+    expect(parseScene(withSlab(`{ file: apo }`)).view!.slab).toEqual({ file: "apo" });
+  });
+
+  it("rejects an unknown file", () => {
+    expect(() => parseScene(withSlab(`{ file: nope }`))).toThrow(/unknown file "nope"/);
+  });
+
+  it("rejects a negative pad", () => {
+    expect(() => parseScene(withSlab(`{ file: apo, pad: -1 }`))).toThrow(/pad.*>= 0/);
+  });
+
+  it("rejects an unknown key", () => {
+    expect(() => parseScene(withSlab(`{ file: apo, radius: 5 }`))).toThrow(
+      /unknown key "radius"/,
+    );
+  });
+});
+
 describe("Moorhen scene — view.centre", () => {
   const withView = (view: string) =>
     `scene: x\nversion: 1\nfiles:\n  - { name: apo, pdb: 1m17 }\nview:\n${view}`;

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -248,6 +248,34 @@ function selectionBoundingSphere(
 }
 
 /**
+ * Resolve the molecule a view directive (centre/slab) acts on. With an explicit
+ * `file`, look it up. Without one, default to the sole loaded molecule — the
+ * common "only one structure open" case — and report an error otherwise (none
+ * loaded, or ambiguous with several). `ref` is a display string for logging.
+ */
+function resolveViewMolecule(
+  file: string | undefined,
+  fileBindings: Map<string, moorhen.Molecule>,
+): { mol?: moorhen.Molecule; ref: string; error?: string } {
+  if (file !== undefined) {
+    const mol = fileBindings.get(file);
+    return mol
+      ? { mol, ref: file }
+      : { ref: file, error: `file "${file}" not bound to a loaded molecule` };
+  }
+  if (fileBindings.size === 1) {
+    return { mol: [...fileBindings.values()][0], ref: "(sole molecule)" };
+  }
+  return {
+    ref: "(unspecified)",
+    error:
+      fileBindings.size === 0
+        ? "no file specified and no molecule loaded"
+        : `no file specified but ${fileBindings.size} molecules loaded — add a file:`,
+  };
+}
+
+/**
  * Apply a scene to the currently-loaded molecules.
  *
  * Returns a SceneResolveResult describing what was applied and what
@@ -544,19 +572,19 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
     // clip, so it pre-empts centre/origin (below) and clip (further down).
     let slabDepth: number | undefined;
     if (scene.view.slab) {
-      const { file, selection, pad } = scene.view.slab;
+      const { selection, pad } = scene.view.slab;
       const cid = selection ?? "/*/*/*/*";
-      const mol = fileBindings.get(file);
-      if (!mol) {
+      const { mol, ref, error } = resolveViewMolecule(scene.view.slab.file, fileBindings);
+      if (error || !mol) {
         result.log.push({
-          file, domain: "view.slab",
-          message: `cannot slab: file "${file}" not bound to a loaded molecule`,
+          file: ref, domain: "view.slab",
+          message: `cannot slab: ${error}`,
         });
       } else {
         const sphere = selectionBoundingSphere(mol, cid);
         if (!sphere) {
           result.log.push({
-            file, domain: "view.slab",
+            file: ref, domain: "view.slab",
             message: `slab: selection "${cid}" matched no atoms (or gemmi unavailable)`,
           });
         } else {
@@ -564,7 +592,7 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
             await mol.centreOn(cid, false, false);
           } catch (e) {
             result.log.push({
-              file, domain: "view.slab",
+              file: ref, domain: "view.slab",
               message: `centre on "${cid}" failed: ${e instanceof Error ? e.message : "unknown error"}`,
             });
           }
@@ -572,21 +600,21 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
         }
       }
     } else if (scene.view.centre) {
-      const { file, selection } = scene.view.centre;
+      const { selection } = scene.view.centre;
       const cid = selection ?? "/*/*/*/*";
-      const mol = fileBindings.get(file);
-      if (!mol) {
+      const { mol, ref, error } = resolveViewMolecule(scene.view.centre.file, fileBindings);
+      if (error || !mol) {
         result.log.push({
-          file,
+          file: ref,
           domain: "view.centre",
-          message: `cannot centre: file "${file}" not bound to a loaded molecule`,
+          message: `cannot centre: ${error}`,
         });
       } else {
         try {
           await mol.centreOn(cid, false, false); // no animate, don't touch zoom
         } catch (e) {
           result.log.push({
-            file,
+            file: ref,
             domain: "view.centre",
             message: `centre on "${cid}" failed: ${e instanceof Error ? e.message : "unknown error"}`,
           });

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -634,12 +634,16 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
     const zoom = scene.view.zoom ?? ctx.glRef?.zoom ?? 1;
     const fco = ctx.glRef?.fogClipOffset ?? 250;
     if (slabDepth !== undefined) {
-      // Slab: a symmetric field depth = the selection's bounding radius (+pad),
-      // in Å, applied through coot's clip/fog formula and locked.
-      dispatch(setClipStart(zoom * slabDepth));
-      dispatch(setClipEnd(zoom * slabDepth));
-      dispatch(setFogStart(fco - zoom * slabDepth));
-      dispatch(setFogEnd(fco + zoom * slabDepth));
+      // Slab: clip/fog the selection's bounding sphere. clipStart/clipEnd are an
+      // ABSOLUTE half-thickness in world Å about the fogClipOffset plane — the
+      // eye-space z is never scaled by zoom (only x/y are, in the projection), so
+      // the depth is the bounding radius (+pad) directly, NOT zoom*radius. (The
+      // field-depth `clip` form below DOES multiply by zoom because there the
+      // author gives coot's pre-zoom field depths, not an absolute distance.)
+      dispatch(setClipStart(slabDepth));
+      dispatch(setClipEnd(slabDepth));
+      dispatch(setFogStart(fco - slabDepth));
+      dispatch(setFogEnd(fco + slabDepth));
       dispatch(setResetClippingFogging(false));
     } else if (clip === "auto") {
       dispatch(setResetClippingFogging(true)); // let coot recompute from zoom

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -167,6 +167,86 @@ interface ResolveCtx {
   glRef?: { zoom: number; fogClipOffset: number };
 }
 
+// --------------------------------------------------------------------------
+// Geometry: bounding sphere of a selection (for view.slab)
+// --------------------------------------------------------------------------
+
+interface GemmiVec<T> { size(): number; get(i: number): T; delete(): void; }
+interface GemmiAtom { pos: { x: number; y: number; z: number }; }
+interface CCP4GemmiModule {
+  Selection: new (cid: string) => { delete: () => void };
+  selection_get_models(sel: unknown, struct: unknown): GemmiVec<unknown>;
+  selection_get_chains(sel: unknown, model: unknown): GemmiVec<unknown>;
+  selection_get_residues(sel: unknown, chain: unknown): GemmiVec<unknown>;
+  selection_get_atoms(sel: unknown, residue: unknown): GemmiVec<GemmiAtom>;
+}
+
+/**
+ * Centroid + bounding radius (Å) of a CID selection, walked over the molecule's
+ * cached gemmi structure via the gemmi WASM module Moorhen exposes as
+ * `window.CCP4Module`. Orientation-independent. Returns null if gemmi / the
+ * structure is unavailable or the selection matched no atoms. emscripten objects
+ * are .delete()d so the WASM heap doesn't grow on repeated applies.
+ */
+function selectionBoundingSphere(
+  mol: moorhen.Molecule,
+  cid: string,
+): { centre: [number, number, number]; radius: number } | null {
+  const M =
+    typeof window !== "undefined"
+      ? (window as unknown as { CCP4Module?: CCP4GemmiModule }).CCP4Module
+      : undefined;
+  const struct = (mol as unknown as { gemmiStructure?: unknown }).gemmiStructure;
+  if (!M || !struct || typeof M.Selection !== "function") return null;
+
+  const del = (x: unknown) => {
+    try { (x as { delete?: () => void } | null)?.delete?.(); } catch { /* ignore */ }
+  };
+  const xs: number[] = [], ys: number[] = [], zs: number[] = [];
+  let sel: { delete: () => void } | null = null;
+  try {
+    sel = new M.Selection(cid);
+    const models = M.selection_get_models(sel, struct);
+    for (let i = 0; i < models.size(); i++) {
+      const model = models.get(i);
+      const chains = M.selection_get_chains(sel, model);
+      for (let j = 0; j < chains.size(); j++) {
+        const chain = chains.get(j);
+        const residues = M.selection_get_residues(sel, chain);
+        for (let k = 0; k < residues.size(); k++) {
+          const res = residues.get(k);
+          const atoms = M.selection_get_atoms(sel, res);
+          for (let l = 0; l < atoms.size(); l++) {
+            const a = atoms.get(l);
+            xs.push(a.pos.x); ys.push(a.pos.y); zs.push(a.pos.z);
+            del(a);
+          }
+          atoms.delete(); del(res);
+        }
+        residues.delete(); del(chain);
+      }
+      chains.delete(); del(model);
+    }
+    models.delete();
+  } catch {
+    return null; // gemmi/binding error → degrade gracefully (logged by caller)
+  } finally {
+    del(sel);
+  }
+
+  const n = xs.length;
+  if (n === 0) return null;
+  const cx = xs.reduce((s, v) => s + v, 0) / n;
+  const cy = ys.reduce((s, v) => s + v, 0) / n;
+  const cz = zs.reduce((s, v) => s + v, 0) / n;
+  let r = 0;
+  for (let i = 0; i < n; i++) {
+    const d = Math.hypot(xs[i] - cx, ys[i] - cy, zs[i] - cz);
+    if (d > r) r = d;
+  }
+  return { centre: [cx, cy, cz], radius: r };
+}
+
 /**
  * Apply a scene to the currently-loaded molecules.
  *
@@ -459,10 +539,39 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
 
   // 3. Camera. Mirror PasteViewLinkField exactly so behaviour matches.
   if (scene.view) {
-    // Selection-based centre takes precedence over an explicit origin: Moorhen
-    // computes the selection's centroid and sets the origin, so "centre on
-    // chain A" needs no coordinates.
-    if (scene.view.centre) {
+    // Slab: isolate a selection — centre on it AND clip/fog to its bounding
+    // sphere. Computed from the selection's atoms; it drives both centre and
+    // clip, so it pre-empts centre/origin (below) and clip (further down).
+    let slabDepth: number | undefined;
+    if (scene.view.slab) {
+      const { file, selection, pad } = scene.view.slab;
+      const cid = selection ?? "/*/*/*/*";
+      const mol = fileBindings.get(file);
+      if (!mol) {
+        result.log.push({
+          file, domain: "view.slab",
+          message: `cannot slab: file "${file}" not bound to a loaded molecule`,
+        });
+      } else {
+        const sphere = selectionBoundingSphere(mol, cid);
+        if (!sphere) {
+          result.log.push({
+            file, domain: "view.slab",
+            message: `slab: selection "${cid}" matched no atoms (or gemmi unavailable)`,
+          });
+        } else {
+          try {
+            await mol.centreOn(cid, false, false);
+          } catch (e) {
+            result.log.push({
+              file, domain: "view.slab",
+              message: `centre on "${cid}" failed: ${e instanceof Error ? e.message : "unknown error"}`,
+            });
+          }
+          slabDepth = sphere.radius + (pad ?? 0);
+        }
+      }
+    } else if (scene.view.centre) {
       const { file, selection } = scene.view.centre;
       const cid = selection ?? "/*/*/*/*";
       const mol = fileBindings.get(file);
@@ -496,7 +605,15 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
     const clip = scene.view.clip;
     const zoom = scene.view.zoom ?? ctx.glRef?.zoom ?? 1;
     const fco = ctx.glRef?.fogClipOffset ?? 250;
-    if (clip === "auto") {
+    if (slabDepth !== undefined) {
+      // Slab: a symmetric field depth = the selection's bounding radius (+pad),
+      // in Å, applied through coot's clip/fog formula and locked.
+      dispatch(setClipStart(zoom * slabDepth));
+      dispatch(setClipEnd(zoom * slabDepth));
+      dispatch(setFogStart(fco - zoom * slabDepth));
+      dispatch(setFogEnd(fco + zoom * slabDepth));
+      dispatch(setResetClippingFogging(false));
+    } else if (clip === "auto") {
       dispatch(setResetClippingFogging(true)); // let coot recompute from zoom
     } else if (clip && typeof clip === "object") {
       // Field depths in Å; clip = zoom*depth, fog offset by fogClipOffset —

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -24,6 +24,7 @@ import {
   SceneRepresentation,
   SceneCentre,
   SceneClip,
+  SceneSlab,
   SceneColour,
   SceneColourSelection,
   SceneSuperpose,
@@ -188,6 +189,7 @@ export function validateScene(raw: unknown): {
         fogStart: optNum(v, "fogStart", "view.fogStart", errors),
         fogEnd: optNum(v, "fogEnd", "view.fogEnd", errors),
         clip: validateClip(v.clip, errors),
+        slab: validateSlab(v.slab, out.files ?? [], errors),
         background: optStr(v, "background", "view.background", errors),
       };
     } else {
@@ -857,6 +859,51 @@ function validateRepresentation(
     }
   }
   return rep;
+}
+
+function validateSlab(
+  raw: unknown,
+  files: SceneFileRef[],
+  errors: SceneValidationError[],
+): SceneSlab | undefined {
+  if (raw === undefined) return undefined;
+  if (!isObject(raw)) {
+    errors.push({ path: "view.slab", message: "must be a mapping { file, selection?, pad? }" });
+    return undefined;
+  }
+  for (const k of Object.keys(raw as Record<string, unknown>)) {
+    if (k !== "file" && k !== "selection" && k !== "pad") {
+      errors.push({
+        path: `view.slab.${k}`,
+        message: `unknown key "${k}" — slab takes only "file", "selection", "pad"`,
+      });
+    }
+  }
+  const file = strField(raw, "file", "", errors, "view.slab");
+  if (!file) {
+    errors.push({ path: "view.slab.file", message: "required" });
+    return undefined;
+  }
+  if (files.length > 0 && !files.some((f) => f.name === file)) {
+    errors.push({
+      path: "view.slab.file",
+      message: `unknown file "${file}" (not in top-level files block)`,
+    });
+    return undefined;
+  }
+  const slab: SceneSlab = { file };
+  if ("selection" in (raw as Record<string, unknown>)) {
+    const sel = optStr(raw, "selection", "view.slab.selection", errors);
+    if (sel) slab.selection = sel;
+  }
+  if ("pad" in (raw as Record<string, unknown>)) {
+    const pad = optNum(raw, "pad", "view.slab.pad", errors);
+    if (pad !== undefined) {
+      if (pad < 0) errors.push({ path: "view.slab.pad", message: "must be >= 0" });
+      else slab.pad = pad;
+    }
+  }
+  return slab;
 }
 
 function validateClip(

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -879,19 +879,24 @@ function validateSlab(
       });
     }
   }
-  const file = strField(raw, "file", "", errors, "view.slab");
-  if (!file) {
-    errors.push({ path: "view.slab.file", message: "required" });
-    return undefined;
+  // file is optional: omitted ⇒ the resolver defaults to the sole loaded
+  // molecule (and logs if that's ambiguous). When given, cross-check it.
+  const slab: SceneSlab = {};
+  if ("file" in (raw as Record<string, unknown>)) {
+    const file = strField(raw, "file", "", errors, "view.slab");
+    if (!file) {
+      errors.push({ path: "view.slab.file", message: "must be a non-empty string" });
+      return undefined;
+    }
+    if (files.length > 0 && !files.some((f) => f.name === file)) {
+      errors.push({
+        path: "view.slab.file",
+        message: `unknown file "${file}" (not in top-level files block)`,
+      });
+      return undefined;
+    }
+    slab.file = file;
   }
-  if (files.length > 0 && !files.some((f) => f.name === file)) {
-    errors.push({
-      path: "view.slab.file",
-      message: `unknown file "${file}" (not in top-level files block)`,
-    });
-    return undefined;
-  }
-  const slab: SceneSlab = { file };
   if ("selection" in (raw as Record<string, unknown>)) {
     const sel = optStr(raw, "selection", "view.slab.selection", errors);
     if (sel) slab.selection = sel;
@@ -956,19 +961,24 @@ function validateCentre(
       });
     }
   }
-  const file = strField(raw, "file", "", errors, "view.centre");
-  if (!file) {
-    errors.push({ path: "view.centre.file", message: "required" });
-    return undefined;
+  // file is optional: omitted ⇒ the resolver defaults to the sole loaded
+  // molecule (and logs if that's ambiguous). When given, cross-check it.
+  const centre: SceneCentre = {};
+  if ("file" in (raw as Record<string, unknown>)) {
+    const file = strField(raw, "file", "", errors, "view.centre");
+    if (!file) {
+      errors.push({ path: "view.centre.file", message: "must be a non-empty string" });
+      return undefined;
+    }
+    if (files.length > 0 && !files.some((f) => f.name === file)) {
+      errors.push({
+        path: "view.centre.file",
+        message: `unknown file "${file}" (not in top-level files block)`,
+      });
+      return undefined;
+    }
+    centre.file = file;
   }
-  if (files.length > 0 && !files.some((f) => f.name === file)) {
-    errors.push({
-      path: "view.centre.file",
-      message: `unknown file "${file}" (not in top-level files block)`,
-    });
-    return undefined;
-  }
-  const centre: SceneCentre = { file };
   if ("selection" in (raw as Record<string, unknown>)) {
     const sel = optStr(raw, "selection", "view.centre.selection", errors);
     if (sel) centre.selection = sel;

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -704,8 +704,12 @@ scene records the concrete point.
 ### `slab` — isolate a selection
 
 One directive that does centre **and** clip: it walks the selection's atoms for
-a centroid and bounding radius `R`, centres on the centroid, and sets a symmetric
-clip/fog field depth of `R + pad` (Å). "Show just chain A's region."
+a centroid and bounding radius `R`, centres on the centroid, and clips/fogs to a
+symmetric half-thickness of `R + pad` Å about it. "Show just chain A's region."
+
+Unlike `clip: { front, back }` (whose field depths are coot's pre-zoom knobs,
+multiplied by zoom), the slab depth is an **absolute** world-Å distance, so it is
+applied directly — not scaled by zoom.
 
 ```yaml
 view:

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -700,6 +700,28 @@ the camera where it is (it does not fail). The lifter still captures the
 resolved Cartesian `origin:` — `centre:` is an input convenience, so a captured
 scene records the concrete point.
 
+### `slab` — isolate a selection
+
+One directive that does centre **and** clip: it walks the selection's atoms for
+a centroid and bounding radius `R`, centres on the centroid, and sets a symmetric
+clip/fog field depth of `R + pad` (Å). "Show just chain A's region."
+
+```yaml
+view:
+  slab: { file: apo, selection: "//A", pad: 2 }
+```
+
+- `file`: required — a name from the top-level `files:` block.
+- `selection`: optional CID; omitted means the whole molecule.
+- `pad`: optional Å added to the radius on each side (default 0).
+
+`slab` drives both centre and clip, so it takes **precedence over `centre`/`origin`
+and `clip`** when present. (For centre and clip on *different* things, use those
+two directly.) The radius is a bounding sphere, so it's correct from any
+orientation but not minimal; once orientation directives exist it can tighten to
+the selection's depth along the view axis. If the selection matched no atoms (or
+gemmi is unavailable) the resolver logs it and leaves the view alone.
+
 ## `resolver`
 
 Apply-time policy. Currently one option:

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -691,7 +691,8 @@ view:
   zoom: 1.5
 ```
 
-- `file`: required — a name from the top-level `files:` block.
+- `file`: a name from the top-level `files:` block. Optional when exactly one
+  molecule is loaded — it then defaults to that molecule.
 - `selection`: optional CID; omitted means the whole molecule.
 
 `centre` takes **precedence over `origin`** when both are present. If the file
@@ -711,7 +712,8 @@ view:
   slab: { file: apo, selection: "//A", pad: 2 }
 ```
 
-- `file`: required — a name from the top-level `files:` block.
+- `file`: a name from the top-level `files:` block. Optional when exactly one
+  molecule is loaded — it then defaults to that molecule.
 - `selection`: optional CID; omitted means the whole molecule.
 - `pad`: optional Å added to the radius on each side (default 0).
 

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -467,6 +467,11 @@ export interface SceneView {
    *  drives clip/fog (and the lock); the raw clipStart/End/fogStart/End above
    *  stay as an escape hatch. */
   clip?: SceneClip;
+  /** Isolate a selection: centre on it AND clip/fog to its bounding sphere. A
+   *  one-directive "show just chain A's region". Computed at apply-time from the
+   *  selection's atoms, so it needs no coordinates. Drives centre + clip, so it
+   *  takes precedence over `centre`/`origin` and `clip` when present. */
+  slab?: SceneSlab;
   background?: string;        // hex
 }
 
@@ -497,6 +502,21 @@ export interface SceneCentre {
   file: string;
   /** CID selection within that file; omitted ⇒ the whole molecule. */
   selection?: string;
+}
+
+/**
+ * Isolate a selection (see SceneView.slab). The resolver walks the selection's
+ * atoms for a centroid and bounding radius R, centres on the centroid, and sets
+ * a symmetric clip/fog field depth of R + pad. Orientation-independent (a
+ * sphere); once `orient` exists it can tighten to the depth along the view axis.
+ */
+export interface SceneSlab {
+  /** Name of a file from the top-level `files:` block. */
+  file: string;
+  /** CID selection within that file; omitted ⇒ the whole molecule. */
+  selection?: string;
+  /** Extra Ångström added to the radius on each side (default 0). */
+  pad?: number;
 }
 
 // --------------------------------------------------------------------------

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -498,8 +498,9 @@ export interface SceneClipFieldDepth {
 
 /** Selection whose centroid the camera centres on (see SceneView.centre). */
 export interface SceneCentre {
-  /** Name of a file from the top-level `files:` block. */
-  file: string;
+  /** Name of a file from the top-level `files:` block. Optional when exactly one
+   *  molecule is loaded — the resolver then defaults to it. */
+  file?: string;
   /** CID selection within that file; omitted ⇒ the whole molecule. */
   selection?: string;
 }
@@ -511,8 +512,9 @@ export interface SceneCentre {
  * sphere); once `orient` exists it can tighten to the depth along the view axis.
  */
 export interface SceneSlab {
-  /** Name of a file from the top-level `files:` block. */
-  file: string;
+  /** Name of a file from the top-level `files:` block. Optional when exactly one
+   *  molecule is loaded — the resolver then defaults to it. */
+  file?: string;
   /** CID selection within that file; omitted ⇒ the whole molecule. */
   selection?: string;
   /** Extra Ångström added to the radius on each side (default 0). */


### PR DESCRIPTION
One directive that centres on a selection **and** clips/fogs to its bounding sphere — "show just chain A's region":

```yaml
view:
  slab: { file: apo, selection: "//A", pad: 2 }
```

The resolver walks the selection's atoms over the molecule's cached gemmi structure — via the gemmi WASM module Moorhen exposes as `window.CCP4Module` (`new Selection(cid)` + `selection_get_models/chains/residues/atoms`) — for a centroid and bounding radius `R`, centres on the centroid (`centreOn`), and sets a symmetric clip/fog field depth of `R + pad` Å through the clip path landed in #211, locked.

- **Orientation-independent** (a sphere): correct from any angle, not minimal. Once orientation directives exist it can tighten to the selection's depth along the view axis.
- **Drives centre + clip**, so it pre-empts `centre`/`origin` and `clip` when present. (For centre and clip on different things, use those directly.)
- **Degrades gracefully**: empty selection or missing gemmi → logged, view left alone. emscripten objects are `.delete()`d so the WASM heap stays stable across applies.

### Changes
- **types**: `SceneView.slab?: SceneSlab { file, selection?, pad? }`.
- **validate**: `file` cross-checked against `files:`; `pad >= 0`; unknown keys rejected.
- **resolve**: `selectionBoundingSphere` helper + slab handling in the view block.
- docs + parse/validate tests. `tsc` clean.

The gemmi walk is runtime (verified in-browser, like `centreOn`), so it isn't unit-tested — worth a quick manual check that `slab: { file, selection: "//A" }` frames chain A tightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)