### PR TITLE
moorhen scenes: lower tuple arrays to items in the strict profile (Azure strict accept)

### DIFF
--- a/client/renderer/__tests__/scene-schema.test.ts
+++ b/client/renderer/__tests__/scene-schema.test.ts
@@ -118,6 +118,7 @@ describe("published JSON Schema contracts", () => {
       "pattern", "format", "minimum", "maximum", "exclusiveMinimum",
       "exclusiveMaximum", "multipleOf", "minLength", "maxLength", "minItems",
       "maxItems", "uniqueItems", "default", "oneOf", "allOf", "not", "$schema",
+      "prefixItems", // Azure strict rejects tuple arrays; must be lowered to items
     ];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const walk = (node: any): void => {
@@ -135,6 +136,13 @@ describe("published JSON Schema contracts", () => {
         expect([...(node.required ?? [])].sort()).toEqual(
           Object.keys(node.properties).sort(),
         );
+      }
+      const isArrayNode =
+        node.type === "array" ||
+        (Array.isArray(node.type) && node.type.includes("array"));
+      if (isArrayNode) {
+        // Every array must carry `items` (no bare/tuple arrays) — Azure strict.
+        expect(node.items, "array node missing items").toBeDefined();
       }
       for (const v of Object.values(node)) walk(v);
     };

--- a/client/renderer/lib/scene/index.ts
+++ b/client/renderer/lib/scene/index.ts
@@ -135,7 +135,6 @@ const STRUCTURED_KEEP = new Set([
   "properties",
   "required",
   "items",
-  "prefixItems",
   "anyOf",
   "additionalProperties",
   "description",
@@ -196,8 +195,21 @@ function strictify(input: unknown): JsonNode {
   }
 
   if (Array.isArray(node.anyOf)) node.anyOf = node.anyOf.map(strictify);
-  if (Array.isArray(node.prefixItems)) node.prefixItems = node.prefixItems.map(strictify);
-  if (node.items !== undefined) {
+
+  // Azure strict mode rejects tuple arrays (`prefixItems` / array-without-`items`).
+  // Lower a fixed-length tuple to a homogeneous array: `items` = the common branch
+  // schema, or an `anyOf` of the distinct branch types when heterogeneous. The real
+  // tuple length (3-vector origin, 4-vector quat) is re-checked by validateScene —
+  // same trade as dropping pattern/format for strict.
+  const inputPrefix = (input as JsonNode).prefixItems;
+  if (Array.isArray(inputPrefix)) {
+    const branches = inputPrefix.map(strictify);
+    const uniq: JsonNode[] = [];
+    for (const b of branches) {
+      if (!uniq.some((u) => JSON.stringify(u) === JSON.stringify(b))) uniq.push(b);
+    }
+    node.items = uniq.length === 1 ? uniq[0] : { anyOf: uniq };
+  } else if (node.items !== undefined) {
     node.items = Array.isArray(node.items) ? node.items.map(strictify) : strictify(node.items);
   }
 

--- a/client/renderer/lib/scene/moorhen-scene.structured.v1.json
+++ b/client/renderer/lib/scene/moorhen-scene.structured.v1.json
@@ -611,17 +611,9 @@
             "array",
             "null"
           ],
-          "prefixItems": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ]
+          "items": {
+            "type": "number"
+          }
         },
         "centre": {
           "description": "centroid of a selection; beats origin",
@@ -654,20 +646,9 @@
             "array",
             "null"
           ],
-          "prefixItems": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ]
+          "items": {
+            "type": "number"
+          }
         },
         "zoom": {
           "type": [

--- a/server/ccp4i2/scene_contracts/moorhen-scene.structured.v1.json
+++ b/server/ccp4i2/scene_contracts/moorhen-scene.structured.v1.json
@@ -611,17 +611,9 @@
             "array",
             "null"
           ],
-          "prefixItems": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ]
+          "items": {
+            "type": "number"
+          }
         },
         "centre": {
           "description": "centroid of a selection; beats origin",
@@ -654,20 +646,9 @@
             "array",
             "null"
           ],
-          "prefixItems": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ]
+          "items": {
+            "type": "number"
+          }
         },
         "zoom": {
           "type": [


### PR DESCRIPTION
Materia's acceptance probe (`notes-for-ccp4i2/nlp-scene-probe-result.md`) cleared Azure's **100-property size validation** with the 83-prop slim — the cap is solved. It then tripped on a shape bug: `view.origin` (3-vector) and `view.quat` (4-vector) are `z.tuple()`s, which lower to `{type:array, prefixItems:[…]}` with no `items`. Azure strict mode rejects `prefixItems` / arrays-without-`items`:

> array schema missing items (context: `properties.view…properties.origin`)

## Fix
`strictify()` now lowers any fixed-length tuple to a **homogeneous array** — `items` = the common branch schema (or `anyOf` of distinct branch types when heterogeneous). The real 3-/4-vector length is still enforced by `validateScene` at runtime (same trade as dropping `pattern`/`format` for strict). `prefixItems` is removed from the kept-keyword set so no tuple survives.

Result: `view.origin`/`view.quat` → `{type:["array","null"], items:{type:"number"}}`, zero `prefixItems` in the profile.

## Guard hardened
The structural test now forbids `prefixItems` and asserts every array node carries `items`, so this bug-class fails in CI rather than 400ing on the deployment. Materia statically enumerated these as the **only 2 violations**, so the regenerated profile is expected to accept cleanly on re-probe.

## Test
- `npx tsc --noEmit` clean
- 235 unit tests pass (structural guard extended)
- server mirror regenerates identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)