### PR TITLE
Fix PDB fetch 404: prefer legacy 4-char id for download hosts

### DIFF
--- a/client/renderer/__tests__/pdb-id.test.ts
+++ b/client/renderer/__tests__/pdb-id.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   toExtendedPdbId,
   toShortPdbId,
+  toFetchPdbId,
   toDisplayPdbId,
   pdbEntryPayload,
 } from "../components/task/task-elements/pdb-id";
@@ -30,6 +31,17 @@ describe("toShortPdbId", () => {
   it("returns null for a genuinely-extended id beyond the 4-char namespace", () => {
     expect(toShortPdbId("pdb_00abcdef")).toBeNull();
     expect(toShortPdbId("notapdb")).toBeNull();
+  });
+});
+
+describe("toFetchPdbId", () => {
+  it("prefers the legacy 4-char form for entries that have one", () => {
+    expect(toFetchPdbId("1jst")).toBe("1jst");
+    expect(toFetchPdbId("pdb_00001jst")).toBe("1jst");
+    expect(toFetchPdbId("PDB_00001JST")).toBe("1jst");
+  });
+  it("falls back to extended for genuinely-new entries with no legacy form", () => {
+    expect(toFetchPdbId("pdb_00abcdef")).toBe("pdb_00abcdef");
   });
 });
 

--- a/client/renderer/components/task/task-elements/fetch-file-for-param.tsx
+++ b/client/renderer/components/task/task-elements/fetch-file-for-param.tsx
@@ -22,7 +22,7 @@ import {
 } from "./mmcif-sequence-parser";
 import { ChainPickerDialog } from "./chain-picker-dialog";
 import {
-  toExtendedPdbId,
+  toFetchPdbId,
   toShortPdbId,
   toDisplayPdbId,
   pdbEntryPayload,
@@ -180,9 +180,11 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
         // carries Cross-Origin-Resource-Policy: cross-origin and survives
         // the Moorhen COEP page. Direct fetches to www.ebi.ac.uk surface
         // as TypeError: Failed to fetch under COEP.
-        // Query with the extended id (the 4-char endpoints are deprecated);
-        // PDBe keys the response by the legacy 4-char id, so resolve tolerantly.
-        const url = `/api/proxy/pdbe/api/pdb/entry/files/${toExtendedPdbId(identifier)}`;
+        // Query with the host-preferred id (legacy 4-char where it exists): the
+        // PDBe download host only serves the 4-char filename, and the queried
+        // form dictates the download URL the API echoes back. PDBe keys the
+        // response by the legacy id regardless, so resolve tolerantly.
+        const url = `/api/proxy/pdbe/api/pdb/entry/files/${toFetchPdbId(identifier)}`;
         const result = await apiFetch(url);
         const data = await result.json();
         const file = pdbEntryPayload(data, identifier);
@@ -216,9 +218,10 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
   const handleEbiSFsFetch = useCallback(async () => {
     if (identifier) {
       try {
-        // Route through the local proxy (COEP-safe) and query with the extended
-        // id; PDBe keys the response by the legacy 4-char id, so resolve tolerantly.
-        const url = `/api/proxy/pdbe/api/pdb/entry/files/${toExtendedPdbId(identifier)}`;
+        // Route through the local proxy (COEP-safe) and query with the
+        // host-preferred id; the download host serves only the 4-char filename
+        // and PDBe keys the response by the legacy id, so resolve tolerantly.
+        const url = `/api/proxy/pdbe/api/pdb/entry/files/${toFetchPdbId(identifier)}`;
         const result = await apiFetch(url);
         const data = await result.json();
         const file = pdbEntryPayload(data, identifier);
@@ -262,8 +265,9 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
 
   const handleRcsbPdbFetch = useCallback(async () => {
     if (identifier) {
-      // RCSB downloads accept the extended id (the 4-char form is deprecated).
-      const id = toExtendedPdbId(identifier);
+      // RCSB downloads accept both forms; use the host-preferred (legacy where
+      // it exists, extended only for genuinely-new entries).
+      const id = toFetchPdbId(identifier);
       const fetchURL = `https://files.rcsb.org/download/${id}.cif`;
       setMessage(`Fetching coordinates from RCSB for ${id}`);
       try {
@@ -296,8 +300,9 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
   const handleUppsalaEdsFetch = useCallback(async () => {
     // Uppsala EDS was retired in 2017 — fetch from PDB-REDO instead
     if (identifier) {
-      // PDB-REDO accepts the extended id (the 4-char form is deprecated).
-      const id = toExtendedPdbId(identifier);
+      // PDB-REDO serves only the legacy 4-char form (extended 500s), so use the
+      // host-preferred id.
+      const id = toFetchPdbId(identifier);
       const fetchURL = `https://pdb-redo.eu/db/${id}/${id}_final.mtz`;
       setMessage(`Fetching map coefficients from PDB-REDO for ${id}`);
       try {
@@ -355,9 +360,9 @@ export const FetchFileForParam: React.FC<FetchFileForParamProps> = ({
 
       if (source === "ebi") {
         // PDBe molecules API returns structured JSON with sequences per entity.
-        // Query with the extended id; the response is keyed by the legacy id,
+        // Use the host-preferred id; the response is keyed by the legacy id,
         // so parsePdbeMolecules resolves it tolerantly.
-        const url = `https://www.ebi.ac.uk/pdbe/api/pdb/entry/molecules/${toExtendedPdbId(identifier)}`;
+        const url = `https://www.ebi.ac.uk/pdbe/api/pdb/entry/molecules/${toFetchPdbId(identifier)}`;
         const result = await apiFetch(url);
         const data = await result.json();
         chains = parsePdbeMolecules(data, identifier);

--- a/client/renderer/components/task/task-elements/pdb-id.ts
+++ b/client/renderer/components/task/task-elements/pdb-id.ts
@@ -3,21 +3,26 @@
  *
  * The PDB is migrating from the legacy 4-character codes (e.g. `1jst`) to the
  * 12-character extended format `pdb_0000XXXX` (e.g. `pdb_00001jst`), because the
- * 4-character namespace is nearly exhausted. The APIs we call behave as follows
+ * 4-character namespace is nearly exhausted. The hosts we call behave as follows
  * (verified against the live endpoints):
  *
- *   - PDBe `api/pdb/entry/files` and `api/pdb/entry/molecules`: accept BOTH
- *     forms, but always KEY the JSON response by the legacy 4-char id even when
- *     queried with the extended id. So a request for `pdb_00001jst` returns
- *     `{ "1jst": { ... } }`. Tolerant key lookup is therefore mandatory.
+ *   - PDBe `api/pdb/entry/files` and `api/pdb/entry/molecules` (metadata JSON):
+ *     accept BOTH forms, but always KEY the response by the legacy 4-char id
+ *     even when queried with the extended id (`pdb_00001jst` -> `{ "1jst": … }`).
+ *     The download URLs they echo back mirror the queried form.
+ *   - PDBe download host (`entry-files/download`): serves ONLY the legacy 4-char
+ *     filename. `pdb_00001jst.cif` 404s; `1jst.cif` works.
+ *   - PDB-REDO (`pdb-redo.eu/db`): serves ONLY the legacy 4-char form (extended 500s).
+ *   - RCSB FASTA (`rcsb.org/fasta/entry`): accepts ONLY the legacy 4-char form
+ *     (extended 404s).
  *   - RCSB downloads (`files.rcsb.org/download`): accept both forms.
- *   - PDB-REDO (`pdb-redo.eu/db`): accept both forms.
- *   - RCSB FASTA (`rcsb.org/fasta/entry`): accepts ONLY the 4-char form;
- *     the extended form 404s. Use {@link toShortPdbId} for that endpoint.
  *
- * Policy: when an endpoint accepts both, we send the extended (future-proof)
- * form; when an endpoint only accepts the legacy form, we send the short form.
- * Either form may be typed by the user.
+ * So the legacy 4-char form is the universally-working one for entries that have
+ * one; the extended form is needed only for genuinely-new entries beyond the
+ * 4-char namespace (which have no legacy form). Policy: PREFER the legacy form
+ * ({@link toFetchPdbId}), falling back to extended only when no legacy form
+ * exists. Tolerant key lookup ({@link pdbEntryPayload}) absorbs PDBe keying by
+ * the legacy id. Either form may be typed by the user.
  */
 
 /** A legacy 4-char PDB code: a digit followed by three alphanumerics. */
@@ -48,6 +53,18 @@ export function toShortPdbId(raw: string): string | null {
   if (SHORT_RE.test(id)) return id;
   const m = id.match(EXTENDED_LEGACY_RE);
   return m ? m[1] : null;
+}
+
+/**
+ * Id to use when issuing a fetch against any PDB host (API query or file
+ * download). Prefers the legacy 4-char form — the only form the download/file
+ * hosts serve for legacy entries — and falls back to the extended form for
+ * genuinely-new entries that have no legacy form. For PDBe metadata queries the
+ * queried form also dictates the form of the download URLs echoed back, so this
+ * keeps those URLs resolvable.
+ */
+export function toFetchPdbId(raw: string): string {
+  return toShortPdbId(raw) ?? toExtendedPdbId(raw);
 }
 
 /**


### PR DESCRIPTION
Follow-up to #217.

## Problem

After #217, the PDBe coordinate fetch succeeded server-side but failed client-side with **HTTP 404**. #217 made every fetch query the **extended** id form (`pdb_0000XXXX`), on the assumption that the 4-char paths were deprecated. Probing the live hosts shows that's only true of the metadata API — the **file/download hosts have not migrated** and 404/500 on extended filenames for legacy entries.

## Verified host behaviour

| Host | 4-char | extended |
|------|--------|----------|
| PDBe API metadata | ✓ | ✓ (but keys response by 4-char) |
| PDBe **download** (`entry-files/download`) | ✓ | **✗ 404** |
| PDB-REDO | ✓ | **✗ 500** |
| RCSB FASTA | ✓ | **✗ 404** |
| RCSB downloads | ✓ | ✓ |

The PDBe metadata API echoes its download URLs in whatever form it was queried with, so querying `pdb_00001jst` returned a `pdb_00001jst.cif` download URL that 404s on the download host — the reported client-side 404.

## Fix

Replace the "prefer extended" policy with `toFetchPdbId` = **prefer the legacy 4-char form, fall back to extended only when no legacy form exists** (genuinely-new entries beyond the 4-char namespace). The legacy form is the universally-working one for entries that have one; this still fully supports >4-char ids and keeps every legacy fetch working. The tolerant `pdbEntryPayload` lookup is unchanged (PDBe keys responses by the legacy id regardless of query form).

## Tests

`pdb-id.test.ts` extended to 12 cases (adds `toFetchPdbId` legacy-preference + extended-fallback). `tsc --noEmit` clean. End-to-end verified against live hosts: query `1jst` → API returns `1jst.cif` → downloads 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)