### PR TITLE
api: restore DEFAULT_FILTER_BACKENDS (filterset_fields was inert API-wide)

### DIFF
--- a/server/ccp4i2/config/settings.py
+++ b/server/ccp4i2/config/settings.py
@@ -98,9 +98,11 @@ elif DEBUG:  # noqa: F821 — DEBUG is defined earlier in this settings file.
     MIDDLEWARE.insert(0, "ccp4i2_api.middleware.dev_admin.DevAdminMiddleware")
 # else: no auth middleware. AnonymousUser + DRF IsAuthenticated → 401.
 
-REST_FRAMEWORK = {
-    "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"]
-}
+# NOTE: REST_FRAMEWORK is defined once, below. There used to be a second
+# definition here that set DEFAULT_FILTER_BACKENDS; because the later assignment
+# wins, that one was silently dropping the filter backend and rendering every
+# viewset's `filterset_fields` inert. The settings are now merged into the single
+# block below.
 
 # CORS configuration with environment variable support
 CORS_ALLOWED_ORIGINS_ENV = os.environ.get("CORS_ALLOWED_ORIGINS")
@@ -252,6 +254,12 @@ REST_FRAMEWORK = {
         "rest_framework.parsers.FormParser",
         "rest_framework.parsers.MultiPartParser",
     ),
+    # Enables every viewset's `filterset_fields` (e.g. JobViewSet ?project=,
+    # FileViewSet ?job=). Previously set in a separate REST_FRAMEWORK block that
+    # was clobbered by this one, so filterset_fields was inert API-wide.
+    "DEFAULT_FILTER_BACKENDS": [
+        "django_filters.rest_framework.DjangoFilterBackend",
+    ],
     # Authentication: AzureADAuthentication reads from middleware-validated users
     # In development (no auth), this returns None and AllowAny permits access
     # In production, the middleware validates JWT and sets request.user

--- a/server/ccp4i2/config/test_settings.py
+++ b/server/ccp4i2/config/test_settings.py
@@ -24,17 +24,23 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",  # Required by DRF
     "rest_framework",  # Django REST Framework
+    "django_filters",  # DRF filter backend (matches production settings)
     "ccp4i2.db.config.DbConfig",  # Our database app
 ]
 
 MIDDLEWARE = []
 
-# REST Framework settings for tests
+# REST Framework settings for tests. Mirror production's filter backend so
+# `filterset_fields` actually filters under test (otherwise tests would silently
+# diverge from prod — the very bug that let jobs/?project= return all projects).
 REST_FRAMEWORK = {
     "UNAUTHENTICATED_USER": None,  # Allow anonymous access in tests
     "UNAUTHENTICATED_TOKEN": None,
     "DEFAULT_AUTHENTICATION_CLASSES": [],
     "DEFAULT_PERMISSION_CLASSES": [],
+    "DEFAULT_FILTER_BACKENDS": [
+        "django_filters.rest_framework.DjangoFilterBackend",
+    ],
 }
 
 ROOT_URLCONF = "ccp4i2.api.urls"  # Set default URL conf for API tests

--- a/server/ccp4i2/tests/api/unit/test_contract.py
+++ b/server/ccp4i2/tests/api/unit/test_contract.py
@@ -221,6 +221,23 @@ def test_report_xml_action_is_registered_on_jobviewset():
     assert bind, "JobViewSet.report_xml is not a registered DRF @action"
 
 
+def test_filter_backend_is_configured():
+    """The DjangoFilterBackend must stay wired into REST_FRAMEWORK so every
+    viewset's ``filterset_fields`` actually filters. A previous *duplicate*
+    REST_FRAMEWORK definition silently dropped DEFAULT_FILTER_BACKENDS, making
+    e.g. ``jobs/?project=<pk>`` return jobs from every project — which broke
+    scene job+param resolution. Guard against that regressing (a re-introduced
+    second REST_FRAMEWORK block would fail here).
+    """
+    from django.conf import settings
+
+    backends = settings.REST_FRAMEWORK.get("DEFAULT_FILTER_BACKENDS", [])
+    assert any("DjangoFilterBackend" in b for b in backends), (
+        "DjangoFilterBackend missing from REST_FRAMEWORK.DEFAULT_FILTER_BACKENDS "
+        "— filterset_fields is inert API-wide"
+    )
+
+
 def test_resolve_fileuse_parser_returns_documented_shape():
     """The fileUse DSL is contracted; the parser's return shape (the
     four keys ``task_name`` / ``jobIndex`` / ``jobParamName`` /


### PR DESCRIPTION
The root cause behind the scene `job+param` wrong-project saga, fixed centrally.

`settings.py` defined `REST_FRAMEWORK` **twice**; the second assignment won and dropped `DEFAULT_FILTER_BACKENDS`, so `DjangoFilterBackend` was never active and **every viewset's `filterset_fields` silently did nothing**. `jobs/?project=<pk>` returned jobs from *all* projects — which is what made scene file resolution pick a job from the wrong project.

**Safe blast radius:** the only two `filterset_fields` users — `FileViewSet["job"]` and `JobViewSet["project"]` — already filter those exact fields manually in `get_queryset` (FileViewSet always did; JobViewSet got a manual filter in the preceding fix). So restoring the backend changes **no current behaviour** — it just makes the config honest and makes `filterset_fields` work for every present and future viewset.

### Changes
- **`settings.py`**: merge the two `REST_FRAMEWORK` blocks into one (backend + parsers + auth + permissions); remove the dead duplicate, with a comment explaining why.
- **`test_settings.py`**: add `django_filters` + the backend, so tests exercise the *same* filtering as production (they previously diverged silently — tests ran with no backend either).
- **`test_contract.py`**: a hermetic guard asserting `DEFAULT_FILTER_BACKENDS` stays wired, so a re-introduced duplicate `REST_FRAMEWORK` fails CI instead of silently disabling filtering again.

### Verification
- API unit suite: **28 passed**, 92 skipped (the +1 is the new guard).
- Settings load confirmed; `DjangoFilterBackend` imports and is present in `REST_FRAMEWORK`.

Server restart required (settings change).