### PR TITLE
moorhen scenes: superpose round-trip + docs sync

### DIFF
--- a/client/renderer/MOORHEN_SCENES_FOR_MOORHEN.md
+++ b/client/renderer/MOORHEN_SCENES_FOR_MOORHEN.md
@@ -91,6 +91,16 @@ While grounding the format we noticed a few things, shared in case they're news:
   programmatic outline.
 - **`lightPosition` is a position** (default `[25,25,50,1]`, |·|≈61), not a unit
   direction — the resolver maps a conceptual `direction` to a position along it.
+- **Colour rules are molecule-scoped, accumulating, and shared by reference.** A
+  representation's `colourRules` is the parent molecule's `defaultColourRules`
+  *by reference*; `addColourRule` push()es onto it, so per-representation colours
+  accumulate molecule-wide and leak across representations (plus the load-time
+  default chain palette). A genuine per-representation colour API (or not sharing
+  the array by reference) would help. We work around it by nulling `colourRules`
+  before adding, and model two explicit levels in the scene (molecule + per-rep).
+- **SSM/LSQ superpose moves coordinates inside coot** (`changesMolecules` +
+  `setAtomsDirty`), with no display transform — so superposition can't be
+  captured from a molecule's state, only re-applied from a remembered directive.
 
 ## What carving out a core would involve
 

--- a/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
+++ b/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
@@ -248,9 +248,37 @@ becomes a generated compact brief, not hand-maintained prose.
 ## 9. Deferred / open
 
 - **Per-representation material** — deferred until Moorhen gains a material concept (§4b).
-- Honoured-geometry field set — **confirmed** against Moorhen `m2tParameters` and shipped
-  (bond/ball/probe radii, ribbon widths, vdwScale). Resolver mapping lands in step 3.
-- `hints` field set — **confirmed** against Moorhen `glRefSlice` (lighting) and the SSAO/
-  edge-detect/outline/shadow/depth-blur/perspective setters (effects); shipped.
 - `$id` URL scheme and where the published `moorhen-scene.{core,ccp4i2}.v1.json` are hosted.
-- Resolver/lifter wiring for the new fields (step 3) — lifter should emit-only-non-default.
+
+**Shipped since v1 (PRs #223–#226 + superpose):** honoured geometry (→ `m2tParameters`);
+`hints` lighting/effects apply (→ `glRefSlice` + `setDo*`) **and** lifter capture
+(emit-only-non-default); the generated LLM brief + regenerated human grammar; request-time
+**PDB digest** from PDBe; the two-level **colour** model and **superpose round-trip** (§10).
+`outline` was removed (it's a hover highlight, not a scene effect — §4b/§10).
+
+## 10. Colour scoping & superpose round-trip (shipped)
+
+**Two-level colour (matches Moorhen).** A representation's `colourRules` is the parent
+molecule's `defaultColourRules` assigned BY REFERENCE; `addColourRule` push()es onto that
+shared array, so per-rep colours accumulate molecule-wide and leak across reps (the capture
+"colour soup", incl. the load-time default chain palette). The format now mirrors Moorhen's
+real two levels:
+
+- **`element.colour`** — molecule-scoped default, inherited by every representation.
+- **`representation.colour`** — overrides it for that rep (the cascade; effective colour =
+  `rep.colour ?? element.colour`).
+
+Resolver: reset `created.colourRules = null` before `addColourRule` so each rep builds a
+fresh, private list (no leak). Lifter: dedup rules and **hoist** a colour shared by ≥2 reps
+up to `element.colour`. (Clean `setColourRules`/`defaultColourRules` is blocked — Moorhen
+doesn't export `ColourRule` at runtime — so we use the null-reset + addColourRule path.)
+
+**`pdb:` recovery.** The lifter recognises PDBe download URLs (absolute or origin-relative)
+and emits a portable `pdb:` ref rather than a deployment-bound `relativeUrl`.
+
+**Superpose round-trip.** SSM/LSQ **move coordinates inside coot** (`cootCommand`
+`changesMolecules` + `setAtomsDirty`) — there is no display transform to capture, and the
+directive can't be reverse-engineered from a moved molecule. So the host **remembers the
+last-applied `superpose` block** and the lifter **re-emits it** on capture, filtered to
+entries whose `move`/`onto` files survived the lift (no dangling refs). Straight capture of
+a superposed scene now round-trips.

--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -111,6 +111,32 @@ describe("liftHints (lighting + effects capture, emit-only-non-default)", () => 
   });
 });
 
+describe("superpose round-trip (re-emit remembered, filtered by present files)", () => {
+  it("re-emits remembered superpose, dropping entries whose files are absent", () => {
+    const scene = liftScene({
+      molecules: [
+        fakeMol({ name: "a", molNo: 0, uniqueId: "ua", representations: [{ style: "CRs", visible: true, colourRules: [] } as unknown as Partial<moorhen.MoleculeRepresentation>] }),
+        fakeMol({ name: "b", molNo: 1, uniqueId: "ub", representations: [{ style: "CRs", visible: true, colourRules: [] } as unknown as Partial<moorhen.MoleculeRepresentation>] }),
+      ],
+      glRef: fakeGlRef,
+      superpose: [
+        { method: "ssm", move: "b", onto: "a", movChain: "A", refChain: "A" },
+        { method: "ssm", move: "ghost", onto: "a", movChain: "A", refChain: "A" },
+      ],
+    });
+    expect(scene.superpose).toHaveLength(1);
+    expect(scene.superpose![0].move).toBe("b");
+  });
+
+  it("emits no superpose when none was remembered", () => {
+    const scene = liftScene({
+      molecules: [fakeMol({ name: "a", molNo: 0, uniqueId: "ua", representations: [{ style: "CRs", visible: true, colourRules: [] } as unknown as Partial<moorhen.MoleculeRepresentation>] })],
+      glRef: fakeGlRef,
+    });
+    expect(scene.superpose).toBeUndefined();
+  });
+});
+
 describe("liftScene", () => {
   it("captures camera and a single file with a single visible representation", () => {
     const scene = liftScene({

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -42,7 +42,7 @@ import {
   SceneMapFetcher,
   SceneResolveResult,
 } from "../../lib/moorhen-scene-resolver";
-import type { SceneFileRef } from "../../types/moorhen-scene";
+import type { SceneFileRef, SceneSuperpose } from "../../types/moorhen-scene";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
 import { extractFileIdFromUniqueId } from "../../lib/moorhen-view-state";
 import {
@@ -785,6 +785,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   // before each apply — keeps the fetcher callbacks stable while
   // letting per-apply asset maps reach them.
   const bundleAssetsRef = useRef<SceneBundleAssets>(new Map());
+  // Remember the last-applied scene's superpose so capture can re-emit it
+  // (SSM/LSQ move coords inside coot — nothing to lift from the molecule).
+  const lastAppliedSuperposeRef = useRef<SceneSuperpose[] | undefined>(undefined);
 
   const handleFetchSceneFile: SceneFileFetcher = useCallback(
     async (ref: SceneFileRef) => {
@@ -1005,6 +1008,8 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       // non-bundled apply.
       bundleAssetsRef.current = assets;
       const scene = parseScene(yamlText);
+      // Remember this scene's superpose so a later capture can re-emit it.
+      lastAppliedSuperposeRef.current = scene.superpose;
       // Live glRef snapshot for view.clip: { front, back } (clip = zoom*depth,
       // fog offset by fogClipOffset).
       const gl = (store.getState() as moorhen.State).glRef as unknown as {
@@ -1223,6 +1228,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       molecules,
       glRef: glRefState,
       sceneSettings: sceneSettingsState,
+      superpose: lastAppliedSuperposeRef.current,
       projectId: projectInfo?.id,
       projectName: projectInfo?.name,
       // First molecule's monomerLibraryPath is the canonical Moorhen

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -35,6 +35,7 @@ import {
   SceneMap,
   SceneMapColumns,
   SceneRepresentation,
+  SceneSuperpose,
   SceneView,
 } from "../types/moorhen-scene";
 
@@ -79,6 +80,13 @@ export interface LiftCtx {
     depthBlurDepth?: number | null;
     doPerspectiveProjection?: boolean | null;
   };
+  /** Superpose directives from the LAST-applied scene, remembered by the host.
+   *  SSM/LSQ move coordinates *inside* coot (there is no display transform to
+   *  capture), so superposition can't be reverse-engineered from a lifted
+   *  molecule. Re-emitting the remembered directives — filtered to those whose
+   *  move/onto files are still present in the lift — keeps superposed scenes
+   *  round-tripping. */
+  superpose?: SceneSuperpose[];
   /** Optional: the ccp4i2 project UUID. If set, file refs get both
    *  projectId and (derivable) fileId. */
   projectId?: string;
@@ -187,6 +195,17 @@ export function liftScene(ctx: LiftCtx): MoorhenScene {
 
   const hints = liftHints(ctx.glRef, ctx.sceneSettings);
   if (hints) scene.hints = hints;
+
+  // Re-emit the last-applied superpose (coot moved the coords; there's no
+  // transform to capture). Keep only entries whose move + onto files survived
+  // into this lift, so we never emit a dangling reference.
+  if (ctx.superpose?.length) {
+    const fileNames = new Set((scene.files ?? []).map((f) => f.name));
+    const kept = ctx.superpose.filter(
+      (sp) => fileNames.has(sp.move) && fileNames.has(sp.onto),
+    );
+    if (kept.length) scene.superpose = kept;
+  }
 
   const elements = ctx.molecules
     .map((mol, i) => liftElement(mol, scene.files?.[i]?.name ?? `mol${i}`))

--- a/client/renderer/lib/moorhen-scene-prompt.ts
+++ b/client/renderer/lib/moorhen-scene-prompt.ts
@@ -23,6 +23,8 @@ const SCENE_CONVENTIONS = [
   "  secondary-structure, jones-rainbow, mol-symm); OR a per-selection list",
   "  [{selection, colour}]. `by-domain` colours by the top-level `domains:` block:",
   "  define domains (name + selection + color) and set `colour: by-domain` on reps.",
+  "- `element.colour` sets a molecule-wide default (any colour form above) inherited by",
+  "  every representation of that file; a representation's own `colour` overrides it.",
   "- geometry dimensions are Ångström. `hints` (lighting/effects) are ADVISORY —",
   "  a viewer may ignore them; never rely on them for what must be visible.",
 ].join("\n");

--- a/client/renderer/lib/scene/brief.ts
+++ b/client/renderer/lib/scene/brief.ts
@@ -154,6 +154,10 @@ A \`colour\` is one of:
 \`by-domain\` colours by the top-level \`domains:\` block: define domains
 (\`name\` + \`selection\` + \`color\`) and set \`colour: by-domain\` on the reps.
 
+Colour cascades over two levels (matching Moorhen's molecule-level colour):
+\`element.colour\` is the molecule-wide default inherited by every representation
+of that file, and a representation's own \`colour\` overrides it for that rep.
+
 ## Geometry and hints
 
 - \`geometry\` (per representation) is **honoured** — physical dimensions in

--- a/client/renderer/types/moorhen-scene.md
+++ b/client/renderer/types/moorhen-scene.md
@@ -206,6 +206,10 @@ A `colour` is one of:
 `by-domain` colours by the top-level `domains:` block: define domains
 (`name` + `selection` + `color`) and set `colour: by-domain` on the reps.
 
+Colour cascades over two levels (matching Moorhen's molecule-level colour):
+`element.colour` is the molecule-wide default inherited by every representation
+of that file, and a representation's own `colour` overrides it for that rep.
+
 ## Geometry and hints
 
 - `geometry` (per representation) is **honoured** — physical dimensions in


### PR DESCRIPTION
Final piece of the scene round-trip, plus a docs sync.

**Superpose round-trip.** Confirmed from source that SSM/LSQ **move coordinates inside coot** (`cootCommand` `changesMolecules` + `setAtomsDirty`) — there's no display transform to capture and the directive can't be reverse-engineered from a moved molecule. So the wrapper **remembers the last-applied scene's `superpose` block** and the lifter **re-emits it on capture**, filtered to entries whose `move`/`onto` files survived the lift (no dangling refs). Straight capture of a superposed scene now round-trips (was silently lost).

**Docs sync** — brings the curated docs in line with #223–#226 + superpose:
- Design doc: new **§10** (two-level colour, `pdb:` recovery, superpose round-trip); §9 refreshed (shipped items out; per-rep material + `$id` still open).
- Prompt conventions + generated grammar (`.md`) explain the `element.colour` cascade.
- `MOORHEN_SCENES_FOR_MOORHEN.md`: adds the *molecule-scoped colour-rules* and *SSM-moves-coords* findings.

224 unit tests pass; tsc clean. Follow-up to #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)