### PR TITLE
Fix PDB "from internet" fetch: gzip truncation + extended PDB ids

### DIFF
--- a/client/renderer/__tests__/pdb-id.test.ts
+++ b/client/renderer/__tests__/pdb-id.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  toExtendedPdbId,
+  toShortPdbId,
+  toDisplayPdbId,
+  pdbEntryPayload,
+} from "../components/task/task-elements/pdb-id";
+
+describe("toExtendedPdbId", () => {
+  it("expands a legacy 4-char code", () => {
+    expect(toExtendedPdbId("1jst")).toBe("pdb_00001jst");
+    expect(toExtendedPdbId("1JST")).toBe("pdb_00001jst");
+    expect(toExtendedPdbId("  1jst  ")).toBe("pdb_00001jst");
+  });
+  it("passes an already-extended id through (lowercased)", () => {
+    expect(toExtendedPdbId("pdb_00001jst")).toBe("pdb_00001jst");
+    expect(toExtendedPdbId("PDB_00001JST")).toBe("pdb_00001jst");
+    expect(toExtendedPdbId("pdb_00abcdef")).toBe("pdb_00abcdef");
+  });
+  it("leaves unrecognised input trimmed/lowercased", () => {
+    expect(toExtendedPdbId("notapdb")).toBe("notapdb");
+  });
+});
+
+describe("toShortPdbId", () => {
+  it("returns the 4-char form when derivable", () => {
+    expect(toShortPdbId("1jst")).toBe("1jst");
+    expect(toShortPdbId("PDB_00001JST")).toBe("1jst");
+  });
+  it("returns null for a genuinely-extended id beyond the 4-char namespace", () => {
+    expect(toShortPdbId("pdb_00abcdef")).toBeNull();
+    expect(toShortPdbId("notapdb")).toBeNull();
+  });
+});
+
+describe("toDisplayPdbId", () => {
+  it("prefers the compact form, falling back to extended", () => {
+    expect(toDisplayPdbId("pdb_00001jst")).toBe("1jst");
+    expect(toDisplayPdbId("pdb_00abcdef")).toBe("pdb_00abcdef");
+  });
+});
+
+describe("pdbEntryPayload", () => {
+  it("resolves a response keyed by the legacy id when queried with the extended id", () => {
+    const data = { "1jst": { PDB: { downloads: [] } } };
+    expect(pdbEntryPayload(data, "pdb_00001jst")).toBe(data["1jst"]);
+  });
+  it("resolves a response keyed by the extended id", () => {
+    const data = { pdb_00abcdef: { x: 1 } };
+    expect(pdbEntryPayload(data, "pdb_00abcdef")).toBe(data["pdb_00abcdef"]);
+  });
+  it("falls back to the sole value when the key does not match any variant", () => {
+    const data = { weirdkey: { y: 2 } };
+    expect(pdbEntryPayload(data, "1jst")).toBe(data["weirdkey"]);
+  });
+  it("returns undefined for empty or ambiguous responses", () => {
+    expect(pdbEntryPayload({}, "1jst")).toBeUndefined();
+    expect(pdbEntryPayload(null, "1jst")).toBeUndefined();
+    expect(pdbEntryPayload({ a: 1, b: 2 }, "1jst")).toBeUndefined();
+  });
+});

--- a/client/renderer/app/api/proxy/pdbe/[...path]/route.ts
+++ b/client/renderer/app/api/proxy/pdbe/[...path]/route.ts
@@ -44,8 +44,13 @@ async function proxy(
     const headers = new Headers();
     const contentType = res.headers.get("Content-Type");
     if (contentType) headers.set("Content-Type", contentType);
-    const contentLength = res.headers.get("Content-Length");
-    if (contentLength) headers.set("Content-Length", contentLength);
+    // Deliberately do NOT forward the upstream Content-Length. Node's fetch
+    // transparently decompresses gzip/br responses, so `body` here is the
+    // decoded payload, but the upstream Content-Length reflects the *encoded*
+    // (compressed) size. Forwarding it makes the browser read only that many
+    // bytes and truncate the rest — surfacing as "Unterminated string in JSON
+    // at position <compressed-length>". Let NextResponse derive the correct
+    // length from the actual buffer instead.
     headers.set("Cross-Origin-Resource-Policy", "cross-origin");
 
     return new NextResponse(body, { status: res.status, headers });

--- a/client/renderer/components/task/task-elements/fetch-file-for-param.tsx
+++ b/client/renderer/components/task/task-elements/fetch-file-for-param.tsx
@@ -21,6 +21,12 @@ import {
   ChainSequenceInfo,
 } from "./mmcif-sequence-parser";
 import { ChainPickerDialog } from "./chain-picker-dialog";
+import {
+  toExtendedPdbId,
+  toShortPdbId,
+  toDisplayPdbId,
+  pdbEntryPayload,
+} from "./pdb-id";
 
 /** Human-readable labels for download modes shown in the dropdown */
 const MODE_LABELS: Record<string, string> = {
@@ -34,12 +40,12 @@ const MODE_LABELS: Record<string, string> = {
 
 /** Placeholder text for the accession code field per mode */
 const MODE_PLACEHOLDERS: Record<string, string> = {
-  ebiPdb: "e.g. 1cbs",
-  rcsbPdb: "e.g. 1cbs",
+  ebiPdb: "e.g. 1cbs or pdb_00001cbs",
+  rcsbPdb: "e.g. 1cbs or pdb_00001cbs",
   uniprotAFPdb: "e.g. P07550",
-  ebiSFs: "e.g. 1cbs",
+  ebiSFs: "e.g. 1cbs or pdb_00001cbs",
   uniprotFasta: "e.g. P07550 or CDK2_HUMAN",
-  "Uppsala-EDS": "e.g. 1cbs",
+  "Uppsala-EDS": "e.g. 1cbs or pdb_00001cbs",
 };
 
 /** Modes that fetch PDB coordinate files */
@@ -158,7 +164,7 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
   /** Upload a selected chain as a FASTA file */
   const uploadChainAsFasta = useCallback(
     (chain: ChainSequenceInfo) => {
-      const pdbId = pendingPdbId || identifier || "unknown";
+      const pdbId = pendingPdbId || (identifier ? toDisplayPdbId(identifier) : "unknown");
       const fastaContent = buildFasta(pdbId, chain);
       const blob = new Blob([fastaContent], { type: "text/plain" });
       uploadFile(blob, `${pdbId.toUpperCase()}_${chain.chainId}.fasta`);
@@ -174,11 +180,13 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
         // carries Cross-Origin-Resource-Policy: cross-origin and survives
         // the Moorhen COEP page. Direct fetches to www.ebi.ac.uk surface
         // as TypeError: Failed to fetch under COEP.
-        const url = `/api/proxy/pdbe/api/pdb/entry/files/${identifier.toLowerCase()}`;
+        // Query with the extended id (the 4-char endpoints are deprecated);
+        // PDBe keys the response by the legacy 4-char id, so resolve tolerantly.
+        const url = `/api/proxy/pdbe/api/pdb/entry/files/${toExtendedPdbId(identifier)}`;
         const result = await apiFetch(url);
         const data = await result.json();
-        if (data && data[identifier.toLowerCase()]) {
-          const file = data[identifier.toLowerCase()];
+        const file = pdbEntryPayload(data, identifier);
+        if (file) {
           const upstreamURL = file.PDB.downloads
             .filter((item: any) => item.label === "Archive mmCIF file")
             .at(0).url;
@@ -208,18 +216,25 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
   const handleEbiSFsFetch = useCallback(async () => {
     if (identifier) {
       try {
-        const url = `https://www.ebi.ac.uk/pdbe/api/pdb/entry/files/${identifier.toLowerCase()}`;
+        // Route through the local proxy (COEP-safe) and query with the extended
+        // id; PDBe keys the response by the legacy 4-char id, so resolve tolerantly.
+        const url = `/api/proxy/pdbe/api/pdb/entry/files/${toExtendedPdbId(identifier)}`;
         const result = await apiFetch(url);
         const data = await result.json();
-        if (data && data[identifier.toLowerCase()]) {
-          const file = data[identifier.toLowerCase()];
-          let fetchURL = file.PDB.downloads
+        const file = pdbEntryPayload(data, identifier);
+        if (file) {
+          const upstreamURL = file.PDB.downloads
             .filter((item: any) => item.label === "Structure Factors")
             .at(0).url;
-          setMessage(`Fetching file from ${fetchURL}`);
+          // Rewrite the absolute www.ebi.ac.uk URL through the proxy (COEP-safe).
+          const fetchURL = upstreamURL.replace(
+            /^https?:\/\/www\.ebi\.ac\.uk\/pdbe\//,
+            "/api/proxy/pdbe/",
+          );
+          setMessage(`Fetching file from ${upstreamURL}`);
           const content = await apiBlob(fetchURL);
-          setMessage(`Fetched file from ${fetchURL}`);
-          uploadFile(content, fetchURL.split("/").at(-1));
+          setMessage(`Fetched file from ${upstreamURL}`);
+          uploadFile(content, upstreamURL.split("/").at(-1));
           onClose();
         } else {
           const errorText = await result.text();
@@ -247,7 +262,8 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
 
   const handleRcsbPdbFetch = useCallback(async () => {
     if (identifier) {
-      const id = identifier.toLowerCase();
+      // RCSB downloads accept the extended id (the 4-char form is deprecated).
+      const id = toExtendedPdbId(identifier);
       const fetchURL = `https://files.rcsb.org/download/${id}.cif`;
       setMessage(`Fetching coordinates from RCSB for ${id}`);
       try {
@@ -280,7 +296,8 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
   const handleUppsalaEdsFetch = useCallback(async () => {
     // Uppsala EDS was retired in 2017 — fetch from PDB-REDO instead
     if (identifier) {
-      const id = identifier.toLowerCase();
+      // PDB-REDO accepts the extended id (the 4-char form is deprecated).
+      const id = toExtendedPdbId(identifier);
       const fetchURL = `https://pdb-redo.eu/db/${id}/${id}_final.mtz`;
       setMessage(`Fetching map coefficients from PDB-REDO for ${id}`);
       try {
@@ -299,7 +316,7 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
    * Returns ChainSequenceInfo[] from the /api/pdb/entry/molecules/{id} endpoint.
    */
   const parsePdbeMolecules = useCallback((data: any, pdbId: string): ChainSequenceInfo[] => {
-    const entities = data[pdbId.toLowerCase()];
+    const entities = pdbEntryPayload(data, pdbId);
     if (!Array.isArray(entities)) return [];
     const chains: ChainSequenceInfo[] = [];
     for (const entity of entities) {
@@ -331,20 +348,30 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
    */
   const handlePdbSequenceFetch = useCallback(async (source: "ebi" | "rcsb") => {
     if (!identifier) return;
-    const id = identifier.toLowerCase();
+    const id = toDisplayPdbId(identifier);
     try {
       setMessage(`Fetching sequences for ${id.toUpperCase()}...`);
       let chains: ChainSequenceInfo[];
 
       if (source === "ebi") {
-        // PDBe molecules API returns structured JSON with sequences per entity
-        const url = `https://www.ebi.ac.uk/pdbe/api/pdb/entry/molecules/${id}`;
+        // PDBe molecules API returns structured JSON with sequences per entity.
+        // Query with the extended id; the response is keyed by the legacy id,
+        // so parsePdbeMolecules resolves it tolerantly.
+        const url = `https://www.ebi.ac.uk/pdbe/api/pdb/entry/molecules/${toExtendedPdbId(identifier)}`;
         const result = await apiFetch(url);
         const data = await result.json();
-        chains = parsePdbeMolecules(data, id);
+        chains = parsePdbeMolecules(data, identifier);
       } else {
-        // RCSB provides a proper FASTA endpoint
-        const fastaUrl = `https://www.rcsb.org/fasta/entry/${id.toUpperCase()}`;
+        // RCSB's FASTA endpoint accepts ONLY the legacy 4-char code (the
+        // extended form 404s here), so use the short id.
+        const shortId = toShortPdbId(identifier);
+        if (!shortId) {
+          setMessage(
+            `RCSB FASTA does not support extended PDB ids — try PDBe for ${id.toUpperCase()}`,
+          );
+          return;
+        }
+        const fastaUrl = `https://www.rcsb.org/fasta/entry/${shortId.toUpperCase()}`;
         const fastaText = await apiText(fastaUrl);
         chains = parseMultiChainFasta(fastaText);
       }

--- a/client/renderer/components/task/task-elements/pdb-id.ts
+++ b/client/renderer/components/task/task-elements/pdb-id.ts
@@ -1,0 +1,81 @@
+/**
+ * PDB identifier normalization.
+ *
+ * The PDB is migrating from the legacy 4-character codes (e.g. `1jst`) to the
+ * 12-character extended format `pdb_0000XXXX` (e.g. `pdb_00001jst`), because the
+ * 4-character namespace is nearly exhausted. The APIs we call behave as follows
+ * (verified against the live endpoints):
+ *
+ *   - PDBe `api/pdb/entry/files` and `api/pdb/entry/molecules`: accept BOTH
+ *     forms, but always KEY the JSON response by the legacy 4-char id even when
+ *     queried with the extended id. So a request for `pdb_00001jst` returns
+ *     `{ "1jst": { ... } }`. Tolerant key lookup is therefore mandatory.
+ *   - RCSB downloads (`files.rcsb.org/download`): accept both forms.
+ *   - PDB-REDO (`pdb-redo.eu/db`): accept both forms.
+ *   - RCSB FASTA (`rcsb.org/fasta/entry`): accepts ONLY the 4-char form;
+ *     the extended form 404s. Use {@link toShortPdbId} for that endpoint.
+ *
+ * Policy: when an endpoint accepts both, we send the extended (future-proof)
+ * form; when an endpoint only accepts the legacy form, we send the short form.
+ * Either form may be typed by the user.
+ */
+
+/** A legacy 4-char PDB code: a digit followed by three alphanumerics. */
+const SHORT_RE = /^[0-9][a-z0-9]{3}$/;
+
+/** An extended id whose 8-char body encodes a legacy 4-char code (`pdb_0000XXXX`). */
+const EXTENDED_LEGACY_RE = /^pdb_0000([0-9][a-z0-9]{3})$/;
+
+/**
+ * Canonical extended PDB identifier, lowercased.
+ * `1jst` -> `pdb_00001jst`; already-extended ids pass through (lowercased);
+ * anything unrecognised is returned trimmed/lowercased unchanged.
+ */
+export function toExtendedPdbId(raw: string): string {
+  const id = (raw ?? "").trim().toLowerCase();
+  if (id.startsWith("pdb_")) return id;
+  if (SHORT_RE.test(id)) return `pdb_0000${id}`;
+  return id;
+}
+
+/**
+ * Legacy 4-char id when one is derivable, else null.
+ * `pdb_00001jst` -> `1jst`; `1jst` -> `1jst`; a genuinely-extended id beyond the
+ * 4-char namespace (body not starting `0000`) has no short form -> null.
+ */
+export function toShortPdbId(raw: string): string | null {
+  const id = (raw ?? "").trim().toLowerCase();
+  if (SHORT_RE.test(id)) return id;
+  const m = id.match(EXTENDED_LEGACY_RE);
+  return m ? m[1] : null;
+}
+
+/**
+ * Id best suited for display/filenames: the compact 4-char form when derivable,
+ * otherwise the extended form.
+ */
+export function toDisplayPdbId(raw: string): string {
+  return toShortPdbId(raw) ?? toExtendedPdbId(raw);
+}
+
+/**
+ * Resolve the single entry payload from a PDBe-style response keyed by id.
+ * Tries every known id variant, then — since these endpoints return exactly one
+ * entry — falls back to the sole value. Returns undefined if nothing matches.
+ */
+export function pdbEntryPayload<T = any>(
+  data: Record<string, T> | null | undefined,
+  raw: string,
+): T | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const candidates = [
+    toExtendedPdbId(raw),
+    toShortPdbId(raw),
+    (raw ?? "").trim().toLowerCase(),
+  ].filter(Boolean) as string[];
+  for (const key of candidates) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) return data[key];
+  }
+  const values = Object.values(data);
+  return values.length === 1 ? values[0] : undefined;
+}


### PR DESCRIPTION
## Problem

Clicking **from internet** on the `CPdbDataFile` widget to fetch a structure from the PDB failed with `Unterminated string in JSON at position 666 (line 1 column 667)`, even though the server-side proxy returned `200`.

## Root cause

The PDBe proxy forwarded the upstream `Content-Length` header. PDBe sends its JSON **gzip-compressed**; Node's `fetch` transparently decompresses it, so the buffered body is larger than the *compressed* `Content-Length` (666 bytes). The browser honoured the stale header, read only 666 bytes of the larger decompressed body, and truncated the JSON mid-string — hence the parse error at exactly position 666.

## Fixes

**1. gzip truncation** — stop forwarding the upstream `Content-Length` in the PDBe proxy; let `NextResponse` derive the correct length from the actual (decompressed) buffer. (The `ccp4i2` proxy already does this; `uniprot` uses `res.text()` and is unaffected.)

**2. Extended (>4 char) PDB ids** — the 4-char namespace is nearly exhausted and the legacy-only API paths are deprecated. New `pdb-id.ts` normalizes ids and generates requests against the extended `pdb_0000XXXX` form wherever the endpoint supports it. Behaviour was **verified against the live endpoints**:

| Endpoint | Accepts | Response keyed by | Our request |
|----------|---------|-------------------|-------------|
| PDBe files / molecules | both forms | **legacy 4-char** (even when queried by extended id) | extended + tolerant lookup |
| RCSB downloads | both | — | extended |
| PDB-REDO | both | — | extended |
| RCSB FASTA | **4-char only** (extended 404s) | — | short id (clear message if not derivable) |

Because PDBe keys its JSON by the legacy id even when queried with the extended id, `pdbEntryPayload` resolves tolerantly (try each variant, then the sole value). Users may type either form; placeholders hint the extended form.

Also routes the structure-factor fetch through the COEP-safe proxy to match the coordinate fetch (it was doing a direct EBI fetch that fails under COEP).

## Tests

`pdb-id.test.ts` — 10 cases covering normalization, short/extended round-trips, and tolerant payload resolution. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)