### PR TITLE
moorhen scenes: keep dict cifText to the bundle lift only

### DIFF
--- a/client/renderer/__tests__/moorhen-scene-lifter.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-lifter.test.ts
@@ -510,7 +510,7 @@ describe("liftScene — dictionary provenance", () => {
     expect(scene.elements![0].dictionaries).toEqual(["dict-file-100"]);
   });
 
-  it("falls back to inline cifText when the dict has no project source", () => {
+  it("omits an unsourced dict from the terse capture lift (no cifText)", () => {
     const scene = liftScene({
       molecules: [
         fakeMol({
@@ -526,6 +526,30 @@ describe("liftScene — dictionary provenance", () => {
       ],
       glRef: fakeGlRef,
     });
+    // Default lift never inlines cifText — an unsourced dict simply isn't
+    // emitted. cifText is reserved for the bundle lift.
+    expect((scene.files ?? []).some((f) => f.kind === "dictionary")).toBe(false);
+  });
+
+  it("inlines cifText for an unsourced dict only when inlineDicts is set", () => {
+    const scene = liftScene(
+      {
+        molecules: [
+          fakeMol({
+            name: "m",
+            molNo: 7,
+            uniqueId: "x",
+            ligands: [{ resName: "XYZ" }],
+            dicts: { XYZ: "data_comp_XYZ\nstuff" },
+            representations: [
+              { style: "ligands", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            ],
+          }),
+        ],
+        glRef: fakeGlRef,
+      },
+      { inlineDicts: true },
+    );
     const dictRef = scene.files!.find((f) => f.kind === "dictionary");
     expect(dictRef).toMatchObject({ kind: "dictionary", cifText: "data_comp_XYZ\nstuff" });
     expect(dictRef!.fileId).toBeUndefined();
@@ -569,28 +593,31 @@ describe("serialiseSceneWithComments", () => {
   });
 });
 
-describe("liftScene — dictionary lifting", () => {
+describe("liftScene — dictionary lifting (bundle inlining)", () => {
   it("emits a kind: dictionary file ref for each non-standard ligand", () => {
-    const scene = liftScene({
-      molecules: [
-        fakeMol({
-          name: "complex",
-          molNo: 0,
-          uniqueId: "/api/proxy/ccp4i2/files/482/download/",
-          representations: [
-            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
-          ],
-          ligands: [
-            { resName: "LIG", chainName: "A", resNum: "401" } as Partial<moorhen.LigandInfo>,
-          ],
-          dicts: {
-            LIG: "data_comp_LIG\n_chem_comp.id LIG\n",
-          },
-        }),
-      ],
-      glRef: fakeGlRef,
-      projectId: "p-uuid",
-    });
+    const scene = liftScene(
+      {
+        molecules: [
+          fakeMol({
+            name: "complex",
+            molNo: 0,
+            uniqueId: "/api/proxy/ccp4i2/files/482/download/",
+            representations: [
+              { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            ],
+            ligands: [
+              { resName: "LIG", chainName: "A", resNum: "401" } as Partial<moorhen.LigandInfo>,
+            ],
+            dicts: {
+              LIG: "data_comp_LIG\n_chem_comp.id LIG\n",
+            },
+          }),
+        ],
+        glRef: fakeGlRef,
+        projectId: "p-uuid",
+      },
+      { inlineDicts: true },
+    );
 
     expect(scene.files).toHaveLength(2); // complex + dict
     const dictRef = scene.files!.find((f) => f.kind === "dictionary");
@@ -630,55 +657,61 @@ describe("liftScene — dictionary lifting", () => {
   });
 
   it("dedupes by comp_id across multiple ligand instances", () => {
-    const scene = liftScene({
-      molecules: [
-        fakeMol({
-          name: "complex",
-          molNo: 0,
-          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
-          representations: [
-            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
-          ],
-          ligands: [
-            { resName: "LIG", resNum: "401" } as Partial<moorhen.LigandInfo>,
-            { resName: "LIG", resNum: "402" } as Partial<moorhen.LigandInfo>,
-            { resName: "LIG", resNum: "403" } as Partial<moorhen.LigandInfo>,
-          ],
-          dicts: { LIG: "data_comp_LIG\n" },
-        }),
-      ],
-      glRef: fakeGlRef,
-    });
+    const scene = liftScene(
+      {
+        molecules: [
+          fakeMol({
+            name: "complex",
+            molNo: 0,
+            uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+            representations: [
+              { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            ],
+            ligands: [
+              { resName: "LIG", resNum: "401" } as Partial<moorhen.LigandInfo>,
+              { resName: "LIG", resNum: "402" } as Partial<moorhen.LigandInfo>,
+              { resName: "LIG", resNum: "403" } as Partial<moorhen.LigandInfo>,
+            ],
+            dicts: { LIG: "data_comp_LIG\n" },
+          }),
+        ],
+        glRef: fakeGlRef,
+      },
+      { inlineDicts: true },
+    );
     const dictRefs = scene.files!.filter((f) => f.kind === "dictionary");
     expect(dictRefs).toHaveLength(1);
   });
 
   it("emits separate dict refs for two molecules with same-named ligands", () => {
-    const scene = liftScene({
-      molecules: [
-        fakeMol({
-          name: "complex-A",
-          molNo: 0,
-          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
-          representations: [
-            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
-          ],
-          ligands: [{ resName: "LIG" } as Partial<moorhen.LigandInfo>],
-          dicts: { LIG: "data_comp_LIG\nA chemistry\n" },
-        }),
-        fakeMol({
-          name: "complex-B",
-          molNo: 1,
-          uniqueId: "/api/proxy/ccp4i2/files/200/download/",
-          representations: [
-            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
-          ],
-          ligands: [{ resName: "LIG" } as Partial<moorhen.LigandInfo>],
-          dicts: { LIG: "data_comp_LIG\nB chemistry\n" },
-        }),
-      ],
-      glRef: fakeGlRef,
-    });
+    const scene = liftScene(
+      {
+        molecules: [
+          fakeMol({
+            name: "complex-A",
+            molNo: 0,
+            uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+            representations: [
+              { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            ],
+            ligands: [{ resName: "LIG" } as Partial<moorhen.LigandInfo>],
+            dicts: { LIG: "data_comp_LIG\nA chemistry\n" },
+          }),
+          fakeMol({
+            name: "complex-B",
+            molNo: 1,
+            uniqueId: "/api/proxy/ccp4i2/files/200/download/",
+            representations: [
+              { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            ],
+            ligands: [{ resName: "LIG" } as Partial<moorhen.LigandInfo>],
+            dicts: { LIG: "data_comp_LIG\nB chemistry\n" },
+          }),
+        ],
+        glRef: fakeGlRef,
+      },
+      { inlineDicts: true },
+    );
     const dictRefs = scene.files!.filter((f) => f.kind === "dictionary");
     expect(dictRefs).toHaveLength(2);
     // Different dict bodies — that's the whole point of per-molecule scoping.
@@ -690,22 +723,26 @@ describe("liftScene — dictionary lifting", () => {
   });
 
   it("skips non-standard ligands when no dict is stored on the molecule", () => {
-    const scene = liftScene({
-      molecules: [
-        fakeMol({
-          name: "complex",
-          molNo: 0,
-          uniqueId: "/api/proxy/ccp4i2/files/100/download/",
-          representations: [
-            { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
-          ],
-          ligands: [{ resName: "MYS" } as Partial<moorhen.LigandInfo>],
-          // No dicts entry for MYS — getDict returns "" so we skip emission.
-          dicts: {},
-        }),
-      ],
-      glRef: fakeGlRef,
-    });
+    const scene = liftScene(
+      {
+        molecules: [
+          fakeMol({
+            name: "complex",
+            molNo: 0,
+            uniqueId: "/api/proxy/ccp4i2/files/100/download/",
+            representations: [
+              { style: "CRs", visible: true, colourRules: [] } as Partial<moorhen.MoleculeRepresentation>,
+            ],
+            ligands: [{ resName: "MYS" } as Partial<moorhen.LigandInfo>],
+            // No dicts entry for MYS — getDict returns "" so we skip emission
+            // even with inlining requested.
+            dicts: {},
+          }),
+        ],
+        glRef: fakeGlRef,
+      },
+      { inlineDicts: true },
+    );
     const dictRefs = scene.files!.filter((f) => f.kind === "dictionary");
     expect(dictRefs).toHaveLength(0);
   });

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -853,8 +853,9 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   // the whole text to Coot in one call so all blocks get parsed in one shot.
   const handleFetchSceneDictionary = useCallback(
     async (ref: SceneFileRef): Promise<string | null> => {
-      // Inline text: no network needed. The lifter produces these for
-      // dicts loaded from job outputs where there's no stable URL.
+      // Inline text: no network needed. The capture lifter no longer emits
+      // these (dicts travel as fileId/bundle refs), but hand-authored scenes
+      // may still inline a dictionary, so honour cifText when present.
       if (ref.cifText) return ref.cifText;
       // Bundle: decode the asset bytes as UTF-8 text.
       if (ref.bundle) {
@@ -1147,9 +1148,11 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
 
   // Promote an editor YAML to a fully self-contained scene + asset
   // bundle: every URL-resolvable ref is fetched into assets/ and
-  // rewritten to bundle: form; ligand dicts that live in Moorhen's
-  // monomer library are re-collected (the lifter omits them so the
-  // captured YAML stays small, but self-contained mode wants them).
+  // rewritten to bundle: form; ligand dicts the captured YAML omits
+  // (library monomers and custom in-memory dicts — the lifter keeps the
+  // YAML terse) are re-collected here from the monomer library or, for
+  // custom ligands, the molecule's own stored dict, so self-contained
+  // mode carries them as bundle assets.
   const handlePromoteSceneToPortable = useCallback(
     async (
       yamlText: string,
@@ -1221,9 +1224,11 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     // explicit "Save self-contained" action (handlePromoteSceneToPortable),
     // which fetches the bytes into a .scene.zip. Eager-bundling on capture would
     // hide provenance and, if the edited YAML is re-applied, load duplicate
-    // copies of each molecule. liftSceneStraight also drops dict refs the
-    // receiver's monomer library already has (library monomers travel as
-    // nothing; project ligand dicts travel as terse fileId refs).
+    // copies of each molecule. The capture lift never inlines dict cifText:
+    // project ligand dicts travel as terse fileId refs, and any dict without
+    // project provenance (library monomers, ad-hoc custom dicts) is left out
+    // of the YAML — cifText is materialised only by the bundle/self-contained
+    // path (handlePromoteSceneToPortable), which writes it into a bundle asset.
     const { scene, hints } = await liftSceneStraight({
       molecules,
       glRef: glRefState,

--- a/client/renderer/lib/moorhen-scene-lifter.ts
+++ b/client/renderer/lib/moorhen-scene-lifter.ts
@@ -152,7 +152,21 @@ export interface MapRenderState {
  * original source. Callers that go through serialiseSceneWithLiftHints
  * see those comments; everyone else sees a clean MoorhenScene.
  */
-export function liftScene(ctx: LiftCtx): MoorhenScene {
+/**
+ * Options controlling how a scene is lifted.
+ *
+ * `inlineDicts`: when a ligand dictionary has no project provenance (no
+ * `fileId` in `dictSources`), should its CIF be inlined as `cifText:`?
+ * Default **false** — the captured/editable YAML stays terse, carrying
+ * dicts only as re-fetchable `fileId` refs. Inlining `cifText` is reserved
+ * for the bundle lift (`liftSceneToBundle`), which immediately moves the
+ * text into a `bundle:` asset, so `cifText` never escapes into authored YAML.
+ */
+export interface LiftOpts {
+  inlineDicts?: boolean;
+}
+
+export function liftScene(ctx: LiftCtx, opts: LiftOpts = {}): MoorhenScene {
   const scene: MoorhenScene = {
     scene: ctx.sceneName ?? `scene-${new Date().toISOString().slice(0, 19).replace(/[T:]/g, "-")}`,
     version: SCENE_SCHEMA_VERSION,
@@ -184,6 +198,7 @@ export function liftScene(ctx: LiftCtx): MoorhenScene {
       mol, molFileName, scene.files!,
       mol.molNo != null ? ctx.dictSources?.get(mol.molNo) : undefined,
       ctx.projectId,
+      opts.inlineDicts ?? false,
     );
     if (liftedRefs.length > 0) {
       liftedDicts.push({ mol, molFileName, refs: liftedRefs });
@@ -268,6 +283,7 @@ function liftDictionariesForMolecule(
   allFiles: SceneFileRef[],
   sources?: Map<string, { fileId: number; projectId?: string }>,
   fallbackProjectId?: string,
+  inlineUnsourced: boolean = false,
 ): { name: string; comp_id: string }[] {
   const ligands = mol.ligands ?? [];
   // Dedupe by comp_id — multiple instances of the same ligand share a dict.
@@ -296,8 +312,17 @@ function liftDictionariesForMolecule(
       continue;
     }
 
-    // No project source → inline cifText. dropLibraryDicts() may later remove
-    // it if the comp_id resolves in the receiver's monomer library.
+    // No project source. The terse capture path emits nothing here — the
+    // dict can't be expressed as a re-fetchable ref, and inlining cifText is
+    // reserved for the bundle lift (which materialises it into a bundle:
+    // asset). So unless inlining is explicitly requested, skip it: a custom
+    // ligand dict travels only inside a bundle, never as raw cifText in
+    // authored YAML.
+    if (!inlineUnsourced) continue;
+
+    // Bundle lift only → inline cifText. dropLibraryDicts() may later remove
+    // it if the comp_id resolves in the receiver's monomer library, and
+    // liftSceneToBundle moves whatever survives into a bundle: asset.
     let dictText = "";
     try {
       dictText = mol.getDict(comp_id) || "";
@@ -350,11 +375,11 @@ export interface SceneLiftHints {
  * Same as liftScene, but also returns hints for richer YAML output
  * (currently: a comment above each file entry naming its uniqueId).
  */
-export function liftSceneWithHints(ctx: LiftCtx): {
+export function liftSceneWithHints(ctx: LiftCtx, opts: LiftOpts = {}): {
   scene: MoorhenScene;
   hints: SceneLiftHints;
 } {
-  const scene = liftScene(ctx);
+  const scene = liftScene(ctx, opts);
   const fileComments: Record<string, string> = {};
   ctx.molecules.forEach((mol, i) => {
     const fr = scene.files?.[i];
@@ -434,7 +459,10 @@ export async function liftSceneToBundle(ctx: LiftCtx): Promise<{
   hints: SceneLiftHints;
   assets: Map<string, ArrayBuffer>;
 }> {
-  const { scene, hints } = liftSceneWithHints(ctx);
+  // Bundle lift: inline unsourced dicts as cifText so step 2 below can move
+  // them into bundle assets. This is the ONLY path that materialises cifText —
+  // the straight/capture lift leaves them out entirely.
+  const { scene, hints } = liftSceneWithHints(ctx, { inlineDicts: true });
   const assets = new Map<string, ArrayBuffer>();
 
   // 0. Drop inline dict refs the receiver's monomer library already has (shared
@@ -607,12 +635,15 @@ export async function promoteSceneToPortable(ctx: PromoteCtx): Promise<{
     }
   }
 
-  // 2. Library-dict re-collection. The lifter strips dicts whose
-  //    comp_id resolves to the monomer library; self-contained mode
-  //    wants them back. Walk live molecules; for each non-standard
-  //    comp_id that the library has AND isn't already in the scene's
-  //    dict refs, fetch it and append a fresh ref.
-  if (molecules && monomerLibraryPath) {
+  // 2. Dict re-collection for self-contained mode. The capture lift carries
+  //    dicts only as terse `fileId` refs (fetched in step 1 above) and emits
+  //    NOTHING for an unsourced dict — neither library monomers nor custom
+  //    ligand dicts loaded ad-hoc into Moorhen. Self-contained mode wants both
+  //    back, materialised as bundle assets (this is where dict CIF text enters
+  //    a bundle). Walk live molecules; for each non-standard comp_id not
+  //    already represented, take the monomer-library copy, falling back to the
+  //    molecule's own in-memory dict (`mol.getDict`) for custom ligands.
+  if (molecules) {
     const existingDictNames = new Set(
       (scene.files ?? []).filter((f) => f.kind === "dictionary").map((f) => f.name),
     );
@@ -625,28 +656,43 @@ export async function promoteSceneToPortable(ctx: PromoteCtx): Promise<{
         if (STANDARD_MONOMERS.has(compId)) continue; // never travelled
         const dictName = `dict-${molFileName}-${compId}`;
         if (existingDictNames.has(dictName)) continue;
-        const url = `${monomerLibraryPath}/${compId[0].toLowerCase()}/${compId.toUpperCase()}.cif`;
-        try {
-          const res = await fetch(url);
-          if (!res.ok) continue;
-          const buf = await res.arrayBuffer();
-          const assetPath = claim(`assets/${dictName}.cif`);
-          assets.set(assetPath, buf);
-          const newRef: SceneFileRef = {
-            name: dictName,
-            kind: "dictionary",
-            bundle: assetPath,
-          };
-          (scene.files ??= []).push(newRef);
-          existingDictNames.add(dictName);
-          const el = (scene.elements ?? []).find((e) => e.file === molFileName);
-          if (el) {
-            el.dictionaries = el.dictionaries ?? [];
-            if (!el.dictionaries.includes(dictName)) el.dictionaries.push(dictName);
+
+        // Prefer the monomer-library copy; fall back to the molecule's stored
+        // dict so a custom ligand with no library entry still travels.
+        let buf: ArrayBuffer | null = null;
+        if (monomerLibraryPath) {
+          const url = `${monomerLibraryPath}/${compId[0].toLowerCase()}/${compId.toUpperCase()}.cif`;
+          try {
+            const res = await fetch(url);
+            if (res.ok) buf = await res.arrayBuffer();
+          } catch {
+            // network error → fall through to the in-memory dict below.
           }
-        } catch {
-          // network errors → leave the dict out; receiver's own Moorhen
-          // will fetch from its own library at apply time.
+        }
+        if (!buf) {
+          let dictText = "";
+          try {
+            dictText = mol.getDict(compId) || "";
+          } catch {
+            dictText = "";
+          }
+          if (dictText) buf = new TextEncoder().encode(dictText).buffer;
+        }
+        if (!buf) continue; // no library entry and no stored dict → leave out
+
+        const assetPath = claim(`assets/${dictName}.cif`);
+        assets.set(assetPath, buf);
+        const newRef: SceneFileRef = {
+          name: dictName,
+          kind: "dictionary",
+          bundle: assetPath,
+        };
+        (scene.files ??= []).push(newRef);
+        existingDictNames.add(dictName);
+        const el = (scene.elements ?? []).find((e) => e.file === molFileName);
+        if (el) {
+          el.dictionaries = el.dictionaries ?? [];
+          if (!el.dictionaries.includes(dictName)) el.dictionaries.push(dictName);
         }
       }
     }


### PR DESCRIPTION
## What

For a scene YAML (e.g. a fragment campaign), ligand dictionaries should travel as terse, re-fetchable references — not as inline `cifText:` blocks. This change makes `cifText` materialise **only on the bundle / self-contained path**; the captured/editable YAML carries dicts as `fileId` refs (project provenance) and omits anything it can't reference.

## Why

The capture lift (`liftScene` → `liftSceneStraight`) inlined a dict's CIF as `cifText:` for any dict without project provenance. In a campaign scene that:
- bloats the editable YAML with full restraint blocks, and
- risks shipping a **stale** dict variant when the project's own dict (a job output) is the source of truth.

Project dicts come from job outputs and already carry `fileId` provenance, so the right form in the YAML is the terse `fileId`+`projectId` ref.

## How

- **`liftScene` / `liftSceneWithHints`** gain `LiftOpts { inlineDicts }` (default **false**). `liftDictionariesForMolecule` now **skips** an unsourced dict rather than inlining its CIF. Project-sourced dicts still emit `fileId` refs unchanged.
- **`liftSceneToBundle`** passes `inlineDicts: true`, so it inlines the CIF and (existing step 2) folds it into a `bundle:` asset — `cifText` never escapes into authored YAML.
- **`promoteSceneToPortable`** ("Save self-contained") no longer depends on the captured YAML carrying `cifText`. Its dict re-collection now falls back to `mol.getDict()` for custom ligands with no monomer-library entry, so **bundles stay self-contained**.
- The dictionary **fetcher** still honours `cifText` when present, so hand-authored scenes that inline a dict keep working.

## Behaviour change to note

A custom ligand dict with **no** project `fileId` and **not** in the monomer library no longer appears in the plain captured YAML — it travels only inside a bundle. For campaign scenes this is the intended trade-off (those dicts are job outputs with `fileId` provenance).

## Tests

`moorhen-scene-lifter.test.ts` updated to the new contract: the default lift omits `cifText`; inlining is asserted only under `{ inlineDicts: true }`. Full scene suite green (lifter + resolver + scene + schema), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)