### PR TITLE
Moorhen scenes: surface file annotations as labels in the authoring prompt

### DIFF
--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -989,26 +989,17 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   // contents summary of the loaded structure (chains + ligand CIDs, from the
   // coordinate digest). The user appends a request and pastes it into a chatbot.
   const handleBuildAuthoringPrompt = useCallback(async (request: string): Promise<string> => {
-    let contentsBlock = "(no structure loaded)";
     const mol = molecules[0];
-    if (mol) {
-      const fid = extractFileIdFromUniqueId(mol.uniqueId || "");
-      if (fid != null) {
-        try {
-          const resp = await apiGet(`files/${fid}/digest/`);
-          const digest = resp?.data ?? resp;
-          contentsBlock = buildContentsBlock(digest, mol.name || `file_${fid}`);
-        } catch (err) {
-          console.warn("[scene-prompt] digest failed:", err);
-        }
-      }
-    }
+    const fid = mol ? extractFileIdFromUniqueId(mol.uniqueId || "") : null;
+
+    // Project identity + manifest. Resolve the project robustly (prefer the
+    // cached projectInfo, else fetch) so the prompt always pins the current
+    // project, and keep the files list so we can label the loaded structure by
+    // its annotation below.
     let manifestBlock = "(no project context)";
-    // Resolve project identity robustly — prefer the resolved projectInfo, but
-    // fall back to a fresh fetch so the prompt always pins the current project
-    // (otherwise a chat model can drift into a project from earlier context).
     let project: { name?: string; id?: string } | undefined =
       projectInfo ? { name: projectInfo.name, id: projectInfo.id } : undefined;
+    let projectFiles: { id?: number; annotation?: string }[] = [];
     const pk = projectPkRef.current;
     if (pk != null) {
       try {
@@ -1021,12 +1012,30 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
           apiGet(`files/?project=${pk}`),
         ]);
         if (Array.isArray(jobs) && Array.isArray(files)) {
+          projectFiles = files;
           manifestBlock = buildManifestBlock(jobs, files);
         }
       } catch (err) {
         console.warn("[scene-prompt] manifest failed:", err);
       }
     }
+
+    // Contents summary, labelled by the file's annotation where we have one
+    // (e.g. "CDK2-Cyclin A") so the model's selections read against a meaningful
+    // name; fall back to the molecule name, then the file id.
+    let contentsBlock = "(no structure loaded)";
+    if (mol && fid != null) {
+      try {
+        const resp = await apiGet(`files/${fid}/digest/`);
+        const digest = resp?.data ?? resp;
+        const annotation = projectFiles.find((f) => f.id === fid)?.annotation;
+        const label = annotation || mol.name || `file_${fid}`;
+        contentsBlock = buildContentsBlock(digest, label);
+      } catch (err) {
+        console.warn("[scene-prompt] digest failed:", err);
+      }
+    }
+
     return buildAuthoringPrompt({ project, contents: contentsBlock, manifest: manifestBlock, request });
   }, [molecules, projectInfo]);
 

--- a/client/renderer/lib/moorhen-scene-prompt.ts
+++ b/client/renderer/lib/moorhen-scene-prompt.ts
@@ -99,7 +99,9 @@ export function buildManifestBlock(
   if (byJob.size === 0) return "No referenceable job outputs in this project yet.";
 
   const lines: string[] = [];
-  lines.push("Referenceable files (use { job: <number>, param: <PARAM>, projectId }):");
+  lines.push("Reference files by { job: <number>, param: <PARAM>, projectId }.");
+  lines.push('A quoted name (e.g. — "CDK2") is a human label to help you choose the');
+  lines.push("right file; it is NOT a reference key — always reference by job + param.");
   // stable order by job number (numeric-ish)
   const jobPks = [...byJob.keys()].sort((a, b) => {
     const na = parseFloat(jobByPk.get(a)?.number ?? "0");
@@ -112,7 +114,10 @@ export function buildManifestBlock(
     lines.push(header);
     for (const f of byJob.get(pk)!) {
       const mask = f.sub_type === 4 ? ", mask" : "";
-      lines.push(`    - param ${f.job_param_name} -> ${f.type}${mask}`);
+      // The annotation is a human label (e.g. "CDK2-Cyclin A") to help pick the
+      // right file — it is NOT how the file is referenced (use job + param).
+      const ann = f.annotation ? `  — "${f.annotation}"` : "";
+      lines.push(`    - param ${f.job_param_name} -> ${f.type}${mask}${ann}`);
     }
   }
   return lines.join("\n");


### PR DESCRIPTION
File annotations (e.g. "CDK2", "CDK2–Cyclin A") that a user puts on imported coordinates are a great human hint for picking the right file in a project. Surface them in the authoring prompt — as **labels only**, never as a reference key, since annotations aren't unique. The model still references files by the unique `job` + `param`.

- **Manifest** lines now carry the annotation: `param XYZOUT -> coords — "CDK2–Cyclin A"`, with a header note that the quoted name is a label to help choose, **not** a reference key.
- **Contents block** labels the loaded structure by its file annotation where there is one (falls back to molecule name, then file id). The wrapper now fetches the project files before building the contents block so it can look the annotation up.

**Zero ambiguity risk** — annotations drive comprehension, not resolution. The uniqueness-guarded annotation *ref* form (`{ annotation: "CDK2" }` resolving only when unique, erroring with candidate job/params otherwise) was discussed and **deliberately deferred** until real use shows the labels alone aren't enough.

`tsc` clean.