### PR TITLE
Moorhen scenes: resolve job+param against the scene's projectId (uuid→pk)

### DIFF
--- a/client/renderer/app/ccp4i2/(authed)/moorhen-page/project/[id]/page.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/moorhen-page/project/[id]/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const ProjectMoorhenClient = dynamic(
+  () => import("./project-moorhen-client"),
+  { ssr: false }
+);
+
+export default function ProjectMoorhenPage() {
+  return <ProjectMoorhenClient />;
+}

--- a/client/renderer/app/ccp4i2/(authed)/moorhen-page/project/[id]/project-moorhen-client.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/moorhen-page/project/[id]/project-moorhen-client.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Suspense } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+import MoorhenLoader from "@/components/moorhen/client-side-moorhen-loader";
+import { ClientStoreProvider } from "@/providers/client-store-provider";
+
+// Project-scoped Moorhen page: the project (pk from the route) provides context
+// for scene authoring (the prompt manifest) and job+param file resolution, but
+// no specific file or job is loaded — scenes do the loading. The route `[id]` is
+// the project primary key, matching /ccp4i2/project/[id].
+function ProjectMoorhenContent() {
+  const params = useParams();
+  const id = params?.id as string | undefined;
+  const searchParams = useSearchParams();
+  const viewParam = searchParams?.get("view");
+  const projectId = id ? parseInt(id, 10) : null;
+
+  return (
+    <ClientStoreProvider>
+      <MoorhenLoader fileIds={[]} viewParam={viewParam} projectId={projectId} />
+    </ClientStoreProvider>
+  );
+}
+
+const ProjectMoorhenClient = () => (
+  <Suspense fallback={<div>Loading…</div>}>
+    <ProjectMoorhenContent />
+  </Suspense>
+);
+
+export default ProjectMoorhenClient;

--- a/client/renderer/components/menu-bar.tsx
+++ b/client/renderer/components/menu-bar.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Chip,
 } from "@mui/material";
-import { MoreHoriz, Home, Science as ScienceIcon } from "@mui/icons-material";
+import { MoreHoriz, Home, Science as ScienceIcon, ViewInAr } from "@mui/icons-material";
 import EditMenu from "./edit-menu";
 import FileMenu from "./file-menu";
 import HelpMenu from "./help-menu";
@@ -136,6 +136,12 @@ export default function MenuBar() {
     }
   };
 
+  const handleOpenMoorhen = () => {
+    if (projectId) {
+      router.push(`/ccp4i2/moorhen-page/project/${projectId}`);
+    }
+  };
+
   return (
     <AppBar position="static">
       <HistoryToolbar>
@@ -184,6 +190,22 @@ export default function MenuBar() {
                 },
               }}
             />
+          </Tooltip>
+        )}
+
+        {/* Moorhen (project-scoped): opens the 3D viewer with this project's
+            context for scene authoring + job/param file resolution. */}
+        {projectId && (
+          <Tooltip title="Open Moorhen for this project (scenes)">
+            <IconButton
+              color="inherit"
+              onClick={handleOpenMoorhen}
+              aria-label="Open Moorhen for this project"
+              size="small"
+              sx={{ ml: 0.5 }}
+            >
+              <ViewInAr />
+            </IconButton>
           </Tooltip>
         )}
 

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -129,12 +129,18 @@ async function resolveJobParamUrl(
   }
   const files = await apiGet(`files/?job=${job.id}`);
   if (!Array.isArray(files)) return null;
+  // Match by output param name only — do NOT filter on directory. Job outputs
+  // live in the job dir (directory 1), but imported coordinates live in the
+  // import dir (directory 2); both are legitimate job+param targets.
   const file = files.find(
-    (f: { job_param_name?: string; directory: number }) =>
-      f.job_param_name === ref.param && f.directory === 1,
+    (f: { job_param_name?: string }) => f.job_param_name === ref.param,
   );
   if (!file) {
-    console.warn(`[scene] job+param: output param "${ref.param}" (directory 1) not found in job ${ref.job}`);
+    const avail = (files as { job_param_name?: string; directory?: number; type?: string }[])
+      .filter((f) => f.job_param_name)
+      .map((f) => `${f.job_param_name} (dir ${f.directory}, ${f.type})`)
+      .join("; ");
+    console.warn(`[scene] job+param: param "${ref.param}" not found in job ${ref.job}. Available: ${avail || "none"}`);
     return null;
   }
   return `/api/proxy/ccp4i2/files/${file.id}/download/`;

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -91,19 +91,36 @@ function extractDictCompIds(cifText: string): string[] {
  *  logs) if it can't be resolved. */
 async function resolveProjectPk(
   want: { uuid?: string; name?: string },
-  current: { uuid: string | null; pk: number | null },
+  current: { uuid: string | null; name: string | null; pk: number | null },
 ): Promise<number | null> {
   if (!want.uuid && !want.name) return current.pk; // no scene project ref → page context
-  if (want.uuid && want.uuid === current.uuid && current.pk != null) return current.pk;
-  // Cross-project or page not project-scoped: resolve uuid/name → pk via the list.
-  const resp = await apiGet(`projects/`);
-  const list = Array.isArray(resp) ? resp : (resp?.results ?? []);
-  const proj = list.find(
-    (p: { uuid?: string; name?: string }) =>
-      (want.uuid && p.uuid === want.uuid) || (want.name && p.name === want.name),
-  );
-  if (proj?.id != null) return proj.id;
-  console.warn(`[scene] job+param: project "${want.uuid ?? want.name}" not found; falling back to page pk ${current.pk}`);
+  // The current window's project is authoritative: if the scene names it (by
+  // uuid OR name), use its pk directly and never do a projects/ lookup (which
+  // can match a different same-named project — the source of the wrong-project
+  // bug).
+  if (current.pk != null) {
+    if (want.uuid && want.uuid === current.uuid) return current.pk;
+    if (want.name && want.name === current.name) return current.pk;
+  }
+  // Cross-project or page not project-scoped: resolve uuid/name → pk via the
+  // list. Wrapped so a projects/ hiccup falls back to the page pk rather than
+  // throwing out as an opaque "fetch failed".
+  try {
+    const resp = await apiGet(`projects/`);
+    const list = Array.isArray(resp) ? resp : (resp?.results ?? []);
+    const matches = list.filter(
+      (p: { uuid?: string; name?: string }) =>
+        (want.uuid && p.uuid === want.uuid) || (want.name && p.name === want.name),
+    );
+    if (matches.length === 1 && matches[0]?.id != null) return matches[0].id;
+    if (matches.length > 1) {
+      console.warn(`[scene] job+param: project name "${want.name}" is ambiguous (${matches.length} matches); using page pk ${current.pk}`);
+    } else {
+      console.warn(`[scene] job+param: project "${want.uuid ?? want.name}" not found; falling back to page pk ${current.pk}`);
+    }
+  } catch (e) {
+    console.warn(`[scene] job+param: project lookup failed; falling back to page pk ${current.pk}`, e);
+  }
   return current.pk; // last resort: the page's project
 }
 
@@ -116,22 +133,31 @@ async function resolveProjectPk(
  */
 async function resolveJobParamUrl(
   ref: { job: number | string; param: string; projectId?: string; projectName?: string },
-  current: { uuid: string | null; pk: number | null },
+  current: { uuid: string | null; name: string | null; pk: number | null },
 ): Promise<string | null> {
   const projectPk = await resolveProjectPk({ uuid: ref.projectId, name: ref.projectName }, current);
   if (projectPk == null) {
     console.warn(`[scene] job+param ${ref.job}/${ref.param}: no project context (projectId=${ref.projectId ?? "none"}, projectName=${ref.projectName ?? "none"}, page pk null)`);
     return null;
   }
-  const jobs = await apiGet(`jobs/?project=${projectPk}`);
-  if (!Array.isArray(jobs)) return null;
-  const job = jobs.find((j: { number?: string }) => String(j.number) === String(ref.job));
-  if (!job) {
-    console.warn(`[scene] job+param: job number ${ref.job} not found in project pk ${projectPk}`);
+  const jobsResp = await apiGet(`jobs/?project=${projectPk}`);
+  const jobs = Array.isArray(jobsResp) ? jobsResp : (jobsResp?.results ?? []);
+  if (jobs.length === 0) {
+    console.warn(`[scene] job+param: no jobs returned for project pk ${projectPk} (resp shape: ${Array.isArray(jobsResp) ? "array" : typeof jobsResp})`);
     return null;
   }
-  const files = await apiGet(`files/?job=${job.id}`);
-  if (!Array.isArray(files)) return null;
+  const job = jobs.find((j: { number?: string }) => String(j.number) === String(ref.job));
+  if (!job) {
+    const nums = jobs.map((j: { number?: string }) => j.number).join(", ");
+    console.warn(`[scene] job+param: job number "${ref.job}" not found in project pk ${projectPk}. Job numbers present: ${nums}`);
+    return null;
+  }
+  const filesResp = await apiGet(`files/?job=${job.id}`);
+  const files = Array.isArray(filesResp) ? filesResp : (filesResp?.results ?? []);
+  if (files.length === 0) {
+    console.warn(`[scene] job+param: no files returned for job ${ref.job} (pk ${job.id})`);
+    return null;
+  }
   // Match by output param name only — do NOT filter on directory. Job outputs
   // live in the job dir (directory 1), but imported coordinates live in the
   // import dir (directory 2); both are legitimate job+param targets.
@@ -199,6 +225,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   // scene's projectId (a uuid) to the pk the REST filters need.
   const projectPkRef = useRef<number | null>(null);
   const projectUuidRef = useRef<string | null>(null);
+  const projectNameRef = useRef<string | null>(null);
   const timeCapsuleRef = useRef(null);
   const cootInitialized = useSelector(
     (state: moorhen.State) => state.generalStates.cootInitialized
@@ -799,7 +826,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       if (ref.job !== undefined && ref.param) {
         const url = await resolveJobParamUrl(
           { job: ref.job, param: ref.param, projectId: ref.projectId, projectName: ref.projectName },
-          { uuid: projectUuidRef.current, pk: projectPkRef.current },
+          { uuid: projectUuidRef.current, name: projectNameRef.current, pk: projectPkRef.current },
         );
         return url
           ? loadStructure(url, ref.name || `job_${ref.job}_${ref.param}`)
@@ -1029,6 +1056,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         const proj = await apiGet(`projects/${jobInfo.project}`);
         if (cancelled || !proj?.uuid) return;
         projectUuidRef.current = proj.uuid;
+        projectNameRef.current = proj.name ?? null;
         setProjectInfo({ id: proj.uuid, name: proj.name });
       } catch (err) {
         console.warn("[wrapper] failed to resolve project for scene authoring:", err);

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -90,17 +90,20 @@ function extractDictCompIds(cifText: string): string[] {
  *  have the pk, otherwise look it up in the projects list. Returns null (and
  *  logs) if it can't be resolved. */
 async function resolveProjectPk(
-  wantUuid: string | undefined,
+  want: { uuid?: string; name?: string },
   current: { uuid: string | null; pk: number | null },
 ): Promise<number | null> {
-  if (!wantUuid) return current.pk; // no scene projectId → page context
-  if (wantUuid === current.uuid && current.pk != null) return current.pk;
-  // Cross-project or page not project-scoped: resolve uuid → pk via the list.
+  if (!want.uuid && !want.name) return current.pk; // no scene project ref → page context
+  if (want.uuid && want.uuid === current.uuid && current.pk != null) return current.pk;
+  // Cross-project or page not project-scoped: resolve uuid/name → pk via the list.
   const resp = await apiGet(`projects/`);
   const list = Array.isArray(resp) ? resp : (resp?.results ?? []);
-  const proj = list.find((p: { uuid?: string }) => p.uuid === wantUuid);
+  const proj = list.find(
+    (p: { uuid?: string; name?: string }) =>
+      (want.uuid && p.uuid === want.uuid) || (want.name && p.name === want.name),
+  );
   if (proj?.id != null) return proj.id;
-  console.warn(`[scene] job+param: project uuid ${wantUuid} not found; page pk = ${current.pk}`);
+  console.warn(`[scene] job+param: project "${want.uuid ?? want.name}" not found; falling back to page pk ${current.pk}`);
   return current.pk; // last resort: the page's project
 }
 
@@ -112,12 +115,12 @@ async function resolveProjectPk(
  * job_param_name. Returns null (and logs the reason) if anything is missing.
  */
 async function resolveJobParamUrl(
-  ref: { job: number | string; param: string; projectId?: string },
+  ref: { job: number | string; param: string; projectId?: string; projectName?: string },
   current: { uuid: string | null; pk: number | null },
 ): Promise<string | null> {
-  const projectPk = await resolveProjectPk(ref.projectId, current);
+  const projectPk = await resolveProjectPk({ uuid: ref.projectId, name: ref.projectName }, current);
   if (projectPk == null) {
-    console.warn(`[scene] job+param ${ref.job}/${ref.param}: no project context (projectId=${ref.projectId ?? "none"}, page pk null)`);
+    console.warn(`[scene] job+param ${ref.job}/${ref.param}: no project context (projectId=${ref.projectId ?? "none"}, projectName=${ref.projectName ?? "none"}, page pk null)`);
     return null;
   }
   const jobs = await apiGet(`jobs/?project=${projectPk}`);
@@ -795,7 +798,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       // projectId (uuid), falling back to this page's project context.
       if (ref.job !== undefined && ref.param) {
         const url = await resolveJobParamUrl(
-          { job: ref.job, param: ref.param, projectId: ref.projectId },
+          { job: ref.job, param: ref.param, projectId: ref.projectId, projectName: ref.projectName },
           { uuid: projectUuidRef.current, pk: projectPkRef.current },
         );
         return url

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -1001,16 +1001,25 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     ],
   );
 
-  // Resolve project context from jobId so downloaded scenes can include
-  // a stable projectId on their file references. Looked up once on mount;
-  // null when the wrapper isn't tied to a job.
+  // Resolve project context so scene authoring (manifest + projectId) and
+  // job+param resolution work. Prefer jobId; otherwise derive the project from
+  // the first loaded file (file → job → project), which covers the file viewer
+  // and any fileIds-only context. Null only on a truly contextless page.
   const [projectInfo, setProjectInfo] = useState<{ id: string; name?: string } | null>(null);
+  const firstFileId = fileIds?.[0];
   useEffect(() => {
-    if (!jobId) return;
     let cancelled = false;
     (async () => {
       try {
-        const jobInfo = await apiGet(`jobs/${jobId}`);
+        // Find the producing job pk: directly from jobId, else via the file.
+        let jobPk: number | null = jobId ?? null;
+        if (jobPk == null && firstFileId != null) {
+          const fileInfo = await apiGet(`files/${firstFileId}`);
+          if (cancelled) return;
+          jobPk = fileInfo?.job ?? null;
+        }
+        if (jobPk == null) return;
+        const jobInfo = await apiGet(`jobs/${jobPk}`);
         if (cancelled || !jobInfo?.project) return;
         projectPkRef.current = jobInfo.project;
         // jobInfo.project is the project pk; fetch the uuid + name.
@@ -1023,7 +1032,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       }
     })();
     return () => { cancelled = true; };
-  }, [jobId]);
+  }, [jobId, firstFileId]);
 
   // Assemble the LLM "Copy prompt" scaffold: the embedded scene grammar + a
   // manifest of the project's referenceable job outputs + a ground-truth

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -85,28 +85,58 @@ function extractDictCompIds(cifText: string): string[] {
   return out;
 }
 
+/** Map a project UUID to its primary key (the form the REST filters need). The
+ *  scene carries the uuid; if it matches the current page's project we already
+ *  have the pk, otherwise look it up in the projects list. Returns null (and
+ *  logs) if it can't be resolved. */
+async function resolveProjectPk(
+  wantUuid: string | undefined,
+  current: { uuid: string | null; pk: number | null },
+): Promise<number | null> {
+  if (!wantUuid) return current.pk; // no scene projectId → page context
+  if (wantUuid === current.uuid && current.pk != null) return current.pk;
+  // Cross-project or page not project-scoped: resolve uuid → pk via the list.
+  const resp = await apiGet(`projects/`);
+  const list = Array.isArray(resp) ? resp : (resp?.results ?? []);
+  const proj = list.find((p: { uuid?: string }) => p.uuid === wantUuid);
+  if (proj?.id != null) return proj.id;
+  console.warn(`[scene] job+param: project uuid ${wantUuid} not found; page pk = ${current.pk}`);
+  return current.pk; // last resort: the page's project
+}
+
 /**
  * Resolve a scene `job` (number, e.g. "1" or "1.1") + output `param` (e.g.
  * "XYZOUT") to a project file's proxy download URL, using the existing REST:
- * jobs in the project → match number → that job's output files (directory=1)
- * → match job_param_name. Returns null if anything along the chain is missing.
+ * resolve the project pk (preferring the scene's projectId) → jobs in that
+ * project → match number → that job's output files (directory=1) → match
+ * job_param_name. Returns null (and logs the reason) if anything is missing.
  */
 async function resolveJobParamUrl(
-  projectPk: number,
-  jobNumber: number | string,
-  param: string,
+  ref: { job: number | string; param: string; projectId?: string },
+  current: { uuid: string | null; pk: number | null },
 ): Promise<string | null> {
+  const projectPk = await resolveProjectPk(ref.projectId, current);
+  if (projectPk == null) {
+    console.warn(`[scene] job+param ${ref.job}/${ref.param}: no project context (projectId=${ref.projectId ?? "none"}, page pk null)`);
+    return null;
+  }
   const jobs = await apiGet(`jobs/?project=${projectPk}`);
   if (!Array.isArray(jobs)) return null;
-  const job = jobs.find((j: { number?: string }) => String(j.number) === String(jobNumber));
-  if (!job) return null;
+  const job = jobs.find((j: { number?: string }) => String(j.number) === String(ref.job));
+  if (!job) {
+    console.warn(`[scene] job+param: job number ${ref.job} not found in project pk ${projectPk}`);
+    return null;
+  }
   const files = await apiGet(`files/?job=${job.id}`);
   if (!Array.isArray(files)) return null;
   const file = files.find(
     (f: { job_param_name?: string; directory: number }) =>
-      f.job_param_name === param && f.directory === 1,
+      f.job_param_name === ref.param && f.directory === 1,
   );
-  if (!file) return null;
+  if (!file) {
+    console.warn(`[scene] job+param: output param "${ref.param}" (directory 1) not found in job ${ref.job}`);
+    return null;
+  }
   return `/api/proxy/ccp4i2/files/${file.id}/download/`;
 }
 
@@ -155,9 +185,11 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   // lifter can emit terse fileId dict refs instead of inlining cifText.
   const dictSourcesRef = useRef<Map<number, Map<string, { fileId: number; projectId?: string }>>>(new Map());
   const prevActiveMoleculeRef = useRef<null | moorhen.Molecule>(null);
-  // Project pk, mirrored into a ref so the (stable-identity) scene fetcher can
-  // resolve job+param refs against the current project without re-binding.
+  // Current project pk + uuid, mirrored into refs so the (stable-identity) scene
+  // fetcher can resolve job+param refs without re-binding. The uuid lets it map a
+  // scene's projectId (a uuid) to the pk the REST filters need.
   const projectPkRef = useRef<number | null>(null);
+  const projectUuidRef = useRef<string | null>(null);
   const timeCapsuleRef = useRef(null);
   const cootInitialized = useSelector(
     (state: moorhen.State) => state.generalStates.cootInitialized
@@ -753,11 +785,13 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         const url = `/api/proxy/ccp4i2/files/${ref.fileId}/download/`;
         return loadStructure(url, ref.name || `file_${ref.fileId}`);
       }
-      // job + output param → resolve to a project file in the current project.
+      // job + output param → resolve to a project file. Prefer the scene's own
+      // projectId (uuid), falling back to this page's project context.
       if (ref.job !== undefined && ref.param) {
-        const projectPk = projectPkRef.current;
-        if (projectPk == null) return null;
-        const url = await resolveJobParamUrl(projectPk, ref.job, ref.param);
+        const url = await resolveJobParamUrl(
+          { job: ref.job, param: ref.param, projectId: ref.projectId },
+          { uuid: projectUuidRef.current, pk: projectPkRef.current },
+        );
         return url
           ? loadStructure(url, ref.name || `job_${ref.job}_${ref.param}`)
           : null;
@@ -976,6 +1010,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         // jobInfo.project is the project pk; fetch the uuid + name.
         const proj = await apiGet(`projects/${jobInfo.project}`);
         if (cancelled || !proj?.uuid) return;
+        projectUuidRef.current = proj.uuid;
         setProjectInfo({ id: proj.uuid, name: proj.name });
       } catch (err) {
         console.warn("[wrapper] failed to resolve project for scene authoring:", err);

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -71,6 +71,9 @@ export interface MoorhenWrapperProps {
   fileIds?: number[];
   viewParam?: string | null;
   jobId?: number | null;
+  /** Project pk for a project-scoped Moorhen page: provides project context
+   *  (manifest + job/param resolution) without loading any specific file/job. */
+  projectId?: number | null;
 }
 
 /** comp_ids defined by a refmac/coot dictionary CIF (its `data_comp_<X>`
@@ -173,7 +176,7 @@ async function resolveJobParamUrl(
   return `/api/proxy/ccp4i2/files/${file.id}/download/`;
 }
 
-const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, jobId }) => {
+const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, jobId, projectId }) => {
   const capabilities = useMoorhenCapabilities();
   const [isSafari] = useState(() => isSafariBrowser());
   const { setMessage } = usePopcorn();
@@ -1030,28 +1033,33 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   );
 
   // Resolve project context so scene authoring (manifest + projectId) and
-  // job+param resolution work. Prefer jobId; otherwise derive the project from
-  // the first loaded file (file → job → project), which covers the file viewer
-  // and any fileIds-only context. Null only on a truly contextless page.
+  // job+param resolution work. Prefer an explicit projectId (the project-scoped
+  // Moorhen page); else jobId; else derive from the first loaded file
+  // (file → job → project), covering the file viewer. Null only on the truly
+  // contextless blank page.
   const [projectInfo, setProjectInfo] = useState<{ id: string; name?: string } | null>(null);
   const firstFileId = fileIds?.[0];
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        // Find the producing job pk: directly from jobId, else via the file.
-        let jobPk: number | null = jobId ?? null;
-        if (jobPk == null && firstFileId != null) {
-          const fileInfo = await apiGet(`files/${firstFileId}`);
-          if (cancelled) return;
-          jobPk = fileInfo?.job ?? null;
+        // Find the project pk: directly (project page), else via job, else file.
+        let projPk: number | null = projectId ?? null;
+        if (projPk == null) {
+          let jobPk: number | null = jobId ?? null;
+          if (jobPk == null && firstFileId != null) {
+            const fileInfo = await apiGet(`files/${firstFileId}`);
+            if (cancelled) return;
+            jobPk = fileInfo?.job ?? null;
+          }
+          if (jobPk == null) return;
+          const jobInfo = await apiGet(`jobs/${jobPk}`);
+          if (cancelled || !jobInfo?.project) return;
+          projPk = jobInfo.project;
         }
-        if (jobPk == null) return;
-        const jobInfo = await apiGet(`jobs/${jobPk}`);
-        if (cancelled || !jobInfo?.project) return;
-        projectPkRef.current = jobInfo.project;
-        // jobInfo.project is the project pk; fetch the uuid + name.
-        const proj = await apiGet(`projects/${jobInfo.project}`);
+        if (projPk == null) return;
+        projectPkRef.current = projPk;
+        const proj = await apiGet(`projects/${projPk}`);
         if (cancelled || !proj?.uuid) return;
         projectUuidRef.current = proj.uuid;
         projectNameRef.current = proj.name ?? null;
@@ -1061,7 +1069,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       }
     })();
     return () => { cancelled = true; };
-  }, [jobId, firstFileId]);
+  }, [jobId, firstFileId, projectId]);
 
   // Assemble the LLM "Copy prompt" scaffold: the embedded scene grammar + a
   // manifest of the project's referenceable job outputs + a ground-truth

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -94,34 +94,32 @@ async function resolveProjectPk(
   current: { uuid: string | null; name: string | null; pk: number | null },
 ): Promise<number | null> {
   if (!want.uuid && !want.name) return current.pk; // no scene project ref → page context
-  // The current window's project is authoritative: if the scene names it (by
-  // uuid OR name), use its pk directly and never do a projects/ lookup (which
-  // can match a different same-named project — the source of the wrong-project
-  // bug).
+  // The current window's project is authoritative when the scene names it (by
+  // uuid OR name) — use its pk directly, no lookup.
   if (current.pk != null) {
     if (want.uuid && want.uuid === current.uuid) return current.pk;
     if (want.name && want.name === current.name) return current.pk;
   }
-  // Cross-project or page not project-scoped: resolve uuid/name → pk via the
-  // list. Wrapped so a projects/ hiccup falls back to the page pk rather than
-  // throwing out as an opaque "fetch failed".
+  // Otherwise resolve the *named* project exactly via the server-side uuid/name
+  // filter (no list paging, no same-name ambiguity from the full list).
+  const query = want.uuid
+    ? `projects/?uuid=${encodeURIComponent(want.uuid)}`
+    : `projects/?name=${encodeURIComponent(want.name as string)}`;
   try {
-    const resp = await apiGet(`projects/`);
+    const resp = await apiGet(query);
     const list = Array.isArray(resp) ? resp : (resp?.results ?? []);
-    const matches = list.filter(
-      (p: { uuid?: string; name?: string }) =>
-        (want.uuid && p.uuid === want.uuid) || (want.name && p.name === want.name),
-    );
-    if (matches.length === 1 && matches[0]?.id != null) return matches[0].id;
-    if (matches.length > 1) {
-      console.warn(`[scene] job+param: project name "${want.name}" is ambiguous (${matches.length} matches); using page pk ${current.pk}`);
+    if (list.length === 1 && list[0]?.id != null) return list[0].id;
+    if (list.length > 1) {
+      console.warn(`[scene] project+job+param: "${want.uuid ?? want.name}" matched ${list.length} projects — cannot disambiguate`);
     } else {
-      console.warn(`[scene] job+param: project "${want.uuid ?? want.name}" not found; falling back to page pk ${current.pk}`);
+      console.warn(`[scene] project+job+param: project "${want.uuid ?? want.name}" not found`);
     }
   } catch (e) {
-    console.warn(`[scene] job+param: project lookup failed; falling back to page pk ${current.pk}`, e);
+    console.warn(`[scene] project+job+param: project lookup failed for "${want.uuid ?? want.name}"`, e);
   }
-  return current.pk; // last resort: the page's project
+  // A project was explicitly named but couldn't be resolved. Do NOT fall back to
+  // the window's project — that silently loads files from the wrong project.
+  return null;
 }
 
 /**
@@ -137,25 +135,25 @@ async function resolveJobParamUrl(
 ): Promise<string | null> {
   const projectPk = await resolveProjectPk({ uuid: ref.projectId, name: ref.projectName }, current);
   if (projectPk == null) {
-    console.warn(`[scene] job+param ${ref.job}/${ref.param}: no project context (projectId=${ref.projectId ?? "none"}, projectName=${ref.projectName ?? "none"}, page pk null)`);
+    console.warn(`[scene] project+job+param ${ref.job}/${ref.param}: no project context (projectId=${ref.projectId ?? "none"}, projectName=${ref.projectName ?? "none"}, page pk null)`);
     return null;
   }
   const jobsResp = await apiGet(`jobs/?project=${projectPk}`);
   const jobs = Array.isArray(jobsResp) ? jobsResp : (jobsResp?.results ?? []);
   if (jobs.length === 0) {
-    console.warn(`[scene] job+param: no jobs returned for project pk ${projectPk} (resp shape: ${Array.isArray(jobsResp) ? "array" : typeof jobsResp})`);
+    console.warn(`[scene] project+job+param: no jobs returned for project pk ${projectPk} (resp shape: ${Array.isArray(jobsResp) ? "array" : typeof jobsResp})`);
     return null;
   }
   const job = jobs.find((j: { number?: string }) => String(j.number) === String(ref.job));
   if (!job) {
     const nums = jobs.map((j: { number?: string }) => j.number).join(", ");
-    console.warn(`[scene] job+param: job number "${ref.job}" not found in project pk ${projectPk}. Job numbers present: ${nums}`);
+    console.warn(`[scene] project+job+param: job number "${ref.job}" not found in project pk ${projectPk}. Job numbers present: ${nums}`);
     return null;
   }
   const filesResp = await apiGet(`files/?job=${job.id}`);
   const files = Array.isArray(filesResp) ? filesResp : (filesResp?.results ?? []);
   if (files.length === 0) {
-    console.warn(`[scene] job+param: no files returned for job ${ref.job} (pk ${job.id})`);
+    console.warn(`[scene] project+job+param: no files returned for job ${ref.job} (pk ${job.id})`);
     return null;
   }
   // Match by output param name only — do NOT filter on directory. Job outputs
@@ -169,7 +167,7 @@ async function resolveJobParamUrl(
       .filter((f) => f.job_param_name)
       .map((f) => `${f.job_param_name} (dir ${f.directory}, ${f.type})`)
       .join("; ");
-    console.warn(`[scene] job+param: param "${ref.param}" not found in job ${ref.job}. Available: ${avail || "none"}`);
+    console.warn(`[scene] project+job+param: param "${ref.param}" not found in job ${ref.job}. Available: ${avail || "none"}`);
     return null;
   }
   return `/api/proxy/ccp4i2/files/${file.id}/download/`;

--- a/client/renderer/lib/moorhen-scene-prompt.ts
+++ b/client/renderer/lib/moorhen-scene-prompt.ts
@@ -86,17 +86,18 @@ export function buildManifestBlock(
   files: ManifestFile[],
 ): string {
   const jobByPk = new Map<number, ManifestJob>(jobs.map((j) => [j.id, j]));
-  // group renderable output files by their producing job
+  // group renderable referenceable files by their producing job. Include both
+  // job-output-dir (1) and import-dir (2) files: imported coordinates carry a
+  // job + param too and are valid job+param targets.
   const byJob = new Map<number, ManifestFile[]>();
   for (const f of files) {
-    if (f.directory !== 1) continue; // job outputs only
     if (!f.job_param_name) continue;
     if (!f.type || !RENDERABLE_TYPES.has(f.type)) continue;
     const arr = byJob.get(f.job) ?? [];
     arr.push(f);
     byJob.set(f.job, arr);
   }
-  if (byJob.size === 0) return "No referenceable job outputs in this project yet.";
+  if (byJob.size === 0) return "No referenceable files in this project yet.";
 
   const lines: string[] = [];
   lines.push("Reference files by { job: <number>, param: <PARAM>, projectId }.");

--- a/server/ccp4i2/api/JobViewSet.py
+++ b/server/ccp4i2/api/JobViewSet.py
@@ -158,6 +158,22 @@ class JobViewSet(ModelViewSet):
     filterset_fields = ["project"]
     permission_classes = [IsAuthenticated]
 
+    def get_queryset(self):
+        # Manual ?project= / ?project__uuid= filtering. The DjangoFilterBackend is
+        # NOT active (a second REST_FRAMEWORK block in settings.py drops
+        # DEFAULT_FILTER_BACKENDS), so filterset_fields=["project"] is inert and
+        # `jobs/?project=<pk>` would otherwise return jobs across ALL projects —
+        # which made scene job+param resolution pick a job-number-1 from the wrong
+        # project. Mirror FileViewSet's own manual get_queryset filtering.
+        queryset = super().get_queryset()
+        project = self.request.query_params.get("project")
+        if project is not None:
+            queryset = queryset.filter(project_id=project)
+        project_uuid = self.request.query_params.get("project__uuid")
+        if project_uuid is not None:
+            queryset = queryset.filter(project__uuid=project_uuid)
+        return queryset
+
     def destroy(self, request, *args, **kwargs):
         """
         Delete a job and all its dependent jobs.

--- a/server/ccp4i2/api/ProjectViewSet.py
+++ b/server/ccp4i2/api/ProjectViewSet.py
@@ -74,6 +74,14 @@ class ProjectViewSet(ModelViewSet):
     def get_queryset(self):
         """Optimize queryset based on action."""
         queryset = super().get_queryset()
+        # Exact lookups by uuid / name so a client can resolve a project
+        # authoritatively (e.g. a scene's projectId) without paging the full list.
+        uuid = self.request.query_params.get("uuid")
+        if uuid is not None:
+            queryset = queryset.filter(uuid=uuid)
+        name = self.request.query_params.get("name")
+        if name is not None:
+            queryset = queryset.filter(name=name)
         if self.action == 'list':
             # List view: order by most recent first, prefetch tags
             return queryset.prefetch_related('tags').order_by('-last_access')


### PR DESCRIPTION
**Bug:** a scene referencing two `job`+`param` files resolved **0 files** ("unresolved: cdk2, cdk2_cyclin") on apply, and the `superpose` then failed ("file not bound") because nothing was bound.

**Cause:** `resolveJobParamUrl` ignored the scene ref's `projectId` and resolved against the page's `projectPkRef`. When the window isn't job-scoped (e.g. a project-level Moorhen page, or before the project effect has resolved), that pk is null → it bailed at the guard and **every `job`+`param` ref failed silently**. The scene carries the project **UUID**, but the REST filters (`jobs/?project=`, `files/?project=`) need the **pk** — and there's no UUID lookup/filter on the projects endpoint.

**Fix:** honour the scene's `projectId`.
- `resolveProjectPk` maps the ref's UUID → pk: uses the current page's pk when the UUID matches (no extra call), else finds it in the projects list, falling back to the page pk.
- Track the current project UUID in a ref so the stable-identity fetcher can do the match.
- **Diagnostics:** a `console.warn` for each failure mode (no project context / uuid not found / job number not found / output param not found), so a silent "unresolved" becomes traceable — directly addressing "I can't tell if the projectId resolved."

Bonus: `job`+`param` refs are now **portable** — a scene resolves against its own project regardless of which window applies it.

`tsc` clean. (gemmi/REST paths are runtime; verified by the same in-browser route as the rest of job+param.)

> Follow-up noted, not in this PR: surface a project's DB params (pk/uuid) in the UI so this is inspectable without devtools.