### PR TITLE
moorhen scenes: clip/fog precedence — explicit planes override the slab/clip bracket

### DIFF
--- a/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
+++ b/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
@@ -282,3 +282,28 @@ directive can't be reverse-engineered from a moved molecule. So the host **remem
 last-applied `superpose` block** and the lifter **re-emits it** on capture, filtered to
 entries whose `move`/`onto` files survived the lift (no dangling refs). Straight capture of
 a superposed scene now round-trips.
+
+## 11. Precedence / cascade
+
+**Principle: apply broad directives first, then let finer ones override the specific
+values they name** — CSS-specificity-like. A directive that sets a *subset* overrides one
+that sets a *superset*. It is **not automatic**: there is no general "which is broader" the
+resolver can infer, so the precedence *order* is encoded per overlapping field-group. Two
+instances today:
+
+| Field group | Broad → fine | Mechanism |
+|---|---|---|
+| Colour | `element.colour` (whole molecule) → `representation.colour` (one rep) | effective = `rep.colour ?? element.colour` (§10) |
+| View clip/fog | `slab` / `clip:{front,back}` (sets all four planes) → explicit `clipStart`/`clipEnd`/`fogStart`/`fogEnd` (per-plane) | `resolveClipFogPlanes`: broad bracket, then explicit overlay |
+
+So `slab` + an explicit `fogEnd` keeps the slab's three other planes and overrides only the
+back fog plane (previously slab won outright and the explicit plane was ignored).
+
+**Two things the principle deliberately does NOT cover:**
+- **Same-target alternatives.** `view.centre` (centroid of a selection) and `view.origin`
+  (explicit coords) both set the *one* camera origin — neither is a subset of the other, so
+  the cascade doesn't apply. It's a "which spelling wins" choice; currently `centre`
+  (intent) wins. A separate decision, not the cascade.
+- **Unit mismatch on overlay.** `slab`/explicit planes are absolute world-Å; `clip:{front,back}`
+  is zoom-scaled. Overlaying an explicit (absolute) plane onto a `clip:{front,back}` bracket
+  is a deliberate hybrid — the explicit literal wins, by design.

--- a/client/renderer/__tests__/moorhen-scene-resolver.test.ts
+++ b/client/renderer/__tests__/moorhen-scene-resolver.test.ts
@@ -15,10 +15,44 @@ import {
   geometryToM2tParams,
   isFetchable,
   resolveChainSelector,
+  resolveClipFogPlanes,
   splitMultiCid,
 } from "../lib/moorhen-scene-resolver";
 
 const present = (...nums: number[]) => new Set(nums);
+
+describe("resolveClipFogPlanes (broad → fine precedence)", () => {
+  const fco = 250;
+  it("slab alone sets all four planes (absolute Å about fco), freezes", () => {
+    const p = resolveClipFogPlanes({}, 20, 1, fco);
+    expect(p).toEqual({ clipStart: 20, clipEnd: 20, fogStart: 230, fogEnd: 270, reset: false });
+  });
+  it("explicit fogEnd OVERRIDES the slab-derived back fog plane (the fix)", () => {
+    const p = resolveClipFogPlanes({ fogEnd: 999 }, 20, 1, fco);
+    expect(p.clipStart).toBe(20); // slab kept
+    expect(p.fogStart).toBe(230); // slab kept
+    expect(p.fogEnd).toBe(999); // explicit wins
+    expect(p.reset).toBe(false);
+  });
+  it("clip:{front,back} sets zoom-scaled field-depth planes", () => {
+    const p = resolveClipFogPlanes({ clip: { front: 8, back: 21 } }, undefined, 2, fco);
+    expect(p).toEqual({ clipStart: 16, clipEnd: 42, fogStart: 234, fogEnd: 292, reset: false });
+  });
+  it("clip:\"auto\" alone = recompute (reset true), no planes", () => {
+    expect(resolveClipFogPlanes({ clip: "auto" }, undefined, 1, fco)).toEqual({ reset: true });
+  });
+  it("explicit overrides clip:\"auto\" (finer wins) and freezes", () => {
+    const p = resolveClipFogPlanes({ clip: "auto", fogEnd: 300 }, undefined, 1, fco);
+    expect(p.fogEnd).toBe(300);
+    expect(p.reset).toBe(false);
+  });
+  it("nothing specified → leave untouched (reset undefined)", () => {
+    expect(resolveClipFogPlanes({ origin: [0, 0, 0] }, undefined, 1, fco)).toEqual({ reset: undefined });
+  });
+  it("clip:\"lock\" alone freezes current with no planes", () => {
+    expect(resolveClipFogPlanes({ clip: "lock" }, undefined, 1, fco)).toEqual({ reset: false });
+  });
+});
 
 describe("buildPendingRules cascade (element.colour ↔ representation.colour)", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client/renderer/lib/moorhen-scene-resolver.ts
+++ b/client/renderer/lib/moorhen-scene-resolver.ts
@@ -81,6 +81,7 @@ import {
   SceneRepresentation,
   SceneLsqMatch,
   SceneSuperpose,
+  SceneView,
   isSceneHexColour,
   isSceneNamedColour,
   isSceneRawColour,
@@ -676,43 +677,19 @@ export async function applyScene(ctx: ResolveCtx): Promise<SceneResolveResult> {
     // (Å in front of / behind the centre, default 8/21) and recomputes them on
     // zoom UNLESS resetClippingFogging is off. So a scene that sets clip/fog also
     // pins that flag, and `clip` gives intent-level control over the depths.
-    const clip = scene.view.clip;
+    // Clip/fog precedence (broad → fine, design doc §11): a `slab` (absolute
+    // world-Å bounding-sphere bracket) or `clip: {front,back}` (zoom-scaled field
+    // depths) sets the broad bracket; explicit clipStart/End/fogStart/End then
+    // override per-plane (finest wins). So `slab` + an explicit `fogEnd` keeps the
+    // slab's other three planes and overrides only the back fog plane.
     const zoom = scene.view.zoom ?? ctx.glRef?.zoom ?? 1;
     const fco = ctx.glRef?.fogClipOffset ?? 250;
-    if (slabDepth !== undefined) {
-      // Slab: clip/fog the selection's bounding sphere. clipStart/clipEnd are an
-      // ABSOLUTE half-thickness in world Å about the fogClipOffset plane — the
-      // eye-space z is never scaled by zoom (only x/y are, in the projection), so
-      // the depth is the bounding radius (+pad) directly, NOT zoom*radius. (The
-      // field-depth `clip` form below DOES multiply by zoom because there the
-      // author gives coot's pre-zoom field depths, not an absolute distance.)
-      dispatch(setClipStart(slabDepth));
-      dispatch(setClipEnd(slabDepth));
-      dispatch(setFogStart(fco - slabDepth));
-      dispatch(setFogEnd(fco + slabDepth));
-      dispatch(setResetClippingFogging(false));
-    } else if (clip === "auto") {
-      dispatch(setResetClippingFogging(true)); // let coot recompute from zoom
-    } else if (clip && typeof clip === "object") {
-      // Field depths in Å; clip = zoom*depth, fog offset by fogClipOffset —
-      // coot's own formula with author depths. Drives clip AND fog together.
-      dispatch(setClipStart(zoom * clip.front));
-      dispatch(setClipEnd(zoom * clip.back));
-      dispatch(setFogStart(fco - zoom * clip.front));
-      dispatch(setFogEnd(fco + zoom * clip.back));
-      dispatch(setResetClippingFogging(false));
-    } else {
-      // Explicit numbers (or `clip: "lock"`): set what's given and freeze, so
-      // coot doesn't recompute them away on the next zoom.
-      const setAny =
-        scene.view.clipStart !== undefined || scene.view.clipEnd !== undefined ||
-        scene.view.fogStart !== undefined || scene.view.fogEnd !== undefined;
-      if (scene.view.clipStart !== undefined) dispatch(setClipStart(scene.view.clipStart));
-      if (scene.view.clipEnd !== undefined) dispatch(setClipEnd(scene.view.clipEnd));
-      if (scene.view.fogStart !== undefined) dispatch(setFogStart(scene.view.fogStart));
-      if (scene.view.fogEnd !== undefined) dispatch(setFogEnd(scene.view.fogEnd));
-      if (clip === "lock" || setAny) dispatch(setResetClippingFogging(false));
-    }
+    const planes = resolveClipFogPlanes(scene.view, slabDepth, zoom, fco);
+    if (planes.clipStart !== undefined) dispatch(setClipStart(planes.clipStart));
+    if (planes.clipEnd !== undefined) dispatch(setClipEnd(planes.clipEnd));
+    if (planes.fogStart !== undefined) dispatch(setFogStart(planes.fogStart));
+    if (planes.fogEnd !== undefined) dispatch(setFogEnd(planes.fogEnd));
+    if (planes.reset !== undefined) dispatch(setResetClippingFogging(planes.reset));
 
     if (scene.view.background) {
       const rgba = hexToRgba01(scene.view.background);
@@ -1480,6 +1457,64 @@ function hexToRgba01(hex: string): [number, number, number, number] | null {
   const g = parseInt(hex.slice(3, 5), 16) / 255;
   const b = parseInt(hex.slice(5, 7), 16) / 255;
   return [r, g, b, 1];
+}
+
+export interface ResolvedClipFog {
+  clipStart?: number;
+  clipEnd?: number;
+  fogStart?: number;
+  fogEnd?: number;
+  /** setResetClippingFogging value: `true` = let coot recompute from zoom (auto);
+   *  `false` = freeze; `undefined` = leave Moorhen's current state untouched. */
+  reset?: boolean;
+}
+
+/**
+ * Resolve clip/fog planes with broad → fine precedence (the cascade principle,
+ * design doc §11):
+ *   1. the broadest source present sets all four planes — `slab` (absolute
+ *      world-Å half-thickness about the fog-clip offset) OR `clip: {front,back}`
+ *      (zoom-scaled coot field depths);
+ *   2. explicit `clipStart`/`clipEnd`/`fogStart`/`fogEnd` then override per-plane
+ *      (finest wins) — so e.g. `slab` + explicit `fogEnd` keeps the slab's other
+ *      three planes and overrides only the back fog plane.
+ * `clip: "auto"` with nothing finer = recompute (`reset:true`); no clip/fog/slab
+ * at all = leave untouched (`reset` undefined); anything else = freeze
+ * (`reset:false`). Pure (no dispatch) so the precedence is unit-testable.
+ */
+export function resolveClipFogPlanes(
+  view: SceneView,
+  slabDepth: number | undefined,
+  zoom: number,
+  fco: number,
+): ResolvedClipFog {
+  const clip = view.clip;
+  const hasBroad = slabDepth !== undefined || (!!clip && typeof clip === "object");
+  const hasExplicit =
+    view.clipStart !== undefined || view.clipEnd !== undefined ||
+    view.fogStart !== undefined || view.fogEnd !== undefined;
+
+  if (clip === "auto" && !hasBroad && !hasExplicit) return { reset: true };
+  if (clip === undefined && !hasBroad && !hasExplicit) return {}; // nothing → leave
+
+  const out: ResolvedClipFog = { reset: false };
+  if (slabDepth !== undefined) {
+    out.clipStart = slabDepth;
+    out.clipEnd = slabDepth;
+    out.fogStart = fco - slabDepth;
+    out.fogEnd = fco + slabDepth;
+  } else if (clip && typeof clip === "object") {
+    out.clipStart = zoom * clip.front;
+    out.clipEnd = zoom * clip.back;
+    out.fogStart = fco - zoom * clip.front;
+    out.fogEnd = fco + zoom * clip.back;
+  }
+  // Finer explicit planes override the broad bracket, per-plane.
+  if (view.clipStart !== undefined) out.clipStart = view.clipStart;
+  if (view.clipEnd !== undefined) out.clipEnd = view.clipEnd;
+  if (view.fogStart !== undefined) out.fogStart = view.fogStart;
+  if (view.fogEnd !== undefined) out.fogEnd = view.fogEnd;
+  return out;
 }
 
 /**


### PR DESCRIPTION
The clip/fog applier was `if slab … else if clip … else explicit`, so a **`slab` won outright** and an explicit `fogEnd`/`clipStart`/… alongside it was silently ignored. Restructured to the **broad → fine cascade**: the broadest source (`slab`, else `clip:{front,back}`) sets all four planes, then explicit per-plane values override.

- **`resolveClipFogPlanes`** — pure, exported, unit-tested: broad bracket then explicit overlay; preserves `auto` (recompute) / `lock` (freeze) / nothing-specified (leave untouched) semantics. So `slab` + explicit `fogEnd` → slab keeps clip + front-fog, `fogEnd` overrides the back plane.
- **Design doc §11 "Precedence / cascade"** — documents the principle (CSS-specificity-like; a subset-setter overrides a superset-setter; encoded per field-group, not automatic) and its two deliberate non-cases: same-target alternatives (`view.centre` vs `view.origin`) and absolute-vs-zoom-scaled overlay.

This generalises the colour cascade (`element.colour` → `representation.colour`, §10) to the second overlapping field-group. 231 tests pass; tsc clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)