### PR TITLE
scene prompt: digest request-named PDB ids from PDBe for pdb: authoring

### DIFF
--- a/client/renderer/__tests__/pdb-digest.test.ts
+++ b/client/renderer/__tests__/pdb-digest.test.ts
@@ -1,0 +1,72 @@
+/**
+ * PDB-id extraction + PDBe digest formatting for the authoring prompt.
+ * The NL→`pdb:` choice happens in the LLM, so the app digests PDB ids it can
+ * see in the request text and embeds chains + ligand CIDs.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  extractPdbIds,
+  formatPdbContents,
+  fetchPdbContents,
+} from "../lib/moorhen-scene-prompt";
+
+describe("extractPdbIds", () => {
+  it("finds the id in the guinea-pig request, no false positives", () => {
+    expect(
+      extractPdbIds(
+        "Using PDB file 1OGU, could we centre and slab on centre of mass of chains A and B",
+      ),
+    ).toEqual(["1OGU"]);
+  });
+
+  it("uppercases + dedupes classic ids and matches extended ids", () => {
+    expect(extractPdbIds("compare 1abc with 1ABC")).toEqual(["1ABC"]);
+    expect(extractPdbIds("entry pdb_00001abc")).toEqual(["pdb_00001abc"]);
+  });
+
+  it("does not match plain words or chain selectors", () => {
+    expect(extractPdbIds("show the dimer of chains A and B as ribbon")).toEqual([]);
+  });
+});
+
+describe("formatPdbContents", () => {
+  it("lists polymer chains (named) and ligand CIDs", () => {
+    const block = formatPdbContents(
+      "1OGU",
+      [
+        { molecule_type: "polypeptide(L)", molecule_name: ["Kinase"], in_chains: ["A", "B"] },
+        { molecule_type: "water", in_chains: ["A"] },
+      ],
+      [{ chem_comp_id: "GOL", chain_id: "A", author_residue_number: 501 }],
+    );
+    expect(block).toContain("PDB 1OGU (from PDBe)");
+    expect(block).toContain("chain A: Kinase");
+    expect(block).toContain("chain B: Kinase");
+    expect(block).not.toContain("water"); // non-polymer excluded from chains
+    expect(block).toContain("GOL at //A/501");
+  });
+});
+
+describe("fetchPdbContents", () => {
+  const ok = (body: unknown) =>
+    ({ ok: true, json: async () => body }) as unknown as Response;
+
+  it("fetches molecules + ligand_monomers and formats", async () => {
+    const fetchFn = vi.fn(async (url: string) =>
+      url.includes("ligand_monomers")
+        ? ok({ "1ogu": [{ chem_comp_id: "GOL", chain_id: "A", author_residue_number: 501 }] })
+        : ok({ "1ogu": [{ molecule_type: "polypeptide(L)", in_chains: ["A"] }] }),
+    ) as unknown as typeof fetch;
+    const block = await fetchPdbContents("1OGU", fetchFn);
+    expect(block).toContain("PDB 1OGU");
+    expect(block).toContain("GOL at //A/501");
+  });
+
+  it("returns null when the entry 404s (over-matched id self-filters)", async () => {
+    const fetchFn = vi.fn(
+      async () => ({ ok: false, status: 404 }) as unknown as Response,
+    ) as unknown as typeof fetch;
+    expect(await fetchPdbContents("2XYZ", fetchFn)).toBeNull();
+  });
+});

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -49,6 +49,8 @@ import {
   buildContentsBlock,
   buildManifestBlock,
   buildAuthoringPrompt,
+  extractPdbIds,
+  fetchPdbContents,
 } from "../../lib/moorhen-scene-prompt";
 import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp } from "../../lib/moorhen-map-file";
 import {
@@ -1107,21 +1109,33 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       }
     }
 
-    // Contents summary, labelled by the file's annotation where we have one
-    // (e.g. "CDK2-Cyclin A") so the model's selections read against a meaningful
-    // name; fall back to the molecule name, then the file id.
-    let contentsBlock = "(no structure loaded)";
+    // Contents summary. One block per source: the loaded structure (labelled by
+    // the file's annotation where we have one, e.g. "CDK2-Cyclin A"), plus a
+    // PDBe digest for any PDB id named in the request (so the model authoring a
+    // `pdb:` ref gets accurate chains + ligand CIDs — it can't fetch them itself).
+    const contentsParts: string[] = [];
     if (mol && fid != null) {
       try {
         const resp = await apiGet(`files/${fid}/digest/`);
         const digest = resp?.data ?? resp;
         const annotation = projectFiles.find((f) => f.id === fid)?.annotation;
         const label = annotation || mol.name || `file_${fid}`;
-        contentsBlock = buildContentsBlock(digest, label);
+        contentsParts.push(buildContentsBlock(digest, label));
       } catch (err) {
         console.warn("[scene-prompt] digest failed:", err);
       }
     }
+    try {
+      const pdbBlocks = await Promise.all(
+        extractPdbIds(request).map((id) => fetchPdbContents(id)),
+      );
+      for (const block of pdbBlocks) if (block) contentsParts.push(block);
+    } catch (err) {
+      console.warn("[scene-prompt] PDB digest failed:", err);
+    }
+    const contentsBlock = contentsParts.length
+      ? contentsParts.join("\n\n")
+      : "(no structure loaded)";
 
     return buildAuthoringPrompt({ project, contents: contentsBlock, manifest: manifestBlock, request });
   }, [molecules, projectInfo]);

--- a/client/renderer/lib/moorhen-scene-prompt.ts
+++ b/client/renderer/lib/moorhen-scene-prompt.ts
@@ -85,6 +85,98 @@ export function buildContentsBlock(digest: FileDigest, label: string): string {
   return `Loaded structure "${label}":\n${lines.join("\n")}`;
 }
 
+// ── PDB references in the request (digest from PDBe) ────────────────────────
+
+// The NL→`pdb:` decision happens inside the LLM, which has no access to our
+// endpoints — so a `pdb:` ref can't be digested lazily. Instead the APP scans
+// the request TEXT for PDB ids it can see ("…from pdb 1OGU…"), fetches their
+// chains + ligand CIDs from PDBe (via the COEP proxy), and embeds them, exactly
+// like a loaded-structure digest. Only fires when an id is literally present;
+// a purely NL reference ("CDK2") degrades gracefully to no digest.
+
+/** Extract candidate PDB ids from free text. Classic ids start with a digit
+ *  (1-9) + 3 alphanumerics; extended ids are `pdb_########`. Over-matching is
+ *  harmless — a non-existent id 404s at PDBe and is dropped. */
+export function extractPdbIds(text: string): string[] {
+  const ids = new Set<string>();
+  for (const m of text.matchAll(/\b[1-9][a-zA-Z0-9]{3}\b/g)) ids.add(m[0].toUpperCase());
+  for (const m of text.matchAll(/\bpdb_[0-9a-z]{8}\b/gi)) ids.add(m[0].toLowerCase());
+  return [...ids];
+}
+
+interface PdbeMolecule {
+  molecule_type?: string;
+  molecule_name?: string[] | string;
+  in_chains?: string[];
+}
+interface PdbeLigand {
+  chem_comp_id?: string;
+  chain_id?: string;
+  author_residue_number?: number;
+}
+
+const MAX_LIGAND_LINES = 30;
+
+/** Format PDBe `molecules` + `ligand_monomers` arrays into a contents block,
+ *  matching buildContentsBlock so the LLM reads PDB and project refs alike. */
+export function formatPdbContents(
+  id: string,
+  molecules: PdbeMolecule[],
+  ligands: PdbeLigand[],
+): string {
+  const isPolymer = (t?: string) =>
+    !!t && /polypeptide|polyribo|polydeoxyribo|polynucleotide|nucleotide|peptide|saccharide|carbohydrate/i.test(t);
+  const lines: string[] = [];
+
+  const chainLines: string[] = [];
+  for (const m of molecules) {
+    if (!isPolymer(m.molecule_type)) continue;
+    const name = Array.isArray(m.molecule_name) ? m.molecule_name[0] : m.molecule_name;
+    for (const c of m.in_chains ?? []) chainLines.push(`  - chain ${c}${name ? `: ${name}` : ""}`);
+  }
+  if (chainLines.length) {
+    lines.push("Polymer chains (reference as e.g. //A or selection ranges):");
+    lines.push(...chainLines);
+  }
+
+  const ligLines = ligands
+    .filter((l) => l.chem_comp_id)
+    .map((l) => `  - ${l.chem_comp_id} at //${l.chain_id}/${l.author_residue_number}`);
+  if (ligLines.length) {
+    lines.push("Ligands / ions (reference by the exact CID shown):");
+    lines.push(...ligLines.slice(0, MAX_LIGAND_LINES));
+    if (ligLines.length > MAX_LIGAND_LINES)
+      lines.push(`  - … and ${ligLines.length - MAX_LIGAND_LINES} more`);
+  }
+
+  if (!lines.length) return `PDB ${id} (from PDBe): no chains or ligands reported.`;
+  return `PDB ${id} (from PDBe):\n${lines.join("\n")}`;
+}
+
+/** Fetch + format a PDB id's contents from PDBe via the proxy. Returns null on
+ *  404/error (so over-matched ids self-filter). `fetchFn`/`base` injectable for tests. */
+export async function fetchPdbContents(
+  id: string,
+  fetchFn: typeof fetch = fetch,
+  base = "/api/proxy/pdbe/api/pdb/entry",
+): Promise<string | null> {
+  const lid = id.toLowerCase();
+  try {
+    const [mr, lr] = await Promise.all([
+      fetchFn(`${base}/molecules/${lid}`),
+      fetchFn(`${base}/ligand_monomers/${lid}`),
+    ]);
+    if (!mr.ok) return null;
+    const mj = (await mr.json()) as Record<string, PdbeMolecule[]>;
+    const lj = lr.ok ? ((await lr.json()) as Record<string, PdbeLigand[]>) : {};
+    const molecules = mj[lid] ?? [];
+    if (!molecules.length) return null;
+    return formatPdbContents(id, molecules, lj[lid] ?? []);
+  } catch {
+    return null;
+  }
+}
+
 // ── Project manifest (from jobs + files REST) ───────────────────────────────
 
 export interface ManifestJob {


### PR DESCRIPTION
Follow-up to #223. Gives `pdb:` references the same disambiguation that project files already get ("the ligand", "chains A and B").

**Why the app must do it:** the NL→`pdb:` decision happens *inside* the LLM, which can't reach our endpoints — so a `pdb:` ref can't be digested lazily. Instead the app scans the **request text** for PDB ids it can see, fetches chains + ligand CIDs from **PDBe** (via the existing COEP proxy), and embeds them in the prompt's contents — exactly like a loaded-structure digest.

- `lib/moorhen-scene-prompt.ts`: `extractPdbIds` (classic + `pdb_########`), `formatPdbContents`, `fetchPdbContents` (404s self-filter over-matched ids).
- `moorhen-wrapper.tsx`: `handleBuildAuthoringPrompt` folds request-derived PDB digests into `contents` alongside the loaded-structure digest.
- Degrades gracefully: a purely-NL reference ("show CDK2", no id) → no digest, authoring proceeds as before.

**Verified against real PDBe data for 1OGU** (the guinea-pig request "Using PDB file 1OGU … chains A and B"): A/C = CDK2, B/D = Cyclin-A2, ligands ST8 + SGM with exact CIDs. 212 unit tests pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)