### PR TITLE
moorhen scenes: in-app NL Generate tier (capability-detected)

### DIFF
--- a/client/renderer/__tests__/scene-schema.test.ts
+++ b/client/renderer/__tests__/scene-schema.test.ts
@@ -20,6 +20,7 @@ import {
   buildJsonSchemas,
   buildStructuredJsonSchema,
   serialiseJsonSchema,
+  normaliseGeneratedScene,
   SceneParseError,
 } from "../lib/scene";
 import { sceneMarkers, pathToSegments } from "../lib/scene/yaml-markers";
@@ -411,5 +412,54 @@ describe("parseScene", () => {
 
   it("throws SceneParseError on invalid scene", () => {
     expect(() => parseScene("scene: x\nversion: 99")).toThrow(SceneParseError);
+  });
+});
+
+describe("normaliseGeneratedScene (LLM ingest tidy-up)", () => {
+  it("strips explicit nulls that strict Structured Outputs emits", () => {
+    // Strict mode makes every optional present-as-null; Zod optional ≠ null,
+    // so these must be dropped before parseScene sees them.
+    const json = JSON.stringify({
+      scene: "s",
+      version: 1,
+      files: [{ name: "prot", pdb: "1abc" }],
+      view: { centre: { file: "prot", selection: "//A" }, zoom: null, origin: null },
+      hints: null,
+    });
+    const out = normaliseGeneratedScene(json);
+    expect(out).not.toContain("null");
+    const parsed = parseScene(out);
+    expect(parsed).toMatchObject({ scene: "s", version: 1 });
+    expect(parsed.view?.zoom).toBeUndefined();
+  });
+
+  it("strips a ```json fence and re-serialises to YAML", () => {
+    const fenced = "```json\n{\"scene\":\"s\",\"version\":1}\n```";
+    const out = normaliseGeneratedScene(fenced);
+    expect(out).not.toContain("```");
+    expect(parseScene(out)).toMatchObject({ scene: "s", version: 1 });
+  });
+
+  it("leaves plain YAML without nulls essentially unchanged in meaning", () => {
+    const yaml = "scene: s\nversion: 1\n";
+    expect(parseScene(normaliseGeneratedScene(yaml))).toMatchObject({
+      scene: "s",
+      version: 1,
+    });
+  });
+
+  it("falls back to the raw text when it doesn't parse", () => {
+    const junk = "this is: not: valid: yaml: [";
+    expect(normaliseGeneratedScene(junk)).toBe(junk);
+  });
+
+  it("keeps array elements (only object nulls are dropped)", () => {
+    const json = JSON.stringify({
+      scene: "s",
+      version: 1,
+      domains: [{ name: "d", selection: "//A", color: "#112233" }],
+    });
+    const parsed = parseScene(normaliseGeneratedScene(json));
+    expect(parsed.domains).toHaveLength(1);
   });
 });

--- a/client/renderer/components/moorhen/moorhen-ccp4i2-tabbed-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-ccp4i2-tabbed-panel.tsx
@@ -50,6 +50,10 @@ export interface MoorhenCcp4i2TabbedPanelProps {
     warnings: string[];
   }>;
   onBuildAuthoringPrompt?: (request: string) => Promise<string>;
+  /** Generate a scene from a natural-language request via an integrated LLM
+   *  endpoint. Optional — passed only when the deployment reports the
+   *  capability; when omitted the panel offers copy-paste authoring only. */
+  onGenerateScene?: (request: string) => Promise<string>;
   cootInitialized: boolean;
 }
 
@@ -58,6 +62,7 @@ export const MoorhenCcp4i2TabbedPanel: React.FC<MoorhenCcp4i2TabbedPanelProps> =
   onCaptureScene,
   onPromoteSceneToPortable,
   onBuildAuthoringPrompt,
+  onGenerateScene,
   cootInitialized,
   ...controlsProps
 }) => {
@@ -90,10 +95,11 @@ export const MoorhenCcp4i2TabbedPanel: React.FC<MoorhenCcp4i2TabbedPanelProps> =
         onCaptureScene={onCaptureScene}
         onPromoteSceneToPortable={onPromoteSceneToPortable}
         onBuildAuthoringPrompt={onBuildAuthoringPrompt}
+        onGenerateScene={onGenerateScene}
         enabled={cootInitialized}
       />
     ),
-    [onApplyScene, onCaptureScene, onPromoteSceneToPortable, onBuildAuthoringPrompt, cootInitialized],
+    [onApplyScene, onCaptureScene, onPromoteSceneToPortable, onBuildAuthoringPrompt, onGenerateScene, cootInitialized],
   );
 
   return (

--- a/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-scenes-panel.tsx
@@ -47,11 +47,13 @@ import {
   PlayArrow as ApplyIcon,
   ArrowDropDown as DropDownIcon,
   AutoAwesome as PromptIcon,
+  AutoFixHigh as GenerateIcon,
 } from "@mui/icons-material";
 import { Editor } from "@monaco-editor/react";
 import JSZip from "jszip";
 
-import { parseScene, SceneParseError } from "../../lib/scene";
+import { parseScene, SceneParseError, normaliseGeneratedScene } from "../../lib/scene";
+import { SceneGenerateError } from "./use-scene-nl-capability";
 import { sceneMarkers } from "../../lib/scene/yaml-markers";
 import { serialiseSceneWithComments } from "../../lib/moorhen-scene";
 import type { MoorhenScene } from "../../types/moorhen-scene";
@@ -127,6 +129,12 @@ interface MoorhenScenesPanelProps {
    *  request. Optional — when omitted the "Generate prompt" button is hidden
    *  (e.g. the campaign viewer). */
   onBuildAuthoringPrompt?: (request: string) => Promise<string>;
+  /** Generate a scene from a natural-language request via an integrated LLM
+   *  endpoint, returning the raw scene text. Optional — passed only when the
+   *  deployment reports the capability. When present, the authoring modal
+   *  offers an in-app "Generate" (result lands in the editor for review, not
+   *  auto-applied); copy-paste stays as a secondary action. */
+  onGenerateScene?: (request: string) => Promise<string>;
   /** True once Moorhen / Coot is ready. Disables apply until then. */
   enabled: boolean;
   /** Optional initial YAML to seed the editor with (e.g. the campaign
@@ -153,6 +161,7 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
   onCaptureScene,
   onPromoteSceneToPortable,
   onBuildAuthoringPrompt,
+  onGenerateScene,
   enabled,
   initialYaml,
   autoApplyInitial,
@@ -256,6 +265,38 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
       setPromptBusy(false);
     }
   }, [onBuildAuthoringPrompt, promptRequest]);
+
+  // Integrated Generate: call the endpoint, normalise the raw output (strip
+  // fence + strict-mode nulls, tidy to YAML), drop it in the editor for REVIEW
+  // (never auto-applied — generation can be imperfect and the markers show
+  // validity). On failure, keep the modal open so the user can fall back to
+  // copy-paste, with a kind-specific message.
+  const handleGenerateScene = useCallback(async () => {
+    if (!onGenerateScene) return;
+    setPromptBusy(true);
+    try {
+      const raw = await onGenerateScene(promptRequest);
+      setYamlText(normaliseGeneratedScene(raw));
+      setPromptModalOpen(false);
+      setMessage({
+        severity: "success",
+        text: "Scene generated into the editor — review it (check the messages below), then Apply.",
+      });
+    } catch (err) {
+      const fallback = onBuildAuthoringPrompt
+        ? " You can still use Copy as prompt to try another model."
+        : "";
+      const text =
+        err instanceof SceneGenerateError && err.kind === "rate_limited"
+          ? `Daily generation limit reached.${fallback}`
+          : err instanceof SceneGenerateError && err.kind === "disabled"
+            ? `Scene generation is disabled on this deployment.${fallback}`
+            : `Could not generate scene: ${err instanceof Error ? err.message : "unknown error"}.${fallback}`;
+      setMessage({ severity: "error", text });
+    } finally {
+      setPromptBusy(false);
+    }
+  }, [onGenerateScene, onBuildAuthoringPrompt, promptRequest]);
 
   const handleOpenClick = useCallback(() => {
     fileInputRef.current?.click();
@@ -551,17 +592,23 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
           </Tooltip>
         )}
 
-        {onBuildAuthoringPrompt && (
-          <Tooltip title="Describe a view in words; we bundle it with the scene grammar, this project's files, and the loaded structure's chains & ligands into one prompt for any chatbot">
+        {(onGenerateScene || onBuildAuthoringPrompt) && (
+          <Tooltip
+            title={
+              onGenerateScene
+                ? "Describe a view in words and generate the scene in-app (into the editor for review before you Apply)"
+                : "Describe a view in words; we bundle it with the scene grammar, this project's files, and the loaded structure's chains & ligands into one prompt for any chatbot"
+            }
+          >
             <span>
               <Button
                 size="small"
                 variant="outlined"
-                startIcon={<PromptIcon />}
+                startIcon={onGenerateScene ? <GenerateIcon /> : <PromptIcon />}
                 onClick={() => setPromptModalOpen(true)}
                 sx={{ fontSize: "0.75rem", textTransform: "none" }}
               >
-                Generate prompt…
+                {onGenerateScene ? "Generate scene…" : "Generate prompt…"}
               </Button>
             </span>
           </Tooltip>
@@ -725,22 +772,39 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
         onChange={handleOpenFile}
       />
 
-      {/* Generate-prompt modal: the user describes a view in words; on "Copy as
-          prompt" we bundle it with the grammar + project files + structure
-          contents and copy the whole prompt for pasting into a chatbot. */}
+      {/* Authoring modal: the user describes a view in words. When an integrated
+          endpoint is available (onGenerateScene) the primary action generates the
+          scene in-app into the editor; otherwise (copy-paste path) we bundle the
+          request with the grammar + project files + contents to the clipboard.
+          Copy-paste stays as a secondary action even when Generate is available —
+          the better-model / offline / quota escape hatch. */}
       <Dialog
         open={promptModalOpen}
         onClose={() => setPromptModalOpen(false)}
         maxWidth="sm"
         fullWidth
       >
-        <DialogTitle>Generate a scene-authoring prompt</DialogTitle>
+        <DialogTitle>
+          {onGenerateScene ? "Generate a scene" : "Generate a scene-authoring prompt"}
+        </DialogTitle>
         <DialogContent>
           <DialogContentText sx={{ mb: 1.5, fontSize: "0.85rem" }}>
-            Describe the view you want in plain language. We bundle your
-            description with the scene grammar, this project&apos;s files, and the
-            loaded structure&apos;s chains &amp; ligands into one prompt. Paste it
-            into any chatbot, then paste the returned YAML back here and Apply.
+            {onGenerateScene ? (
+              <>
+                Describe the view you want in plain language. We ground the request
+                with this project&apos;s files and the loaded structure&apos;s
+                chains &amp; ligands and generate the scene into the editor —
+                review it (see the messages below), then Apply.
+              </>
+            ) : (
+              <>
+                Describe the view you want in plain language. We bundle your
+                description with the scene grammar, this project&apos;s files, and
+                the loaded structure&apos;s chains &amp; ligands into one prompt.
+                Paste it into any chatbot, then paste the returned YAML back here
+                and Apply.
+              </>
+            )}
           </DialogContentText>
           <TextField
             autoFocus
@@ -759,15 +823,30 @@ export const MoorhenScenesPanel: React.FC<MoorhenScenesPanelProps> = ({
           <Button onClick={() => setPromptModalOpen(false)} sx={{ textTransform: "none" }}>
             Cancel
           </Button>
-          <Button
-            variant="contained"
-            startIcon={<PromptIcon />}
-            onClick={handleCopyAsPrompt}
-            disabled={promptBusy || !promptRequest.trim()}
-            sx={{ textTransform: "none" }}
-          >
-            Copy as prompt
-          </Button>
+          {/* Copy-as-prompt is primary when there's no endpoint, secondary when
+              there is (kept as the better-model / offline fallback). */}
+          {onBuildAuthoringPrompt && (
+            <Button
+              variant={onGenerateScene ? "outlined" : "contained"}
+              startIcon={<PromptIcon />}
+              onClick={handleCopyAsPrompt}
+              disabled={promptBusy || !promptRequest.trim()}
+              sx={{ textTransform: "none" }}
+            >
+              Copy as prompt
+            </Button>
+          )}
+          {onGenerateScene && (
+            <Button
+              variant="contained"
+              startIcon={<GenerateIcon />}
+              onClick={handleGenerateScene}
+              disabled={promptBusy || !promptRequest.trim()}
+              sx={{ textTransform: "none" }}
+            >
+              {promptBusy ? "Generating…" : "Generate"}
+            </Button>
+          )}
         </DialogActions>
       </Dialog>
     </Stack>

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -49,9 +49,11 @@ import {
   buildContentsBlock,
   buildManifestBlock,
   buildAuthoringPrompt,
+  buildGroundingBlock,
   extractPdbIds,
   fetchPdbContents,
 } from "../../lib/moorhen-scene-prompt";
+import { useSceneNlCapability, generateScene } from "./use-scene-nl-capability";
 import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp } from "../../lib/moorhen-map-file";
 import {
   liftSceneStraight,
@@ -1082,7 +1084,15 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
   // manifest of the project's referenceable job outputs + a ground-truth
   // contents summary of the loaded structure (chains + ligand CIDs, from the
   // coordinate digest). The user appends a request and pastes it into a chatbot.
-  const handleBuildAuthoringPrompt = useCallback(async (request: string): Promise<string> => {
+  // Assemble the per-call grounding: project identity + referenceable-file
+  // manifest + loaded-structure (and named-PDB) contents. Shared by both the
+  // copy-paste prompt and the integrated Generate path so they ground the model
+  // identically. `request` is used only to spot PDB ids to digest.
+  const assembleGrounding = useCallback(async (request: string): Promise<{
+    project?: { name?: string; id?: string };
+    manifest: string;
+    contents: string;
+  }> => {
     const mol = molecules[0];
     const fid = mol ? extractFileIdFromUniqueId(mol.uniqueId || "") : null;
 
@@ -1142,8 +1152,25 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       ? contentsParts.join("\n\n")
       : "(no structure loaded)";
 
-    return buildAuthoringPrompt({ project, contents: contentsBlock, manifest: manifestBlock, request });
+    return { project, manifest: manifestBlock, contents: contentsBlock };
   }, [molecules, projectInfo]);
+
+  // Copy-paste path: the full self-contained prompt (system prompt + grounding +
+  // request) for pasting into any chatbot.
+  const handleBuildAuthoringPrompt = useCallback(async (request: string): Promise<string> => {
+    const { project, manifest, contents } = await assembleGrounding(request);
+    return buildAuthoringPrompt({ project, contents, manifest, request });
+  }, [assembleGrounding]);
+
+  // Integrated path: send request + grounding to the nlp_scene endpoint (which
+  // holds the static system prompt server-side) and return the raw scene text.
+  const handleGenerateScene = useCallback(async (request: string): Promise<string> => {
+    const { project, manifest, contents } = await assembleGrounding(request);
+    const grounding = buildGroundingBlock({ project, manifest, contents });
+    return generateScene(request, grounding);
+  }, [assembleGrounding]);
+
+  const sceneNl = useSceneNlCapability();
 
   // Promote an editor YAML to a fully self-contained scene + asset
   // bundle: every URL-resolvable ref is fetched into assets/ and
@@ -1269,11 +1296,12 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
           onCaptureScene={handleCaptureScene}
           onPromoteSceneToPortable={handlePromoteSceneToPortable}
           onBuildAuthoringPrompt={handleBuildAuthoringPrompt}
+          onGenerateScene={sceneNl.available ? handleGenerateScene : undefined}
           cootInitialized={cootInitialized}
         />
       ),
     },
-  }), [fetchFile, fetchJobFiles, getViewUrl, molecules, maps, handleMapContourLevelChange, jobId, handleRunServalcat, servalcatStatus, handleApplyScene, handleCaptureScene, handlePromoteSceneToPortable, handleBuildAuthoringPrompt, cootInitialized]);
+  }), [fetchFile, fetchJobFiles, getViewUrl, molecules, maps, handleMapContourLevelChange, jobId, handleRunServalcat, servalcatStatus, handleApplyScene, handleCaptureScene, handlePromoteSceneToPortable, handleBuildAuthoringPrompt, sceneNl.available, handleGenerateScene, cootInitialized]);
 
   // Moorhen 1.0 requires the InstanceProvider to be seeded with a menu system
   // (it builds the per-instance MoorhenInstance from it). One per wrapper.

--- a/client/renderer/components/moorhen/use-scene-nl-capability.ts
+++ b/client/renderer/components/moorhen/use-scene-nl-capability.ts
@@ -1,0 +1,155 @@
+/**
+ * Capability detection + transport for integrated natural-language scene
+ * generation (design: MOORHEN_SCENES_NL_UI.md).
+ *
+ * `useSceneNlCapability()` probes the deployment's `nlp/status` endpoint and
+ * reports whether an in-app "Generate" affordance should appear. It is a
+ * PROVIDER ABSTRACTION, not a Materia hard-dependency: today the only provider
+ * is Materia's compounds `nlp_scene`; future desktop-byo / on-device providers
+ * plug in behind the same shape. Desktop Electron (no compounds app) 404s the
+ * probe → `available: false` → the panel falls back to copy-paste. That absence
+ * IS the signal; nothing needs building into desktop.
+ *
+ * `generateScene()` is the transport for the POST. It uses a raw fetch (not the
+ * apiFetch wrapper) so it can read the structured `{status:"error", kind}` body
+ * on a non-2xx response — the wrapper throws on non-ok and discards the body.
+ */
+import useSWR from "swr";
+import { getAccessToken } from "@ccp4/ccp4i2-api";
+
+// Same-origin proxy paths. NO trailing slash — the Next proxy adds the one
+// Django wants; a pre-added slash 308s the body away (see the compounds proxy
+// convention).
+const STATUS_URL = "/api/proxy/compounds/nlp/status";
+const SCENE_URL = "/api/proxy/compounds/nlp/scene";
+
+export type SceneNlProvider = "none" | "materia";
+
+export interface SceneNlCapability {
+  /** True when an in-app Generate affordance should be shown. */
+  available: boolean;
+  provider: SceneNlProvider;
+  /** What generate_scene will actually use, so the UI can anticipate JSON vs
+   *  YAML. Ingest strips nulls regardless, so this is informational. */
+  responseFormat?: "strict" | "raw";
+  model?: string;
+  quota?: { limit?: number; remaining?: number };
+}
+
+interface NlStatusResponse {
+  scene?: {
+    enabled?: boolean;
+    responseFormat?: "strict" | "raw";
+    model?: string;
+    dailyLimit?: number;
+    dailyRemaining?: number;
+  };
+}
+
+/** Materia's error kinds (mirrors nlp_query), plus a client-only "network". */
+export type SceneGenerateErrorKind =
+  | "disabled"
+  | "rate_limited"
+  | "bad_request"
+  | "llm_error"
+  | "network";
+
+export class SceneGenerateError extends Error {
+  constructor(
+    public readonly kind: SceneGenerateErrorKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SceneGenerateError";
+  }
+}
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const token = await getAccessToken();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return headers;
+}
+
+async function statusFetcher(): Promise<NlStatusResponse | null> {
+  try {
+    const resp = await fetch(STATUS_URL, { headers: await authHeaders() });
+    if (!resp.ok) return null; // 404 (no compounds app, e.g. desktop) → unavailable
+    return (await resp.json()) as NlStatusResponse;
+  } catch {
+    return null; // network / offline → unavailable (safe: falls back to copy-paste)
+  }
+}
+
+/**
+ * Probe capability. SWR-cached; a 404/unreachable result is terminal for the
+ * session (don't hammer a missing endpoint), so retry-on-error is off.
+ */
+export function useSceneNlCapability(): SceneNlCapability {
+  const { data } = useSWR<NlStatusResponse | null>(STATUS_URL, statusFetcher, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+    dedupingInterval: 5 * 60_000,
+  });
+  const scene = data?.scene;
+  const available = !!scene?.enabled;
+  return {
+    available,
+    provider: available ? "materia" : "none",
+    responseFormat: scene?.responseFormat,
+    model: scene?.model,
+    quota: scene
+      ? { limit: scene.dailyLimit, remaining: scene.dailyRemaining }
+      : undefined,
+  };
+}
+
+const STATUS_TO_KIND: Record<number, SceneGenerateErrorKind> = {
+  400: "bad_request",
+  404: "disabled",
+  429: "rate_limited",
+  502: "llm_error",
+};
+
+/**
+ * POST a request (+ optional grounding) to the scene endpoint and return the
+ * model's RAW scene text (YAML or JSON) for the caller to normalise/parse.
+ * Throws SceneGenerateError with the server's `kind` (or one mapped from the
+ * HTTP status) on failure.
+ */
+export async function generateScene(
+  request: string,
+  grounding?: string,
+): Promise<string> {
+  let resp: Response;
+  try {
+    resp = await fetch(SCENE_URL, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({ request, grounding }),
+    });
+  } catch (e) {
+    throw new SceneGenerateError(
+      "network",
+      `Could not reach the scene service: ${e instanceof Error ? e.message : "network error"}`,
+    );
+  }
+
+  let body: { status?: string; scene?: string; kind?: SceneGenerateErrorKind; message?: string } = {};
+  try {
+    body = await resp.json();
+  } catch {
+    /* non-JSON body; handled below via status */
+  }
+
+  if (resp.ok && body.status === "scene" && typeof body.scene === "string") {
+    return body.scene;
+  }
+
+  const kind: SceneGenerateErrorKind =
+    body.kind ?? STATUS_TO_KIND[resp.status] ?? "llm_error";
+  throw new SceneGenerateError(
+    kind,
+    body.message || `Scene generation failed (HTTP ${resp.status}).`,
+  );
+}

--- a/client/renderer/lib/moorhen-scene-prompt.ts
+++ b/client/renderer/lib/moorhen-scene-prompt.ts
@@ -344,21 +344,26 @@ export function buildSceneSystemPrompt(): string {
   ].join("\n");
 }
 
-// ── Whole prompt ────────────────────────────────────────────────────────────
+// ── Grounding (the per-call variable block) ──────────────────────────────────
 
-export function buildAuthoringPrompt(opts: {
+/**
+ * The variable, per-call context block: project identity + referenceable-file
+ * manifest + loaded-structure contents. This is the `grounding` the integrated
+ * `nlp_scene` endpoint takes as the leading part of its user message, and the
+ * same block `buildAuthoringPrompt` places after the static system prompt. Kept
+ * single-sourced here so the copy-paste path and the endpoint path ground the
+ * model identically.
+ */
+export function buildGroundingBlock(opts: {
   project?: { name?: string; id?: string };
   contents: string;
   manifest: string;
-  request: string;
 }): string {
   const projName = opts.project?.name;
   const projId = opts.project?.id;
   // Pin the project identity hard: a chat model carrying context from an earlier
   // project will otherwise reference the wrong one. Every job/param ref must
-  // carry these. This is the FIRST variable element — everything above it (the
-  // system prompt) is static and cacheable; everything from here down varies per
-  // call, ordered most-stable-to-least (project → manifest → contents → request).
+  // carry these.
   const projectLines: string[] = ["=== CURRENT PROJECT (use ONLY this one) ==="];
   if (projName) projectLines.push(`projectName: ${projName}`);
   if (projId) projectLines.push(`projectId: ${projId}`);
@@ -371,8 +376,6 @@ export function buildAuthoringPrompt(opts: {
   );
 
   return [
-    buildSceneSystemPrompt(),
-    "",
     projectLines.join("\n"),
     "",
     "=== REFERENCEABLE PROJECT FILES ===",
@@ -380,6 +383,23 @@ export function buildAuthoringPrompt(opts: {
     "",
     "=== LOADED STRUCTURE CONTENTS ===",
     opts.contents,
+  ].join("\n");
+}
+
+// ── Whole prompt (copy-paste path) ────────────────────────────────────────────
+
+export function buildAuthoringPrompt(opts: {
+  project?: { name?: string; id?: string };
+  contents: string;
+  manifest: string;
+  request: string;
+}): string {
+  // Static system prompt first (cacheable), then the variable grounding block
+  // (project → manifest → contents), then the request last — most-stable-to-least.
+  return [
+    buildSceneSystemPrompt(),
+    "",
+    buildGroundingBlock(opts),
     "",
     "=== REQUEST ===",
     "Produce a scene YAML that satisfies the following request. Use the project,",

--- a/client/renderer/lib/scene/index.ts
+++ b/client/renderer/lib/scene/index.ts
@@ -96,6 +96,39 @@ export function serialiseScene(scene: unknown): string {
   return YAML.stringify(scene);
 }
 
+/** Recursively drop null-valued object keys (keeps array elements). */
+function stripNulls(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(stripNulls);
+  if (v && typeof v === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      if (val === null) continue;
+      out[k] = stripNulls(val);
+    }
+    return out;
+  }
+  return v;
+}
+
+/**
+ * Prepare raw LLM output for the editor. Strips a ```yaml/```json fence, then —
+ * because strict OpenAI Structured Outputs emits explicit `null`s for absent
+ * optionals and Zod treats *optional* ≠ *null* — drops those nulls, and
+ * re-serialises to tidy YAML (JSON ⊂ YAML, so JSON output normalises too). Falls
+ * back to the raw text if it doesn't parse, so the editor still shows something
+ * the validity markers can flag. Parsing/validation stay with parseScene; this
+ * is only ingest tid-up.
+ */
+export function normaliseGeneratedScene(text: string): string {
+  try {
+    const raw = YAML.parse(stripCodeFence(text));
+    if (raw == null || typeof raw !== "object") return text;
+    return YAML.stringify(stripNulls(raw));
+  } catch {
+    return text;
+  }
+}
+
 // --- JSON Schema generation (the published contracts) ---------------------
 
 /**


### PR DESCRIPTION
Implements tier 3 of `MOORHEN_SCENES_NL_UI.md`: when the deployment exposes a live `nlp_scene` endpoint, the scene panel offers **in-app natural-language generation**; otherwise it falls back to the existing copy-paste path. No new UI surface — the existing "describe the view" modal swaps its primary action on detected capability.

## Pieces
- **`use-scene-nl-capability.ts`** (new) — `useSceneNlCapability()` SWR-probes `/api/proxy/compounds/nlp/status`; `404`/unreachable (desktop, no compounds app) → `available:false` → copy-paste only. `generateScene()` POSTs `nlp/scene` via a **raw fetch** (not `apiFetch`, which discards the error body) so it can surface Materia's `{status:"error", kind}` as a typed `SceneGenerateError`, with an HTTP-status fallback. Provider abstraction — not a Materia hard-dependency.
- **`buildGroundingBlock()`** factored out of `buildAuthoringPrompt` so the copy-paste prompt and the endpoint's `grounding` field ground the model identically (single-sourced).
- **`normaliseGeneratedScene()`** (`lib/scene`) — strips a ` ```fence ` and the explicit nulls strict Structured Outputs emits (Zod optional ≠ null), re-serialising to tidy YAML; falls back to raw text if unparseable. + unit tests.
- **Wrapper** — `assembleGrounding()` shared by both paths; `handleGenerateScene` passed to the panel only when `sceneNl.available`.
- **Panel** — Generate is primary when available (**result lands in the editor for review — never auto-applied**; validity markers show status); Copy-as-prompt stays as the secondary better-model/offline/quota fallback. `rate_limited`/`disabled` map to in-place messages pointing at copy-paste.

## Design decisions honoured
Review-then-apply (no auto-apply); copy-paste retained; strict-JSON null-strip; provider abstraction with desktop degrading via 404.

## Test
- `npx tsc --noEmit` clean
- 240 unit tests pass (new `normaliseGeneratedScene` coverage)
- **Runtime note:** the integrated path needs the Materia-web deployment to exercise live; desktop/base dev correctly reports unavailable (Generate hidden). Not yet runtime-verified end-to-end against a live endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)