### PR TITLE
moorhen scenes: mirror server-consumed artifacts into the ccp4i2 package

### DIFF
--- a/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
+++ b/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
@@ -353,6 +353,20 @@ Depth 5 and the property count sit near older documented OpenAI ceilings; curren
 limits clear them, but Materia owns the live API and should confirm against its pinned
 `AZURE_OPENAI_API_VERSION`.
 
+**Server reachability (slim deployments).** The five artifacts above live under
+`client/renderer/lib/scene/` because that is where the Zod generator lives. But a
+frontend-free Django deployment (Materia's slim `nlp_scene` server) installs only the
+`ccp4i2` Python package and never copies `client/renderer/*`, so it cannot read them there.
+The two artifacts a *server* consumes — `moorhen-scene.system-prompt.v1.md` (system message)
+and `moorhen-scene.structured.v1.json` (strict profile) — are therefore **mirrored** into
+`server/ccp4i2/scene_contracts/`, which ships as package data (`[tool.setuptools.package-data]
+ccp4i2 = ["**/*"]`, no pyproject change) and is read via
+`importlib.resources.files("ccp4i2") / "scene_contracts" / …`. The frontend copies stay
+canonical; the same drift test writes and byte-equality-checks the server mirror, so the two
+locations can never diverge from the one Zod source. (Chosen over having the consumer COPY
+from the submodule's frontend path at image build — that couples an external build to a
+frontend file location; the mirror keeps it single-source and pinned with the package.)
+
 **Endpoint contract** (Materia-owned, `notes-for-ccp4i2/nlp-scene-endpoint-contract.md`):
 `POST /api/proxy/compounds/nlp/scene` (no trailing slash); body `{ request, grounding?,
 brief? }`; response `{ status:"scene", scene:"<raw>" }`. **Spike** = no `response_format`

--- a/client/renderer/__tests__/scene-schema.test.ts
+++ b/client/renderer/__tests__/scene-schema.test.ts
@@ -8,7 +8,7 @@
  *
  *   UPDATE_SCHEMA=1 npx vitest run renderer/__tests__/scene-schema.test.ts
  */
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -34,6 +34,31 @@ const CONTRACTS = {
   core: path.join(SCENE_DIR, "moorhen-scene.core.v1.json"),
   ccp4i2: path.join(SCENE_DIR, "moorhen-scene.ccp4i2.v1.json"),
 } as const;
+
+// Server-side mirror of the artifacts a slim (frontend-free) Django deployment
+// consumes — Materia's nlp_scene endpoint reads them from the installed ccp4i2
+// package via importlib.resources. client/renderer is canonical (the Zod source
+// lives here); this keeps the server copies byte-identical so they can never
+// drift. See MOORHEN_SCENES_SCHEMA_V1_DESIGN.md §12.
+const SERVER_CONTRACTS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../server/ccp4i2/scene_contracts",
+);
+
+/** Assert a server-tree mirror is byte-identical to the canonical content
+ *  (regenerating it under UPDATE_SCHEMA). */
+function assertServerMirror(filename: string, content: string): void {
+  const p = path.join(SERVER_CONTRACTS_DIR, filename);
+  if (process.env.UPDATE_SCHEMA) {
+    mkdirSync(SERVER_CONTRACTS_DIR, { recursive: true });
+    writeFileSync(p, content);
+  }
+  expect(
+    existsSync(p),
+    `server mirror ${filename} missing; run with UPDATE_SCHEMA=1`,
+  ).toBe(true);
+  expect(readFileSync(p, "utf8")).toBe(content);
+}
 
 describe("published JSON Schema contracts", () => {
   const built = buildJsonSchemas();
@@ -72,6 +97,7 @@ describe("published JSON Schema contracts", () => {
     if (process.env.UPDATE_SCHEMA) writeFileSync(sysPath, sys);
     expect(existsSync(sysPath), "committed system prompt missing; run with UPDATE_SCHEMA=1").toBe(true);
     expect(readFileSync(sysPath, "utf8")).toBe(sys);
+    assertServerMirror("moorhen-scene.system-prompt.v1.md", sys);
   });
 
   const STRUCTURED = path.join(SCENE_DIR, "moorhen-scene.structured.v1.json");
@@ -81,6 +107,7 @@ describe("published JSON Schema contracts", () => {
     if (process.env.UPDATE_SCHEMA) writeFileSync(STRUCTURED, serialised);
     expect(existsSync(STRUCTURED), "committed structured profile missing; run with UPDATE_SCHEMA=1").toBe(true);
     expect(serialised).toBe(readFileSync(STRUCTURED, "utf8"));
+    assertServerMirror("moorhen-scene.structured.v1.json", serialised);
   });
 
   it("the strict profile obeys OpenAI Structured Outputs shape rules", () => {

--- a/server/ccp4i2/scene_contracts/README.md
+++ b/server/ccp4i2/scene_contracts/README.md
@@ -1,0 +1,30 @@
+# Moorhen scene contracts — server-readable mirror
+
+These files are **generated artifacts mirrored from the frontend**, where the Zod
+source of truth lives (`client/renderer/lib/scene/`). They are duplicated here so
+a slim, frontend-free Django deployment can read them from the installed `ccp4i2`
+package — `server/ccp4i2/**/*` ships as package data, so:
+
+```python
+from importlib.resources import files
+text = (files("ccp4i2") / "scene_contracts" / "moorhen-scene.system-prompt.v1.md").read_text()
+```
+
+| File | Role |
+|------|------|
+| `moorhen-scene.system-prompt.v1.md` | the static LLM **system** message for scene authoring (Materia's `nlp_scene` endpoint) |
+| `moorhen-scene.structured.v1.json` | strict **OpenAI Structured Outputs** profile (production `json_schema` constraint) |
+
+## Do not edit by hand
+
+They are byte-equality-checked against the canonical frontend copies by
+`client/renderer/__tests__/scene-schema.test.ts`. To regenerate after an
+intentional schema/prompt change, run (from `client/`):
+
+```bash
+UPDATE_SCHEMA=1 npx vitest run renderer/__tests__/scene-schema.test.ts
+```
+
+That rewrites both the `client/renderer/lib/scene/` originals and these mirrors
+from the one Zod source, so they can never drift. See
+`client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md` §12.

--- a/server/ccp4i2/scene_contracts/moorhen-scene.structured.v1.json
+++ b/server/ccp4i2/scene_contracts/moorhen-scene.structured.v1.json
@@ -1,0 +1,1309 @@
+{
+  "type": "object",
+  "properties": {
+    "scene": {
+      "type": "string",
+      "description": "human-readable scene name"
+    },
+    "version": {
+      "type": "number",
+      "description": "must equal 1"
+    },
+    "authoredIn": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "projectId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "projectName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "createdAt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "createdBy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ccp4i2Version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "projectId",
+        "projectName",
+        "createdAt",
+        "createdBy",
+        "ccp4i2Version"
+      ]
+    },
+    "files": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "local name referenced by elements/maps"
+          },
+          "kind": {
+            "description": "default \"coordinates\"",
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "coordinates",
+              "dictionary",
+              "mtz",
+              "map",
+              null
+            ]
+          },
+          "pdb": {
+            "description": "PDB id; fetched via proxy on apply",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "description": "absolute URL (portable)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bundle": {
+            "description": "asset path inside a .scene.zip",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cifText": {
+            "description": "inline CIF (dictionary refs only)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "relativeUrl": {
+            "description": "origin-relative URL (/api/…); not portable across deployments",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "projectId": {
+            "description": "UUID; required with fileId or job+param",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "projectName": {
+            "description": "advisory",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "fileId": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "job": {
+            "description": "pair with param",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "param": {
+            "description": "job parameter, e.g. \"XYZOUT\"",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "kind",
+          "pdb",
+          "url",
+          "bundle",
+          "cifText",
+          "relativeUrl",
+          "projectId",
+          "projectName",
+          "fileId",
+          "job",
+          "param"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "superpose": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "method": {
+                "type": "string",
+                "const": "ssm"
+              },
+              "move": {
+                "type": "string",
+                "description": "file being transformed"
+              },
+              "onto": {
+                "type": "string",
+                "description": "reference file (unchanged)"
+              },
+              "movChain": {
+                "type": "string"
+              },
+              "refChain": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "method",
+              "move",
+              "onto",
+              "movChain",
+              "refChain"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "method": {
+                "type": "string",
+                "const": "lsq"
+              },
+              "move": {
+                "type": "string"
+              },
+              "onto": {
+                "type": "string"
+              },
+              "matches": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "refChain": {
+                      "type": "string"
+                    },
+                    "refRange": {
+                      "type": "string"
+                    },
+                    "movChain": {
+                      "type": "string"
+                    },
+                    "movRange": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "refChain",
+                    "refRange",
+                    "movChain",
+                    "movRange"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "chain": {
+                "description": "shorthand chain, both sides",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "range": {
+                "description": "shorthand range, both sides",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "matchType": {
+                "description": "default \"main\"",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "all",
+                  "main",
+                  "ca",
+                  null
+                ]
+              }
+            },
+            "required": [
+              "method",
+              "move",
+              "onto",
+              "matches",
+              "chain",
+              "range",
+              "matchType"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "globalDictionaries": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "domains": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "used by colour: by-domain and the resolver log"
+          },
+          "selection": {
+            "type": "string",
+            "description": "CID selection, e.g. //F or //F/32-64"
+          },
+          "color": {
+            "type": "string",
+            "description": "hex colour #rrggbb or #rrggbbaa"
+          }
+        },
+        "required": [
+          "name",
+          "selection",
+          "color"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "elements": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "name of a files[] entry"
+          },
+          "dictionaries": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "colour": {
+            "description": "molecule-scoped colour: the default for every representation of this file; a representation's own `colour` overrides it",
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "hex colour #rrggbb or #rrggbbaa"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "by-domain",
+                  "b-factor",
+                  "b-factor-norm",
+                  "af2-plddt",
+                  "secondary-structure",
+                  "jones-rainbow",
+                  "mol-symm"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "selection": {
+                      "type": "string",
+                      "description": "CID, e.g. \"//A\" or \"//A/121-130\""
+                    },
+                    "colour": {
+                      "type": "string",
+                      "description": "hex colour #rrggbb or #rrggbbaa"
+                    }
+                  },
+                  "required": [
+                    "selection",
+                    "colour"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "raw": {
+                    "type": "object",
+                    "properties": {
+                      "ruleType": {
+                        "type": "string"
+                      },
+                      "args": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            }
+                          ]
+                        }
+                      },
+                      "isMultiColourRule": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
+                      "applyColourToNonCarbonAtoms": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "ruleType",
+                      "args",
+                      "isMultiColourRule",
+                      "applyColourToNonCarbonAtoms"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "raw"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "representations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "style": {
+                  "type": "string",
+                  "enum": [
+                    "VdwSpheres",
+                    "ligands",
+                    "CAs",
+                    "CBs",
+                    "CDs",
+                    "gaussian",
+                    "allHBonds",
+                    "rama",
+                    "rotamer",
+                    "CRs",
+                    "MolecularSurface",
+                    "DishyBases",
+                    "VdWSurface",
+                    "Calpha",
+                    "unitCell",
+                    "hover",
+                    "environment",
+                    "ligand_environment",
+                    "contact_dots",
+                    "chemical_features",
+                    "ligand_validation",
+                    "glycoBlocks",
+                    "restraints",
+                    "residueSelection",
+                    "MetaBalls",
+                    "adaptativeBonds",
+                    "StickBases",
+                    "residue_environment",
+                    "transformation"
+                  ],
+                  "description": "Moorhen RepresentationStyle, e.g. \"CRs\", \"CBs\""
+                },
+                "selection": {
+                  "description": "CID; default all-atoms",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "colour": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "hex colour #rrggbb or #rrggbbaa"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "by-domain",
+                        "b-factor",
+                        "b-factor-norm",
+                        "af2-plddt",
+                        "secondary-structure",
+                        "jones-rainbow",
+                        "mol-symm"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "selection": {
+                            "type": "string",
+                            "description": "CID, e.g. \"//A\" or \"//A/121-130\""
+                          },
+                          "colour": {
+                            "type": "string",
+                            "description": "hex colour #rrggbb or #rrggbbaa"
+                          }
+                        },
+                        "required": [
+                          "selection",
+                          "colour"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "raw": {
+                          "type": "object",
+                          "properties": {
+                            "ruleType": {
+                              "type": "string"
+                            },
+                            "args": {
+                              "type": "array",
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              }
+                            },
+                            "isMultiColourRule": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "applyColourToNonCarbonAtoms": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "ruleType",
+                            "args",
+                            "isMultiColourRule",
+                            "applyColourToNonCarbonAtoms"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "raw"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "alpha": {
+                  "description": "opacity 0..1 (honoured: governs visibility)",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "geometry": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "bondRadius": {
+                      "description": "bond cylinder radius (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "ballRadius": {
+                      "description": "ball-and-stick atom ball radius (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "vdwScale": {
+                      "description": "VdW sphere radius multiplier (×element radius)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "probeRadius": {
+                      "description": "molecular-surface solvent probe radius (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "ribbonCoilThickness": {
+                      "description": "ribbon coil thickness (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "ribbonHelixWidth": {
+                      "description": "ribbon helix width (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "ribbonStrandWidth": {
+                      "description": "ribbon strand width (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "ribbonArrowWidth": {
+                      "description": "ribbon arrow width (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "ribbonDNARNAWidth": {
+                      "description": "nucleotide ribbon width (Å)",
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "bondRadius",
+                    "ballRadius",
+                    "vdwScale",
+                    "probeRadius",
+                    "ribbonCoilThickness",
+                    "ribbonHelixWidth",
+                    "ribbonStrandWidth",
+                    "ribbonArrowWidth",
+                    "ribbonDNARNAWidth"
+                  ]
+                }
+              },
+              "required": [
+                "style",
+                "selection",
+                "colour",
+                "alpha",
+                "geometry"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "file",
+          "dictionaries",
+          "colour",
+          "representations"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "maps": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "file": {
+            "type": "string",
+            "description": "name of a files[] entry (kind mtz or map)"
+          },
+          "columns": {
+            "description": "required for mtz, omit for map",
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "F": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "PHI": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "Fobs": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "SigFobs": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "FreeR": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "useWeight": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "calcStructFact": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "F",
+              "PHI",
+              "Fobs",
+              "SigFobs",
+              "FreeR",
+              "useWeight",
+              "calcStructFact"
+            ]
+          },
+          "isMask": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "isDifference": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "contourLevel": {
+            "description": "rmsd-relative",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "radius": {
+            "description": "contour radius (Å)",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "alpha": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "style": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "lines",
+              "solid",
+              "lit-lines",
+              null
+            ]
+          },
+          "colour": {
+            "description": "non-difference maps only",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "positiveColour": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "hex colour #rrggbb or #rrggbbaa"
+          },
+          "negativeColour": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "hex colour #rrggbb or #rrggbbaa"
+          },
+          "visible": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "file",
+          "columns",
+          "isMask",
+          "isDifference",
+          "contourLevel",
+          "radius",
+          "alpha",
+          "style",
+          "colour",
+          "positiveColour",
+          "negativeColour",
+          "visible"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "activeMap": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "view": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "origin": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "centre": {
+          "description": "centroid of a selection; beats origin",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "selection": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "file",
+            "selection"
+          ]
+        },
+        "quat": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "zoom": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "clipStart": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "clipEnd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "fogStart": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "fogEnd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "clip": {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "auto"
+            },
+            {
+              "type": "string",
+              "const": "lock"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "front": {
+                  "type": "number"
+                },
+                "back": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "front",
+                "back"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "slab": {
+          "description": "z-depth window for a selection; beats clip",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "selection": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pad": {
+              "description": "extra Å each side",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "file",
+            "selection",
+            "pad"
+          ]
+        },
+        "background": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "hex colour #rrggbb or #rrggbbaa"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "origin",
+        "centre",
+        "quat",
+        "zoom",
+        "clipStart",
+        "clipEnd",
+        "fogStart",
+        "fogEnd",
+        "clip",
+        "slab",
+        "background"
+      ]
+    },
+    "hints": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "lighting": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "direction": {
+              "description": "principal directional light vector → Moorhen lightPosition",
+              "type": [
+                "array",
+                "null"
+              ],
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "ambient": {
+              "description": "ambient light colour",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "diffuse": {
+              "description": "diffuse light colour",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "specular": {
+              "description": "specular light colour",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "shininess": {
+              "description": "specular power → Moorhen specularPower",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "direction",
+            "ambient",
+            "diffuse",
+            "specular",
+            "shininess"
+          ]
+        },
+        "effects": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "ssao": {
+              "description": "screen-space ambient occlusion",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "enabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "radius": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "bias": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "enabled",
+                "radius",
+                "bias"
+              ]
+            },
+            "edgeDetect": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "enabled": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                },
+                "depthThreshold": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "normalThreshold": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "depthScale": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "normalScale": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "enabled",
+                "depthThreshold",
+                "normalThreshold",
+                "depthScale",
+                "normalScale"
+              ]
+            },
+            "shadows": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "depthBlur": {
+              "description": "depth-of-field blur",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "radius": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "depth": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "radius",
+                "depth"
+              ]
+            },
+            "perspective": {
+              "description": "perspective vs orthographic",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ssao",
+            "edgeDetect",
+            "shadows",
+            "depthBlur",
+            "perspective"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "lighting",
+        "effects"
+      ]
+    },
+    "resolver": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "onMissingResidues": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "clamp-and-log",
+            "strict",
+            null
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "onMissingResidues"
+      ]
+    }
+  },
+  "required": [
+    "scene",
+    "version",
+    "authoredIn",
+    "files",
+    "superpose",
+    "globalDictionaries",
+    "domains",
+    "elements",
+    "maps",
+    "activeMap",
+    "view",
+    "hints",
+    "resolver"
+  ],
+  "additionalProperties": false
+}

--- a/server/ccp4i2/scene_contracts/moorhen-scene.system-prompt.v1.md
+++ b/server/ccp4i2/scene_contracts/moorhen-scene.system-prompt.v1.md
@@ -1,0 +1,227 @@
+You are drafting a Moorhen "scene": a YAML document describing a molecular
+view. Follow the grammar below EXACTLY. Return the scene as a SINGLE fenced YAML
+code block (```yaml ... ```) and nothing else outside it — YAML is
+whitespace-sensitive, and a code block lets the chat UI show a copy button that
+preserves the exact indentation (selecting the text by hand does not). If — and
+only if — the request is materially ambiguous and no reasonable default exists,
+you may FIRST ask one concise clarifying question in plain text and wait for the
+reply before producing the code block.
+Reference project files with { job, param, projectId } using the manifest; use
+pdb:/url: only for structures not in the project; never use relativeUrl:.
+Use the exact ligand CIDs from the contents summary for ligand selections.
+
+=== SCENE GRAMMAR ===
+Moorhen scene — YAML grammar (fields, ? = optional):
+
+scene: string  # human-readable scene name
+version: number  # must equal 1
+authoredIn?: {
+  projectId?: string
+  projectName?: string
+  createdAt?: string
+  createdBy?: string
+  ccp4i2Version?: string
+}
+files?: ({
+  name: string  # local name referenced by elements/maps
+  kind?: "coordinates"|"dictionary"|"mtz"|"map"  # default "coordinates"
+  pdb?: string  # PDB id; fetched via proxy on apply
+  url?: string  # absolute URL (portable)
+  bundle?: string  # asset path inside a .scene.zip
+  cifText?: string  # inline CIF (dictionary refs only)
+  relativeUrl?: string  # origin-relative URL (/api/…); not portable across deployments
+  projectId?: string  # UUID; required with fileId or job+param
+  projectName?: string  # advisory
+  fileId?: number
+  job?: number  # pair with param
+  param?: string  # job parameter, e.g. "XYZOUT"
+})[]
+superpose?: ({
+  method: "ssm"
+  move: string  # file being transformed
+  onto: string  # reference file (unchanged)
+  movChain: string
+  refChain: string
+} | {
+  method: "lsq"
+  move: string
+  onto: string
+  matches?: {
+    refChain: string
+    refRange: string
+    movChain: string
+    movRange: string
+  }[]
+  chain?: string  # shorthand chain, both sides
+  range?: string  # shorthand range, both sides
+  matchType?: "all"|"main"|"ca"  # default "main"
+})[]
+globalDictionaries?: string[]
+domains?: { name: string, selection: string, color: string }[]
+elements?: ({
+  file: string  # name of a files[] entry
+  dictionaries?: string[]
+  colour?: string | "by-domain"|"b-factor"|"b-factor-norm"|"af2-plddt"|"secondary-structure"|"jones-rainbow"|"mol-symm" | { selection: string, colour: string }[] | {
+    raw: {
+      ruleType: string
+      args: (string | number)[]
+      isMultiColourRule?: boolean
+      applyColourToNonCarbonAtoms?: boolean
+    }
+  }  # molecule-scoped colour: the default for every representation of this file; a representation's own `colour` overrides it
+  representations?: ({
+    style: "VdwSpheres"|"ligands"|"CAs"|"CBs"|"CDs"|"gaussian"|"allHBonds"|"rama"|"rotamer"|"CRs"|"MolecularSurface"|"DishyBases"|"VdWSurface"|"Calpha"|"unitCell"|"hover"|"environment"|"ligand_environment"|"contact_dots"|"chemical_features"|"ligand_validation"|"glycoBlocks"|"restraints"|"residueSelection"|"MetaBalls"|"adaptativeBonds"|"StickBases"|"residue_environment"|"transformation"  # Moorhen RepresentationStyle, e.g. "CRs", "CBs"
+    selection?: string  # CID; default all-atoms
+    colour?: string | "by-domain"|"b-factor"|"b-factor-norm"|"af2-plddt"|"secondary-structure"|"jones-rainbow"|"mol-symm" | { selection: string, colour: string }[] | {
+      raw: {
+        ruleType: string
+        args: (string | number)[]
+        isMultiColourRule?: boolean
+        applyColourToNonCarbonAtoms?: boolean
+      }
+    }
+    alpha?: number  # opacity 0..1 (honoured: governs visibility)
+    geometry?: {
+      bondRadius?: number  # bond cylinder radius (Å)
+      ballRadius?: number  # ball-and-stick atom ball radius (Å)
+      vdwScale?: number  # VdW sphere radius multiplier (×element radius)
+      probeRadius?: number  # molecular-surface solvent probe radius (Å)
+      ribbonCoilThickness?: number  # ribbon coil thickness (Å)
+      ribbonHelixWidth?: number  # ribbon helix width (Å)
+      ribbonStrandWidth?: number  # ribbon strand width (Å)
+      ribbonArrowWidth?: number  # ribbon arrow width (Å)
+      ribbonDNARNAWidth?: number  # nucleotide ribbon width (Å)
+    }
+  })[]
+})[]
+maps?: ({
+  name: string
+  file: string  # name of a files[] entry (kind mtz or map)
+  columns?: {
+    F?: string
+    PHI?: string
+    Fobs?: string
+    SigFobs?: string
+    FreeR?: string
+    useWeight?: boolean
+    calcStructFact?: boolean
+  }  # required for mtz, omit for map
+  isMask?: boolean
+  isDifference?: boolean
+  contourLevel?: number  # rmsd-relative
+  radius?: number  # contour radius (Å)
+  alpha?: number
+  style?: "lines"|"solid"|"lit-lines"
+  colour?: string  # non-difference maps only
+  positiveColour?: string  # hex colour #rrggbb or #rrggbbaa
+  negativeColour?: string  # hex colour #rrggbb or #rrggbbaa
+  visible?: boolean
+})[]
+activeMap?: string
+view?: {
+  origin?: [number, number, number]
+  centre?: { file?: string, selection?: string }  # centroid of a selection; beats origin
+  quat?: [number, number, number, number]
+  zoom?: number
+  clipStart?: number
+  clipEnd?: number
+  fogStart?: number
+  fogEnd?: number
+  clip?: "auto" | "lock" | { front: number, back: number }
+  slab?: { file?: string, selection?: string, pad?: number }  # z-depth window for a selection; beats clip
+  background?: string  # hex colour #rrggbb or #rrggbbaa
+}
+hints?: {
+  lighting?: {
+    direction?: [number, number, number]  # principal directional light vector → Moorhen lightPosition
+    ambient?: string  # ambient light colour
+    diffuse?: string  # diffuse light colour
+    specular?: string  # specular light colour
+    shininess?: number  # specular power → Moorhen specularPower
+  }
+  effects?: {
+    ssao?: { enabled?: boolean, radius?: number, bias?: number }  # screen-space ambient occlusion
+    edgeDetect?: {
+      enabled?: boolean
+      depthThreshold?: number
+      normalThreshold?: number
+      depthScale?: number
+      normalScale?: number
+    }
+    shadows?: boolean
+    depthBlur?: { radius?: number, depth?: number }  # depth-of-field blur
+    perspective?: boolean  # perspective vs orthographic
+  }
+}
+resolver?: { onMissingResidues?: "clamp-and-log"|"strict" }
+
+=== CONVENTIONS ===
+- Selections are Coot CIDs: //A (whole chain A), //A/703-740 (residue range),
+  //*/LIG (residues named LIG), //A/750/CA (one atom). Join several with || :
+  //A||//B. Same syntax in representation `selection` and in view.centre/slab.
+- A representation draws its own `selection` (the WHOLE molecule if omitted);
+  colour does NOT limit what is drawn — scope the selection to limit it.
+- colour is a hex "#rrggbb"; OR a named scheme (by-domain, b-factor, af2-plddt,
+  secondary-structure, jones-rainbow, mol-symm); OR a per-selection list
+  [{selection, colour}]. `by-domain` colours by the top-level `domains:` block:
+  define domains (name + selection + color) and set `colour: by-domain` on reps.
+- `element.colour` sets a molecule-wide default (any colour form above) inherited by
+  every representation of that file; a representation's own `colour` overrides it.
+- geometry dimensions are Ångström. `hints` (lighting/effects) are ADVISORY —
+  a viewer may ignore them; never rely on them for what must be visible.
+
+=== EXAMPLE (shape only — use the PROJECT/CONTENTS below for real refs) ===
+```yaml
+scene: example
+version: 1
+files:
+  - { name: prot, pdb: 1ABC }
+domains:
+  - { name: nterm, selection: "//A/1-100",   color: "#4b8bbe" }
+  - { name: cterm, selection: "//A/101-200", color: "#e74c3c" }
+elements:
+  - file: prot
+    representations:
+      - { style: CRs, selection: "//A", colour: by-domain }
+view:
+  centre: { file: prot, selection: "//A" }
+```
+
+=== INTERPRETING THE REQUEST ===
+Turn everyday phrasing into concrete selections using the CONTENTS and PROJECT
+above. Never invent chains, ligands, or residues that are not listed.
+- Back-references point to what the request already named: "the dimer", "the
+  complex", "it", "both", "that" refer to the chains/entities mentioned earlier
+  in the SAME request. After "chains A and B ...", "the dimer" means chains A and B.
+- A representation draws its own `selection` (the WHOLE molecule if you omit it),
+  so to show only certain chains/residues you MUST set that selection. Colour does
+  NOT limit what is drawn: "chains A and B as ribbon" needs a CRs representation
+  with selection //A||//B — an unscoped one draws every chain (C and D too), even
+  if the colours only cover A and B.
+- When a representation is requested "of"/"for" an entity, scope THAT
+  representation's selection to the same entity. "a surface of the dimer" after
+  "chains A and B" => a MolecularSurface whose selection covers chains A and B.
+- "the protein" / "the model" / "everything" => all polymer chains.
+- "monomer" => one polymer chain; "dimer"/"trimer"/... => that many polymer
+  chains (prefer the chains the request names; otherwise the polymer chains
+  present, in order).
+- A ligand named or given by 3-letter code ("ATP", "the ligand", "the inhibitor",
+  "the drug") => the matching ligand CID from the contents. If exactly one ligand
+  is present, "the ligand" means it.
+- "active site" / "binding site" / "around the ligand" => the ligand and its
+  surroundings (a neighbourhood selection if the grammar supports one, else the
+  ligand's chain/residue).
+- Colour cues: "by domain" => the domains block; "by chain" / "rainbow" /
+  "spectrum" => the matching colour scheme in the grammar.
+- To cover several chains or residue ranges in ONE selection, join them with
+  "||" (e.g. //A||//B). This works in representation selections AND in view
+  directives (centre, slab) — use the same form throughout.
+- Camera vs depth are SEPARATE directives. `view.centre` moves the camera to a
+  selection; `view.slab` only sets the clip DEPTH (it does not move the camera).
+  So "centre on chains A and B AND slab to contain them" needs BOTH:
+  view.centre.selection = //A||//B  and  view.slab.selection = //A||//B. Emitting
+  slab alone will not centre the view.
+For minor ambiguity, choose the most likely reading and proceed. Ask a concise
+clarifying question ONLY when the ambiguity would materially change the scene and
+no reasonable default exists (e.g. which two chains form "the dimer" in a
+tetramer) — ask once, then return the YAML code block once answered.


### PR DESCRIPTION
Closes the one decision Materia handed back (`notes-for-ccp4i2/nlp-scene-spike-built.md`): the scene artifacts live under `client/renderer/` (where the Zod generator is), but Materia's slim `nlp_scene` server installs only the `ccp4i2` Python package and never copies `client/renderer/*`, so it can't read them in production.

## What
Mirror the two **server-consumed** artifacts into `server/ccp4i2/scene_contracts/`:
- `moorhen-scene.system-prompt.v1.md` — the LLM system message
- `moorhen-scene.structured.v1.json` — the strict OpenAI Structured Outputs profile

`server/ccp4i2/**/*` already ships as package data (`[tool.setuptools.package-data]`), so these travel with `pip install ccp4i2` with **no pyproject change**, read via `importlib.resources.files("ccp4i2") / "scene_contracts" / …`.

## Single-source guarantee
`client/renderer/lib/scene/` stays canonical (the Zod source lives there). The **same** `scene-schema` drift test now also writes + byte-equality-checks the server mirror, so the two locations can never diverge. (Chosen over Materia `COPY`-ing from the submodule's frontend path — that couples an external image build to a frontend file location.)

Design doc §12 records the decision + import path. Reply note to Materia written.

## Test
- `npx tsc --noEmit` clean
- 234 unit tests pass (drift test extended to cover the server mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)