### PR TITLE
moorhen scenes: fit the strict profile under Azure's 100-property cap

### DIFF
--- a/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
+++ b/client/renderer/MOORHEN_SCENES_SCHEMA_V1_DESIGN.md
@@ -332,26 +332,48 @@ differing byte, so anything general must sit *above* the first volatile element.
 the block verbatim lets a pinned submodule (Materia's `nlp_scene` endpoint) hold it as the
 server-side system message without importing TS.
 
-**Strict profile.** `buildStructuredJsonSchema()` mechanically rewrites the **ccp4i2**
-contract (not core — the endpoint grounds the model with the project manifest, so job/param
-refs must be expressible) into OpenAI strict form: `oneOf`→`anyOf`; every object gets
-`additionalProperties:false` and **all** keys required; optional fields become nullable
-(present-as-null); and all unsupported vocabulary is dropped (`pattern`, `format`, numeric/
-length/array bounds, `default`, `$schema`). The transform is **lossy by design** — the
-constraints it drops (CID/hex patterns, Å bounds, exactly-one-file-source, cross-references)
-are re-checked by `parseScene`/`validateScene`, which stay the sole authority. A structural
-test asserts no forbidden keyword survives and every object is closed+all-required.
+**Strict profile.** `buildStructuredJsonSchema()` derives the strict profile from the
+**ccp4i2** contract (not core — the endpoint grounds the model with the project manifest, so
+job/param refs must be expressible) in two passes:
+
+1. **`pruneForAuthoringCore`** — narrows to the *authoring core*. **Azure OpenAI hard-caps a
+   strict `json_schema` at 100 object properties total** (a documented subset limit, the same
+   for every model/api-version — *not* something a version bump raises; OpenAI's own platform
+   raised its limit but Azure's stayed at 100/5 as of 2026-06). The full contract is ~142
+   properties, so the strict profile drops the fields §7a always earmarked as the "hide from a
+   small authoring model" set: the whole `hints` block (advisory; the resolver doesn't apply
+   lighting yet — ~22 props), the raw-colour escape hatch (~10), `authoredIn` provenance (6),
+   plus rarely-authored detail (`relativeUrl`/`bundle`/`cifText`, ribbon geometry dims, the
+   four fine clip/fog planes, MTZ `columns`). Result: **83 properties, depth 4** — comfortably
+   under 100/5, with a test asserting ≤90 so a later schema addition fails loudly here instead
+   of 400ing in production. This narrows only what the model can *emit*; `validateScene` still
+   accepts every dropped field, so a human (or the non-strict path) can still author them.
+2. **`strictify`** — OpenAI strict *shape*: `oneOf`→`anyOf`; every object gets
+   `additionalProperties:false` and **all** keys required; optionals become nullable
+   (present-as-null); unsupported vocabulary dropped (`pattern`, `format`, numeric/length/array
+   bounds, `default`, `$schema`).
+
+Both passes are **lossy by design** — the dropped constraints (CID/hex patterns, Å bounds,
+exactly-one-file-source, cross-references) and the pruned fields are re-checked / re-admitted
+by `parseScene`/`validateScene`, the sole authority. A structural test asserts no forbidden
+keyword survives, every object is closed + all-required, and the property/depth budget holds.
+
+> **Why not `$defs` dedup instead of pruning?** Routing repeated subschemas through `$defs`
+> would only help if Azure counts a definition once rather than per-`$ref` (undocumented). It
+> is moot regardless: the contract has almost no duplication — only the raw-colour rule and the
+> `{selection,colour}` pair repeat (~7 properties), so perfect dedup still lands ~135, far over
+> 100. Pruning to the authoring core is the only approach that actually fits.
 
 **Null-strip on ingest.** Strict mode makes the model emit explicit `null`s for absent
 optionals; Zod treats *optional* ≠ *null*. So the frontend strips nulls before `parseScene`
 (JSON ⊂ YAML, so the JSON output parses directly otherwise). This is a ccp4i2-side concern;
 Materia returns the model output verbatim.
 
-**Profile size (verify against the live deployment's limits before the production switch):**
-29 object nodes, **142 total properties**, max object-nesting **depth 5**, 59 enum values.
-Depth 5 and the property count sit near older documented OpenAI ceilings; current gpt-4o
-limits clear them, but Materia owns the live API and should confirm against its pinned
-`AZURE_OPENAI_API_VERSION`.
+**Profile size (post-prune):** **83 properties, depth 4** — under Azure's documented 100/5
+strict caps with headroom (the *full* contract is ~142/depth-5, which Azure rejects). The
+remaining go/no-go is one live call on Materia's deployment: POST the profile as
+`response_format` and confirm acceptance — the empirical check now points at the *fitted*
+profile, not the over-cap original.
 
 **Server reachability (slim deployments).** The five artifacts above live under
 `client/renderer/lib/scene/` because that is where the Zod generator lives. But a

--- a/client/renderer/__tests__/scene-schema.test.ts
+++ b/client/renderer/__tests__/scene-schema.test.ts
@@ -140,6 +140,29 @@ describe("published JSON Schema contracts", () => {
     };
     walk(buildStructuredJsonSchema());
   });
+
+  it("the strict profile stays under Azure's 100-property cap (with headroom)", () => {
+    // Azure OpenAI hard-caps a strict json_schema at 100 object properties total
+    // and 5 nesting levels. The authoring-core prune (STRUCTURED_PRUNE) keeps us
+    // under; this guard fails loudly if a schema addition pushes it back over,
+    // rather than the model 400ing in production.
+    let properties = 0;
+    let maxDepth = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const walk = (node: any, depth: number): void => {
+      if (Array.isArray(node)) return node.forEach((n) => walk(n, depth));
+      if (!node || typeof node !== "object") return;
+      const here = node.properties ? depth + 1 : depth;
+      if (node.properties) {
+        properties += Object.keys(node.properties).length;
+        maxDepth = Math.max(maxDepth, here);
+      }
+      for (const v of Object.values(node)) walk(v, here);
+    };
+    walk(buildStructuredJsonSchema(), 0);
+    expect(properties).toBeLessThanOrEqual(90); // ≤100 cap, ≥10 headroom
+    expect(maxDepth).toBeLessThanOrEqual(5);
+  });
 });
 
 // --- a minimal portable scene used across validity tests ------------------

--- a/client/renderer/lib/scene/index.ts
+++ b/client/renderer/lib/scene/index.ts
@@ -223,16 +223,90 @@ function strictify(input: unknown): JsonNode {
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
+ * Authoring-core prune list: fields removed from the STRICT generation profile
+ * (not from the validator). Azure OpenAI caps a strict `json_schema` at **100
+ * object properties total**; the full ccp4i2 contract is ~142, so the strict
+ * profile is narrowed to the "authoring core" the design doc §7a anticipated —
+ * dropping advisory, escape-hatch, provenance and rarely-authored fields. The
+ * runtime `validateScene` still accepts every one of them; this only narrows
+ * what the constrained model can *emit*. Each entry is justified:
+ */
+const STRUCTURED_PRUNE = {
+  /** Whole top-level blocks the model should not author. */
+  topLevel: [
+    "authoredIn", // provenance — stamped by the app, never by the model
+    "hints", // advisory lighting/effects; the resolver doesn't even apply lighting yet
+  ],
+  /** Property names removed wherever they occur. Each is unique to one block in
+   *  this schema, so name-matching is unambiguous. */
+  props: new Set([
+    "relativeUrl", // deployment ref the system prompt already forbids
+    "bundle", // rare file source (.scene.zip asset)
+    "cifText", // rare file source (inline dictionary CIF)
+    "ribbonCoilThickness", "ribbonHelixWidth", "ribbonStrandWidth",
+    "ribbonArrowWidth", "ribbonDNARNAWidth", // keep bond/ball/vdw/probe radii; drop ribbon dims
+    "clipStart", "clipEnd", "fogStart", "fogEnd", // slab/clip cover the common case
+    "columns", // MTZ column spec — the resolver derives it from the file
+  ]),
+} as const;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/** A colour-union branch that is the raw-rule escape hatch (`{ raw: {…} }`). */
+function isRawColourBranch(node: any): boolean {
+  return (
+    isPlainObject(node) &&
+    isPlainObject(node.properties) &&
+    Object.keys(node.properties).length === 1 &&
+    "raw" in node.properties
+  );
+}
+
+/** Deep-clone the schema while removing the authoring-core exclusions: top-level
+ *  blocks, named properties, and the raw-colour escape-hatch union branch. Run
+ *  BEFORE strictify so it recomputes required/additionalProperties cleanly. */
+function pruneForAuthoringCore(input: unknown, atRoot = false): any {
+  if (Array.isArray(input)) return input.map((n) => pruneForAuthoringCore(n));
+  if (!isPlainObject(input)) return input;
+
+  const out: JsonNode = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (k === "properties" && isPlainObject(v)) {
+      const props: JsonNode = {};
+      for (const [pk, pv] of Object.entries(v)) {
+        if (STRUCTURED_PRUNE.props.has(pk)) continue;
+        if (atRoot && (STRUCTURED_PRUNE.topLevel as readonly string[]).includes(pk)) continue;
+        props[pk] = pruneForAuthoringCore(pv);
+      }
+      out[k] = props;
+    } else if (k === "required" && Array.isArray(v)) {
+      out[k] = v.filter(
+        (r: string) =>
+          !STRUCTURED_PRUNE.props.has(r) &&
+          !(atRoot && (STRUCTURED_PRUNE.topLevel as readonly string[]).includes(r)),
+      );
+    } else if (k === "anyOf" && Array.isArray(v)) {
+      out[k] = v.filter((b) => !isRawColourBranch(b)).map((n) => pruneForAuthoringCore(n));
+    } else {
+      out[k] = pruneForAuthoringCore(v);
+    }
+  }
+  return out;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
  * Build the strict OpenAI Structured Outputs profile from the ccp4i2 contract.
  *
  * Derived from the ccp4i2 dialect (not core): the production endpoint sends the
  * project manifest as grounding, so the model must be able to emit
- * job/param/fileId refs. The transform is mechanical and lossy by design —
- * constraints the model can't be trusted to honour structurally (CID patterns,
- * hex format, Å bounds, exactly-one-file-source) are dropped here and re-checked
- * by parseScene/validateScene, which remain the sole authority.
+ * job/param/fileId refs. Two transforms, both lossy by design — the dropped
+ * information is re-checked by parseScene/validateScene, the sole authority:
+ *   1. pruneForAuthoringCore — narrows to the authoring core to fit Azure's
+ *      100-property strict cap (see STRUCTURED_PRUNE).
+ *   2. strictify — OpenAI strict shape (oneOf→anyOf, all-required+nullable,
+ *      additionalProperties:false, unsupported vocabulary dropped).
  */
 export function buildStructuredJsonSchema(): unknown {
   const { ccp4i2 } = buildJsonSchemas();
-  return strictify(ccp4i2);
+  return strictify(pruneForAuthoringCore(ccp4i2, true));
 }

--- a/client/renderer/lib/scene/moorhen-scene.structured.v1.json
+++ b/client/renderer/lib/scene/moorhen-scene.structured.v1.json
@@ -9,52 +9,6 @@
       "type": "number",
       "description": "must equal 1"
     },
-    "authoredIn": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "properties": {
-        "projectId": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "projectName": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "createdAt": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "createdBy": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ccp4i2Version": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "projectId",
-        "projectName",
-        "createdAt",
-        "createdBy",
-        "ccp4i2Version"
-      ]
-    },
     "files": {
       "type": [
         "array",
@@ -90,27 +44,6 @@
           },
           "url": {
             "description": "absolute URL (portable)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "bundle": {
-            "description": "asset path inside a .scene.zip",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "cifText": {
-            "description": "inline CIF (dictionary refs only)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "relativeUrl": {
-            "description": "origin-relative URL (/api/…); not portable across deployments",
             "type": [
               "string",
               "null"
@@ -156,9 +89,6 @@
           "kind",
           "pdb",
           "url",
-          "bundle",
-          "cifText",
-          "relativeUrl",
           "projectId",
           "projectName",
           "fileId",
@@ -391,55 +321,6 @@
                 }
               },
               {
-                "type": "object",
-                "properties": {
-                  "raw": {
-                    "type": "object",
-                    "properties": {
-                      "ruleType": {
-                        "type": "string"
-                      },
-                      "args": {
-                        "type": "array",
-                        "items": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "number"
-                            }
-                          ]
-                        }
-                      },
-                      "isMultiColourRule": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "applyColourToNonCarbonAtoms": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "ruleType",
-                      "args",
-                      "isMultiColourRule",
-                      "applyColourToNonCarbonAtoms"
-                    ],
-                    "additionalProperties": false
-                  }
-                },
-                "required": [
-                  "raw"
-                ],
-                "additionalProperties": false
-              },
-              {
                 "type": "null"
               }
             ]
@@ -534,55 +415,6 @@
                       }
                     },
                     {
-                      "type": "object",
-                      "properties": {
-                        "raw": {
-                          "type": "object",
-                          "properties": {
-                            "ruleType": {
-                              "type": "string"
-                            },
-                            "args": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "number"
-                                  }
-                                ]
-                              }
-                            },
-                            "isMultiColourRule": {
-                              "type": [
-                                "boolean",
-                                "null"
-                              ]
-                            },
-                            "applyColourToNonCarbonAtoms": {
-                              "type": [
-                                "boolean",
-                                "null"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "ruleType",
-                            "args",
-                            "isMultiColourRule",
-                            "applyColourToNonCarbonAtoms"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": [
-                        "raw"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
                       "type": "null"
                     }
                   ]
@@ -627,41 +459,6 @@
                         "number",
                         "null"
                       ]
-                    },
-                    "ribbonCoilThickness": {
-                      "description": "ribbon coil thickness (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonHelixWidth": {
-                      "description": "ribbon helix width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonStrandWidth": {
-                      "description": "ribbon strand width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonArrowWidth": {
-                      "description": "ribbon arrow width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonDNARNAWidth": {
-                      "description": "nucleotide ribbon width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
                     }
                   },
                   "additionalProperties": false,
@@ -669,12 +466,7 @@
                     "bondRadius",
                     "ballRadius",
                     "vdwScale",
-                    "probeRadius",
-                    "ribbonCoilThickness",
-                    "ribbonHelixWidth",
-                    "ribbonStrandWidth",
-                    "ribbonArrowWidth",
-                    "ribbonDNARNAWidth"
+                    "probeRadius"
                   ]
                 }
               },
@@ -712,67 +504,6 @@
           "file": {
             "type": "string",
             "description": "name of a files[] entry (kind mtz or map)"
-          },
-          "columns": {
-            "description": "required for mtz, omit for map",
-            "type": [
-              "object",
-              "null"
-            ],
-            "properties": {
-              "F": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "PHI": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "Fobs": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "SigFobs": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "FreeR": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "useWeight": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "calcStructFact": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "F",
-              "PHI",
-              "Fobs",
-              "SigFobs",
-              "FreeR",
-              "useWeight",
-              "calcStructFact"
-            ]
           },
           "isMask": {
             "type": [
@@ -849,7 +580,6 @@
         "required": [
           "name",
           "file",
-          "columns",
           "isMask",
           "isDifference",
           "contourLevel",
@@ -945,30 +675,6 @@
             "null"
           ]
         },
-        "clipStart": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "clipEnd": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "fogStart": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "fogEnd": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
         "clip": {
           "anyOf": [
             {
@@ -1048,222 +754,9 @@
         "centre",
         "quat",
         "zoom",
-        "clipStart",
-        "clipEnd",
-        "fogStart",
-        "fogEnd",
         "clip",
         "slab",
         "background"
-      ]
-    },
-    "hints": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "properties": {
-        "lighting": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "properties": {
-            "direction": {
-              "description": "principal directional light vector → Moorhen lightPosition",
-              "type": [
-                "array",
-                "null"
-              ],
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ]
-            },
-            "ambient": {
-              "description": "ambient light colour",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "diffuse": {
-              "description": "diffuse light colour",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "specular": {
-              "description": "specular light colour",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "shininess": {
-              "description": "specular power → Moorhen specularPower",
-              "type": [
-                "number",
-                "null"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "direction",
-            "ambient",
-            "diffuse",
-            "specular",
-            "shininess"
-          ]
-        },
-        "effects": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "properties": {
-            "ssao": {
-              "description": "screen-space ambient occlusion",
-              "type": [
-                "object",
-                "null"
-              ],
-              "properties": {
-                "enabled": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "radius": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "bias": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "enabled",
-                "radius",
-                "bias"
-              ]
-            },
-            "edgeDetect": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "properties": {
-                "enabled": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "depthThreshold": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "normalThreshold": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "depthScale": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "normalScale": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "enabled",
-                "depthThreshold",
-                "normalThreshold",
-                "depthScale",
-                "normalScale"
-              ]
-            },
-            "shadows": {
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
-            "depthBlur": {
-              "description": "depth-of-field blur",
-              "type": [
-                "object",
-                "null"
-              ],
-              "properties": {
-                "radius": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "depth": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "radius",
-                "depth"
-              ]
-            },
-            "perspective": {
-              "description": "perspective vs orthographic",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "ssao",
-            "edgeDetect",
-            "shadows",
-            "depthBlur",
-            "perspective"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "lighting",
-        "effects"
       ]
     },
     "resolver": {
@@ -1293,7 +786,6 @@
   "required": [
     "scene",
     "version",
-    "authoredIn",
     "files",
     "superpose",
     "globalDictionaries",
@@ -1302,7 +794,6 @@
     "maps",
     "activeMap",
     "view",
-    "hints",
     "resolver"
   ],
   "additionalProperties": false

--- a/server/ccp4i2/scene_contracts/moorhen-scene.structured.v1.json
+++ b/server/ccp4i2/scene_contracts/moorhen-scene.structured.v1.json
@@ -9,52 +9,6 @@
       "type": "number",
       "description": "must equal 1"
     },
-    "authoredIn": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "properties": {
-        "projectId": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "projectName": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "createdAt": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "createdBy": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ccp4i2Version": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "projectId",
-        "projectName",
-        "createdAt",
-        "createdBy",
-        "ccp4i2Version"
-      ]
-    },
     "files": {
       "type": [
         "array",
@@ -90,27 +44,6 @@
           },
           "url": {
             "description": "absolute URL (portable)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "bundle": {
-            "description": "asset path inside a .scene.zip",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "cifText": {
-            "description": "inline CIF (dictionary refs only)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "relativeUrl": {
-            "description": "origin-relative URL (/api/…); not portable across deployments",
             "type": [
               "string",
               "null"
@@ -156,9 +89,6 @@
           "kind",
           "pdb",
           "url",
-          "bundle",
-          "cifText",
-          "relativeUrl",
           "projectId",
           "projectName",
           "fileId",
@@ -391,55 +321,6 @@
                 }
               },
               {
-                "type": "object",
-                "properties": {
-                  "raw": {
-                    "type": "object",
-                    "properties": {
-                      "ruleType": {
-                        "type": "string"
-                      },
-                      "args": {
-                        "type": "array",
-                        "items": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "number"
-                            }
-                          ]
-                        }
-                      },
-                      "isMultiColourRule": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "applyColourToNonCarbonAtoms": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "ruleType",
-                      "args",
-                      "isMultiColourRule",
-                      "applyColourToNonCarbonAtoms"
-                    ],
-                    "additionalProperties": false
-                  }
-                },
-                "required": [
-                  "raw"
-                ],
-                "additionalProperties": false
-              },
-              {
                 "type": "null"
               }
             ]
@@ -534,55 +415,6 @@
                       }
                     },
                     {
-                      "type": "object",
-                      "properties": {
-                        "raw": {
-                          "type": "object",
-                          "properties": {
-                            "ruleType": {
-                              "type": "string"
-                            },
-                            "args": {
-                              "type": "array",
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "number"
-                                  }
-                                ]
-                              }
-                            },
-                            "isMultiColourRule": {
-                              "type": [
-                                "boolean",
-                                "null"
-                              ]
-                            },
-                            "applyColourToNonCarbonAtoms": {
-                              "type": [
-                                "boolean",
-                                "null"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "ruleType",
-                            "args",
-                            "isMultiColourRule",
-                            "applyColourToNonCarbonAtoms"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": [
-                        "raw"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
                       "type": "null"
                     }
                   ]
@@ -627,41 +459,6 @@
                         "number",
                         "null"
                       ]
-                    },
-                    "ribbonCoilThickness": {
-                      "description": "ribbon coil thickness (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonHelixWidth": {
-                      "description": "ribbon helix width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonStrandWidth": {
-                      "description": "ribbon strand width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonArrowWidth": {
-                      "description": "ribbon arrow width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "ribbonDNARNAWidth": {
-                      "description": "nucleotide ribbon width (Å)",
-                      "type": [
-                        "number",
-                        "null"
-                      ]
                     }
                   },
                   "additionalProperties": false,
@@ -669,12 +466,7 @@
                     "bondRadius",
                     "ballRadius",
                     "vdwScale",
-                    "probeRadius",
-                    "ribbonCoilThickness",
-                    "ribbonHelixWidth",
-                    "ribbonStrandWidth",
-                    "ribbonArrowWidth",
-                    "ribbonDNARNAWidth"
+                    "probeRadius"
                   ]
                 }
               },
@@ -712,67 +504,6 @@
           "file": {
             "type": "string",
             "description": "name of a files[] entry (kind mtz or map)"
-          },
-          "columns": {
-            "description": "required for mtz, omit for map",
-            "type": [
-              "object",
-              "null"
-            ],
-            "properties": {
-              "F": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "PHI": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "Fobs": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "SigFobs": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "FreeR": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "useWeight": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "calcStructFact": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            },
-            "additionalProperties": false,
-            "required": [
-              "F",
-              "PHI",
-              "Fobs",
-              "SigFobs",
-              "FreeR",
-              "useWeight",
-              "calcStructFact"
-            ]
           },
           "isMask": {
             "type": [
@@ -849,7 +580,6 @@
         "required": [
           "name",
           "file",
-          "columns",
           "isMask",
           "isDifference",
           "contourLevel",
@@ -945,30 +675,6 @@
             "null"
           ]
         },
-        "clipStart": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "clipEnd": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "fogStart": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "fogEnd": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
         "clip": {
           "anyOf": [
             {
@@ -1048,222 +754,9 @@
         "centre",
         "quat",
         "zoom",
-        "clipStart",
-        "clipEnd",
-        "fogStart",
-        "fogEnd",
         "clip",
         "slab",
         "background"
-      ]
-    },
-    "hints": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "properties": {
-        "lighting": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "properties": {
-            "direction": {
-              "description": "principal directional light vector → Moorhen lightPosition",
-              "type": [
-                "array",
-                "null"
-              ],
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ]
-            },
-            "ambient": {
-              "description": "ambient light colour",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "diffuse": {
-              "description": "diffuse light colour",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "specular": {
-              "description": "specular light colour",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "shininess": {
-              "description": "specular power → Moorhen specularPower",
-              "type": [
-                "number",
-                "null"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "direction",
-            "ambient",
-            "diffuse",
-            "specular",
-            "shininess"
-          ]
-        },
-        "effects": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "properties": {
-            "ssao": {
-              "description": "screen-space ambient occlusion",
-              "type": [
-                "object",
-                "null"
-              ],
-              "properties": {
-                "enabled": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "radius": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "bias": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "enabled",
-                "radius",
-                "bias"
-              ]
-            },
-            "edgeDetect": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "properties": {
-                "enabled": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "depthThreshold": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "normalThreshold": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "depthScale": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "normalScale": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "enabled",
-                "depthThreshold",
-                "normalThreshold",
-                "depthScale",
-                "normalScale"
-              ]
-            },
-            "shadows": {
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
-            "depthBlur": {
-              "description": "depth-of-field blur",
-              "type": [
-                "object",
-                "null"
-              ],
-              "properties": {
-                "radius": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "depth": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "radius",
-                "depth"
-              ]
-            },
-            "perspective": {
-              "description": "perspective vs orthographic",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "ssao",
-            "edgeDetect",
-            "shadows",
-            "depthBlur",
-            "perspective"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "lighting",
-        "effects"
       ]
     },
     "resolver": {
@@ -1293,7 +786,6 @@
   "required": [
     "scene",
     "version",
-    "authoredIn",
     "files",
     "superpose",
     "globalDictionaries",
@@ -1302,7 +794,6 @@
     "maps",
     "activeMap",
     "view",
-    "hints",
     "resolver"
   ],
   "additionalProperties": false


### PR DESCRIPTION
Materia found a documented hard blocker (`notes-for-ccp4i2/nlp-scene-api-limit-finding.md`): **Azure OpenAI caps a strict `json_schema` at 100 object properties total** (a subset limit, the same for every model/api-version). Our profile was 142 → rejected.

## `$defs` can't fix it
Grouping all 142 properties by structural signature shows almost no duplication — only the raw-colour rule and the `{selection,colour}` pair repeat (~7 props). Even perfect `$defs` dedup lands ~135, still far over 100. Pruning is the only lever that reaches the target.

## Fix: authoring-core strict profile
`buildStructuredJsonSchema()` now prunes to an authoring core (the subset design doc §7a always earmarked) **before** the strict transform. Dropped from **generation only** — `validateScene` still accepts all of them:

| Dropped | Props | Why |
|---|---|---|
| `hints` (lighting+effects) | ~22 | advisory; resolver doesn't apply lighting yet |
| raw-colour escape hatch | ~10 | §7a hides escape hatches from a small authoring model |
| `authoredIn` | 6 | app-stamped provenance, never model-authored |
| `relativeUrl`/`bundle`/`cifText` | 3 | `relativeUrl` already forbidden; others rare |
| ribbon geometry dims | 5 | bond/ball/vdw/probe radii kept |
| fine clip/fog planes | 4 | `slab`/`clip` cover the common case |
| MTZ `columns` | 7 | resolver derives columns from the file |

**Result: 142 → 83 properties, depth 5 → 4** — under 100/5 with headroom. A drift test asserts ≤90 props / ≤5 depth so future schema growth fails loudly in CI, not in production.

Kept: files (pdb/url/fileId/job+param), domains, elements + representations + non-raw colour, core geometry radii, maps (minus columns), superpose, view, resolver.

Server mirror regenerates identically. Design doc §12 records the cap + the `$defs`-is-moot analysis + the prune rationale. Reply note to Materia written.

## Test
- `npx tsc --noEmit` clean
- 235 unit tests pass (structural guard + new property/depth-budget guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)