### PR TITLE
Moorhen scenes: return YAML in a fenced code block (preserve indentation)

### DIFF
--- a/client/renderer/__tests__/moorhen-scene.test.ts
+++ b/client/renderer/__tests__/moorhen-scene.test.ts
@@ -319,6 +319,24 @@ describe("Moorhen scene — view.clip", () => {
   });
 });
 
+describe("Moorhen scene — code-fence tolerance", () => {
+  const body = `scene: x\nversion: 1\nfiles:\n  - { name: s, pdb: 1m17 }`;
+
+  it("parses YAML wrapped in a ```yaml fenced block", () => {
+    const fenced = "```yaml\n" + body + "\n```";
+    expect(parseScene(fenced).scene).toBe("x");
+  });
+
+  it("parses a bare ``` fence and ignores surrounding prose", () => {
+    const fenced = "Here is your scene:\n\n```\n" + body + "\n```\n\nHope that helps!";
+    expect(parseScene(fenced).scene).toBe("x");
+  });
+
+  it("still parses plain YAML with no fence", () => {
+    expect(parseScene(body).scene).toBe("x");
+  });
+});
+
 describe("Moorhen scene — view.slab", () => {
   const withSlab = (slab: string) =>
     `scene: x\nversion: 1\nfiles:\n  - { name: apo, pdb: 1m17 }\nview:\n  slab: ${slab}\n`;

--- a/client/renderer/lib/moorhen-scene-prompt.ts
+++ b/client/renderer/lib/moorhen-scene-prompt.ts
@@ -152,7 +152,7 @@ const INTERPRETATION_GUIDANCE = [
   "For minor ambiguity, choose the most likely reading and proceed. Ask a concise",
   "clarifying question ONLY when the ambiguity would materially change the scene and",
   "no reasonable default exists (e.g. which two chains form \"the dimer\" in a",
-  "tetramer) — ask once, then output only the YAML once answered.",
+  "tetramer) — ask once, then return the YAML code block once answered.",
 ].join("\n");
 
 // ── Whole prompt ────────────────────────────────────────────────────────────
@@ -181,10 +181,13 @@ export function buildAuthoringPrompt(opts: {
 
   return [
     "You are drafting a Moorhen \"scene\": a YAML document describing a molecular",
-    "view. Follow the grammar below EXACTLY. When you produce the scene, output ONLY",
-    "the YAML (no prose, no code fences). If — and only if — the request is materially",
-    "ambiguous and no reasonable default exists, you may FIRST ask one concise",
-    "clarifying question in plain text and wait for the reply before producing the YAML.",
+    "view. Follow the grammar below EXACTLY. Return the scene as a SINGLE fenced YAML",
+    "code block (```yaml ... ```) and nothing else outside it — YAML is",
+    "whitespace-sensitive, and a code block lets the chat UI show a copy button that",
+    "preserves the exact indentation (selecting the text by hand does not). If — and",
+    "only if — the request is materially ambiguous and no reasonable default exists,",
+    "you may FIRST ask one concise clarifying question in plain text and wait for the",
+    "reply before producing the code block.",
     "Reference project files with { job, param, projectId } using the manifest; use",
     "pdb:/url: only for structures not in the project; never use path:.",
     "Use the exact ligand CIDs from the contents summary for ligand selections.",
@@ -206,8 +209,8 @@ export function buildAuthoringPrompt(opts: {
     "Produce a scene YAML that satisfies the following request. Use the project,",
     "files, and CIDs above. For minor ambiguity choose sensible defaults; only for a",
     "material ambiguity with no reasonable default, ask one concise question first.",
-    "When you produce the scene, output ONLY the YAML (no prose, no code fences).",
-    "The request:",
+    "When you produce the scene, return it as a SINGLE ```yaml fenced code block and",
+    "nothing else outside it. The request:",
     "",
     opts.request.trim() || "(no request given — produce a clear default overview of the loaded structure)",
     "",

--- a/client/renderer/lib/moorhen-scene.ts
+++ b/client/renderer/lib/moorhen-scene.ts
@@ -62,10 +62,23 @@ export class SceneParseError extends Error {
  * Parse a YAML scene document into a typed MoorhenScene.
  * Throws SceneParseError if validation fails.
  */
+/**
+ * Strip a Markdown code fence around the YAML if present. LLMs are asked to
+ * return a ```yaml block (so the chat UI's copy button preserves indentation),
+ * but a hand-copied response can carry the ``` fences — and surrounding prose —
+ * into the editor. Extract the first fenced block's contents; if there's no
+ * fence, return the text unchanged. Plain YAML never starts a line with ```, so
+ * this is safe for non-LLM input too.
+ */
+function stripCodeFence(text: string): string {
+  const m = text.match(/```[ \t]*[\w+-]*[ \t]*\r?\n([\s\S]*?)\r?\n?```/);
+  return m ? m[1] : text;
+}
+
 export function parseScene(yamlText: string): MoorhenScene {
   let raw: unknown;
   try {
-    raw = YAML.parse(yamlText);
+    raw = YAML.parse(stripCodeFence(yamlText));
   } catch (e) {
     throw new SceneParseError([
       { path: "", message: `YAML parse error: ${(e as Error).message}` },


### PR DESCRIPTION
Hand-selecting an LLM response in the browser drops the column layout, and YAML is whitespace-sensitive — so the pasted scene came back broken.

- **Prompt:** ask the model to return the scene as a single ```` ```yaml ```` fenced code block (every chat UI renders those with a copy button that preserves exact indentation). Reverses the earlier "no code fences" instruction, which was wrong. Updated all three instruction sites.
- **Parser (belt-and-braces):** `parseScene` now strips a surrounding code fence — and any prose around it — before parsing, so stray ``` markers surviving a hand-copy don't break it. Plain YAML never starts a line with ```` ``` ````, so it's safe for non-LLM input too.
- Tests cover fenced ```` ```yaml ````, a bare ```` ``` ```` with surrounding prose, and plain unfenced YAML. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)