### PR TITLE
moorhen scenes: molecule-scoped colour (element.colour) + fix colour-rule leak; lift pdb: from PDBe

### DIFF
--- a/client/renderer/__tests__/fixtures/demo.scene.yaml
+++ b/client/renderer/__tests__/fixtures/demo.scene.yaml
@@ -25,16 +25,19 @@ domains:
 
 elements:
   - file: gamma
+    # molecule-scoped colour: every representation inherits this unless it sets
+    # its own `colour` (the two-level cascade — element default, rep override).
+    colour: by-domain
     representations:
-      - { style: CRs, selection: "//A", colour: by-domain }
-      # honoured geometry: bond cylinder radius in Å
+      - { style: CRs, selection: "//A" } # inherits element.colour (by-domain)
+      # per-rep OVERRIDE of the molecule colour + honoured geometry (bond radius, Å)
       - {
           style: CBs,
           selection: "//A/750",
           colour: "#888888",
           geometry: { bondRadius: 0.18 },
         }
-      # translucent surface — ambient occlusion (hints.effects.ssao) reads best here
+      # per-rep override; translucent surface — SSAO (hints) reads best on surfaces
       - {
           style: MolecularSurface,
           selection: "//A",

--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -149,13 +149,13 @@ describe("liftScene", () => {
     expect(scene.elements![0].representations![0].selection).toBeUndefined();
   });
 
-  it("falls back to url: when the molecule wasn't loaded via ccp4i2", () => {
+  it("falls back to url: for a non-PDBe absolute loader URL", () => {
     const scene = liftScene({
       molecules: [
         fakeMol({
-          name: "pdb",
+          name: "ext",
           molNo: 0,
-          uniqueId: "https://www.ebi.ac.uk/pdbe/entry-files/download/3jbt.cif",
+          uniqueId: "https://refined.example.org/structures/foo.cif",
           representations: [
             { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
           ],
@@ -164,9 +164,71 @@ describe("liftScene", () => {
       glRef: fakeGlRef,
     });
     expect(scene.files![0]).toEqual({
-      name: "pdb",
-      url: "https://www.ebi.ac.uk/pdbe/entry-files/download/3jbt.cif",
+      name: "ext",
+      url: "https://refined.example.org/structures/foo.cif",
     });
+  });
+
+  it("recovers a portable pdb: ref from a PDBe download URL (absolute or relative)", () => {
+    for (const uniqueId of [
+      "https://www.ebi.ac.uk/pdbe/entry-files/download/3jbt.cif",
+      "/api/proxy/pdbe/entry-files/download/1ogu.cif",
+    ]) {
+      const scene = liftScene({
+        molecules: [
+          fakeMol({
+            name: "p",
+            molNo: 0,
+            uniqueId,
+            representations: [
+              { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            ],
+          }),
+        ],
+        glRef: fakeGlRef,
+      });
+      expect(scene.files![0].pdb).toBe(uniqueId.includes("3jbt") ? "3JBT" : "1OGU");
+      expect(scene.files![0].relativeUrl).toBeUndefined();
+    }
+  });
+
+  it("hoists a colour shared by all reps to molecule-scoped element.colour", () => {
+    const rule = { ruleType: "molecule", cid: "//A", color: "#abcdef", isMultiColourRule: false, args: ["//A", "#abcdef"] };
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m", molNo: 0, uniqueId: "x",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [rule] } as unknown as Partial<moorhen.MoleculeRepresentation>,
+            { style: "MolecularSurface", visible: true, colourRules: [rule] } as unknown as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const el = scene.elements![0];
+    expect(el.colour).toBe("#abcdef");
+    expect(el.representations!.every((r) => r.colour === undefined)).toBe(true);
+  });
+
+  it("keeps per-rep colour (no hoist) when representations differ", () => {
+    const mk = (c: string) => ({ ruleType: "molecule", cid: "//A", color: c, isMultiColourRule: false, args: ["//A", c] });
+    const scene = liftScene({
+      molecules: [
+        fakeMol({
+          name: "m", molNo: 0, uniqueId: "x",
+          representations: [
+            { style: "CRs", visible: true, colourRules: [mk("#111111")] } as unknown as Partial<moorhen.MoleculeRepresentation>,
+            { style: "CBs", visible: true, colourRules: [mk("#222222")] } as unknown as Partial<moorhen.MoleculeRepresentation>,
+          ],
+        }),
+      ],
+      glRef: fakeGlRef,
+    });
+    const el = scene.elements![0];
+    expect(el.colour).toBeUndefined();
+    expect(el.representations![0].colour).toBe("#111111");
+    expect(el.representations![1].colour).toBe("#222222");
   });
 
   it("hides representations that are explicitly hidden", () => {

--- a/client/renderer/__tests__/moorhen-scene-resolver.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-resolver.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect } from "vitest";
 import {
+  buildPendingRules,
   clampRangeToPresent,
   directionToLightPosition,
   expandLsqMatches,
@@ -18,6 +19,38 @@ import {
 } from "../lib/moorhen-scene-resolver";
 
 const present = (...nums: number[]) => new Set(nums);
+
+describe("buildPendingRules cascade (element.colour ↔ representation.colour)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const base: any = {
+    molecule: {},
+    domains: [],
+    fileName: "f",
+    log: [],
+    policy: "clamp-and-log",
+    dispatch: () => {},
+  };
+
+  it("falls back to element.colour when the representation has none", () => {
+    const rules = buildPendingRules(
+      { ...base, rep: { style: "CRs" }, elementColour: "#abcdef" },
+      "//A",
+    );
+    expect(rules[0].color).toBe("#abcdef");
+  });
+
+  it("representation.colour overrides element.colour", () => {
+    const rules = buildPendingRules(
+      { ...base, rep: { style: "CRs", colour: "#123456" }, elementColour: "#abcdef" },
+      "//A",
+    );
+    expect(rules[0].color).toBe("#123456");
+  });
+
+  it("no colour at either level → no rules", () => {
+    expect(buildPendingRules({ ...base, rep: { style: "CRs" } }, "//A")).toEqual([]);
+  });
+});
 
 describe("geometryToM2tParams (honoured geometry → Moorhen m2tParameters)", () => {
   it("maps each field to its m2tParameters key, merged onto the base", () => {

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -696,6 +696,19 @@ function liftFileRef(mol: moorhen.Molecule, ctx: LiftCtx): SceneFileRef {
     };
   }
 
+  // PDBe-fetched structures: recover the portable `pdb:` ref from the proxy
+  // download URL (absolute or origin-relative), e.g.
+  //   /api/proxy/pdbe/entry-files/download/1ogu.cif  ->  pdb: 1OGU
+  // Mirrors the resolver's matchOneFile pdb matching, so a fetched PDB
+  // round-trips as a portable `pdb:` rather than a deployment-bound URL.
+  const pdbMatch = mol.uniqueId?.match(
+    /\/pdbe\/entry-files\/download\/([0-9a-zA-Z_]+)\.(?:cif|pdb|ent)/i,
+  );
+  if (pdbMatch) {
+    const id = pdbMatch[1];
+    return { name, pdb: /^pdb_/i.test(id) ? id.toLowerCase() : id.toUpperCase() };
+  }
+
   // Plain URL fallback for non-ccp4i2 loaders (e.g. PDBe direct fetches).
   if (mol.uniqueId && /^https?:\/\//.test(mol.uniqueId)) {
     return { name, url: mol.uniqueId };
@@ -937,7 +950,28 @@ function liftElement(mol: moorhen.Molecule, fileName: string): SceneElement | nu
   if (visible.length === 0) return null;
 
   const out: SceneRepresentation[] = visible.map(liftRepresentation);
-  return { file: fileName, representations: out };
+  const element: SceneElement = { file: fileName, representations: out };
+  hoistCommonColour(element);
+  return element;
+}
+
+/**
+ * If every representation carries the SAME colour, hoist it to a molecule-scoped
+ * `element.colour` (matching Moorhen's molecule-level colour) and drop it from
+ * the reps — terser, and the natural "colour this whole structure" form. Reps
+ * with differing colours keep their own (the per-rep override). No hoist unless
+ * all reps have an identical, defined colour.
+ */
+function hoistCommonColour(element: SceneElement): void {
+  const reps = element.representations ?? [];
+  // Only factor out a colour genuinely SHARED by ≥2 reps. A single rep keeps
+  // its own colour (nothing to hoist; avoids surprising the common one-rep case).
+  if (reps.length < 2) return;
+  const first = JSON.stringify(reps[0].colour);
+  if (reps[0].colour === undefined) return;
+  if (!reps.every((r) => JSON.stringify(r.colour) === first)) return;
+  element.colour = reps[0].colour;
+  for (const r of reps) delete r.colour;
 }
 
 function liftRepresentation(rep: moorhen.MoleculeRepresentation): SceneRepresentation {
@@ -985,8 +1019,17 @@ function liftColour(rules: moorhen.ColourRule[]): SceneColour | undefined {
   // and residue-range CIDs are the same shape, so by-domain re-applies through
   // the same path.
   if (rules.every(isSingleHexRule)) {
-    if (rules.length === 1) return rules[0].color;
-    return rules.map((r) => ({ selection: r.cid, colour: r.color }));
+    // Dedup (cid, colour) pairs — Moorhen can accumulate duplicate rules on a
+    // molecule's shared list; the dedup keeps a captured colour clean.
+    const seen = new Set<string>();
+    const uniq = rules.filter((r) => {
+      const k = `${r.cid} ${r.color}`;
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
+    if (uniq.length === 1) return uniq[0].color;
+    return uniq.map((r) => ({ selection: r.cid, colour: r.color }));
   }
 
   const r = rules[0];

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -526,6 +526,7 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
         log: result.log,
         policy,
         dispatch,
+        elementColour: element.colour,
       });
       if (ok) added++;
     }
@@ -1023,6 +1024,9 @@ interface ApplyRepCtx {
   log: SceneResolveLogEntry[];
   policy: "clamp-and-log" | "strict";
   dispatch: Dispatch;
+  /** Molecule-scoped colour from element.colour — the per-rep colour falls
+   *  back to this when the representation has no `colour` of its own. */
+  elementColour?: SceneColour;
 }
 
 /**
@@ -1075,6 +1079,13 @@ async function applyRepresentation(ctx: ApplyRepCtx): Promise<boolean> {
         );
       }
       if (pendingRules.length > 0) {
+        // Decouple this representation from the molecule's shared
+        // `defaultColourRules` array (assigned to a rep BY REFERENCE at draw
+        // time in Moorhen). Without this reset, addColourRule push()es onto the
+        // shared array, so colour rules accumulate molecule-wide and leak across
+        // every representation (the "colour soup" on capture). Nulling it makes
+        // the first addColourRule build a fresh, rep-private list.
+        created.colourRules = null;
         for (const r of pendingRules) {
           // Colour rule CID stays as authored — the rule's CID and the
           // representation's CID don't have to match (e.g. by-domain
@@ -1151,16 +1162,19 @@ function extractRepError(e: unknown): string {
   }
 }
 
-function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] {
+export function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] {
   const { molecule, rep, domains, fileName, log, policy } = ctx;
-  if (!rep.colour) return [];
+  // Effective colour: the representation's own, else the molecule-scoped
+  // element.colour (the cascade — a rep's own colour overrides element.colour).
+  const colour = rep.colour ?? ctx.elementColour;
+  if (!colour) return [];
 
-  if (Array.isArray(rep.colour)) {
+  if (Array.isArray(colour)) {
     // Per-selection colour list: one single-colour rule per entry. A whole-chain
     // CID ("//A") and a residue range ("//A/121-130") apply identically here —
     // it's the general form by-domain compiles to, and what coot's default
     // per-chain colouring round-trips through.
-    return rep.colour.map((c) => ({
+    return colour.map((c) => ({
       ruleType: "molecule",
       cid: c.selection,
       color: c.colour,
@@ -1169,7 +1183,7 @@ function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] 
     }));
   }
 
-  if (isSceneHexColour(rep.colour)) {
+  if (isSceneHexColour(colour)) {
     // libcoot's add_colour_rule reads cid+colour from args, not from
     // this.cid/this.color (which are only consulted by the bond-style
     // shim_set_bond_colours path). Without [cid, colour] in args,
@@ -1178,15 +1192,15 @@ function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] 
       {
         ruleType: "molecule",
         cid: defaultCid,
-        color: rep.colour,
-        args: [defaultCid, rep.colour],
+        color: colour,
+        args: [defaultCid, colour],
         isMultiColourRule: false,
       },
     ];
   }
 
-  if (isSceneNamedColour(rep.colour)) {
-    if (rep.colour === "by-domain") {
+  if (isSceneNamedColour(colour)) {
+    if (colour === "by-domain") {
       return buildByDomainPendingRule(molecule, domains, fileName, log, policy);
     }
     // Named schemes (b-factor, af2-plddt, etc.) are Moorhen multi-rules
@@ -1194,7 +1208,7 @@ function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] 
     // args array; Moorhen's internal getMultiColourRuleArgs supplies them.
     return [
       {
-        ruleType: rep.colour,
+        ruleType: colour,
         cid: defaultCid,
         color: "#ffffff",
         args: [],
@@ -1203,8 +1217,8 @@ function buildPendingRules(ctx: ApplyRepCtx, defaultCid: string): PendingRule[] 
     ];
   }
 
-  if (isSceneRawColour(rep.colour)) {
-    const raw = rep.colour.raw;
+  if (isSceneRawColour(colour)) {
+    const raw = colour.raw;
     return [
       {
         ruleType: raw.ruleType,

--- a/client/renderer/lib/scene/core.ts
+++ b/client/renderer/lib/scene/core.ts
@@ -229,6 +229,9 @@ export const Element = z
   .object({
     file: z.string().describe("name of a files[] entry"),
     dictionaries: z.array(z.string()).optional(),
+    colour: Colour.optional().describe(
+      "molecule-scoped colour: the default for every representation of this file; a representation's own `colour` overrides it",
+    ),
     representations: z.array(Representation).optional(),
   })
   .strict();

--- a/client/renderer/lib/scene/moorhen-scene.ccp4i2.v1.json
+++ b/client/renderer/lib/scene/moorhen-scene.ccp4i2.v1.json
@@ -251,6 +251,91 @@
               "type": "string"
             }
           },
+          "colour": {
+            "description": "molecule-scoped colour: the default for every representation of this file; a representation's own `colour` overrides it",
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$",
+                "description": "hex colour #rrggbb or #rrggbbaa"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "by-domain",
+                  "b-factor",
+                  "b-factor-norm",
+                  "af2-plddt",
+                  "secondary-structure",
+                  "jones-rainbow",
+                  "mol-symm"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "selection": {
+                      "type": "string",
+                      "description": "CID, e.g. \"//A\" or \"//A/121-130\""
+                    },
+                    "colour": {
+                      "type": "string",
+                      "pattern": "^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$",
+                      "description": "hex colour #rrggbb or #rrggbbaa"
+                    }
+                  },
+                  "required": [
+                    "selection",
+                    "colour"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "raw": {
+                    "type": "object",
+                    "properties": {
+                      "ruleType": {
+                        "type": "string"
+                      },
+                      "args": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "isMultiColourRule": {
+                        "type": "boolean"
+                      },
+                      "applyColourToNonCarbonAtoms": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "ruleType",
+                      "args"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "raw"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
           "representations": {
             "type": "array",
             "items": {

--- a/client/renderer/lib/scene/moorhen-scene.core.v1.json
+++ b/client/renderer/lib/scene/moorhen-scene.core.v1.json
@@ -228,6 +228,91 @@
               "type": "string"
             }
           },
+          "colour": {
+            "description": "molecule-scoped colour: the default for every representation of this file; a representation's own `colour` overrides it",
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$",
+                "description": "hex colour #rrggbb or #rrggbbaa"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "by-domain",
+                  "b-factor",
+                  "b-factor-norm",
+                  "af2-plddt",
+                  "secondary-structure",
+                  "jones-rainbow",
+                  "mol-symm"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "selection": {
+                      "type": "string",
+                      "description": "CID, e.g. \"//A\" or \"//A/121-130\""
+                    },
+                    "colour": {
+                      "type": "string",
+                      "pattern": "^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$",
+                      "description": "hex colour #rrggbb or #rrggbbaa"
+                    }
+                  },
+                  "required": [
+                    "selection",
+                    "colour"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "raw": {
+                    "type": "object",
+                    "properties": {
+                      "ruleType": {
+                        "type": "string"
+                      },
+                      "args": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "isMultiColourRule": {
+                        "type": "boolean"
+                      },
+                      "applyColourToNonCarbonAtoms": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "ruleType",
+                      "args"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "raw"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
           "representations": {
             "type": "array",
             "items": {

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -65,6 +65,14 @@ domains?: { name: string, selection: string, color: string }[]
 elements?: ({
   file: string  # name of a files[] entry
   dictionaries?: string[]
+  colour?: string | "by-domain"|"b-factor"|"b-factor-norm"|"af2-plddt"|"secondary-structure"|"jones-rainbow"|"mol-symm" | { selection: string, colour: string }[] | {
+    raw: {
+      ruleType: string
+      args: (string | number)[]
+      isMultiColourRule?: boolean
+      applyColourToNonCarbonAtoms?: boolean
+    }
+  }  # molecule-scoped colour: the default for every representation of this file; a representation's own `colour` overrides it
   representations?: ({
     style: "VdwSpheres"|"ligands"|"CAs"|"CBs"|"CDs"|"gaussian"|"allHBonds"|"rama"|"rotamer"|"CRs"|"MolecularSurface"|"DishyBases"|"VdWSurface"|"Calpha"|"unitCell"|"hover"|"environment"|"ligand_environment"|"contact_dots"|"chemical_features"|"ligand_validation"|"glycoBlocks"|"restraints"|"residueSelection"|"MetaBalls"|"adaptativeBonds"|"StickBases"|"residue_environment"|"transformation"  # Moorhen RepresentationStyle, e.g. "CRs", "CBs"
     selection?: string  # CID; default all-atoms

--- a/client/renderer/types/moorhen-scene.ts
+++ b/client/renderer/types/moorhen-scene.ts
@@ -326,6 +326,11 @@ export interface SceneElement {
    *  different chemistry — each gets its own scoped dictionary. */
   dictionaries?: string[];
 
+  /** Molecule-scoped colour: the default colour rules for every
+   *  representation of this file (maps to Moorhen's molecule-level colour).
+   *  A representation's own `colour` overrides it for that representation. */
+  colour?: SceneColour;
+
   /** Representations to draw on this file. */
   representations?: SceneRepresentation[];
 }


### PR DESCRIPTION
Fixes the capture "colour soup" (every rep coming back with a duplicated, cross-contaminated colour list) by matching the scene format to Moorhen's actual two-level colour model.

**Root cause:** a representation's `colourRules` is the parent molecule's `defaultColourRules` **assigned by reference**; the resolver's `addColourRule` then `push()`es onto that shared array, so rules accumulate molecule-wide and every rep lifts the union (+ the load-time default chain palette).

**Fix:**
- New **`element.colour`** (molecule-scoped) — the default for every representation; `representation.colour` overrides it (cascade), mirroring Moorhen.
- **Resolver:** reset `created.colourRules = null` before `addColourRule` → each rep gets a fresh independent list (no leak); effective colour is `rep.colour ?? element.colour`.
- **Lifter:** dedup rules; hoist a colour shared by ≥2 reps to `element.colour`; and recover a portable **`pdb:`** ref from PDBe download URLs (absolute or origin-relative) instead of a deployment-bound `relativeUrl`.
- Demo now exercises the cascade (`element.colour: by-domain` + per-rep overrides).

Your AI 1OGU example would now lift back as clean per-rep hexes (CRs //A `#6495ED`, CRs //C `#FFD700`, …) instead of the nine-entry soup ×3, and as `pdb: 1OGU`/`8ROZ`/`1BUH` instead of `relativeUrl`. 222 unit tests pass; tsc clean.

Follow-up to #223–#225. (Superpose round-trip is a separate, upcoming PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)