### PR TITLE
Legacy CCP4i2 migration: structural pre-flight, copy-in, and admin wizard

### DIFF
--- a/client/renderer/app/ccp4i2/(authed)/admin/migrate-legacy/page.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/admin/migrate-legacy/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { Paper } from "@mui/material";
+import { NavigationShortcutsProvider } from "@/providers/navigation-shortcuts-provider";
+import CCP4i2TopBar from "@/components/ccp4i2-topbar";
+import { MigrateLegacyContent } from "@/components/migrate-legacy-content";
+
+export default function MigrateLegacyPage() {
+  return (
+    <NavigationShortcutsProvider>
+      <CCP4i2TopBar
+        title="Migrate legacy CCP4i2"
+        showBackButton
+        backPath="/ccp4i2"
+      />
+      <Paper
+        sx={{
+          height: "calc(100vh - 80px)",
+          overflow: "auto",
+          p: 3,
+        }}
+      >
+        <MigrateLegacyContent />
+      </Paper>
+    </NavigationShortcutsProvider>
+  );
+}

--- a/client/renderer/components/migrate-legacy-content.tsx
+++ b/client/renderer/components/migrate-legacy-content.tsx
@@ -366,14 +366,73 @@ const ValidateStep: React.FC<{
 }> = ({ report, acknowledged, setAcknowledged, canAdvance, busy, onBack, onNext }) => {
   const s = report.summary;
   const blocking = s.blocking_issues;
+  const topMissing = s.top_level_files_missing;
+  const subMissing = s.sub_job_files_missing;
   return (
     <Stack spacing={3}>
-      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-        <RatioChip label="Projects on disk" value={s.projects_on_disk} />
-        <RatioChip label="Jobs on disk" value={s.jobs_on_disk} />
-        <RatioChip label="Files on disk" value={s.files_on_disk} />
-        <RatioChip label="Import sources" value={s.import_sources_on_disk} />
-      </Stack>
+      {/* Structural health — these hold the data migration carries. */}
+      <Box>
+        <Typography variant="overline" color="text.secondary">
+          Project data
+        </Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          <RatioChip label="Projects on disk" value={s.projects_on_disk} />
+          <RatioChip label="Job directories on disk" value={s.jobs_on_disk} />
+          <RatioChip label="Files on disk" value={s.files_on_disk} />
+        </Stack>
+      </Box>
+
+      {/* In-contract violation: top-level job files that SHOULD be present. */}
+      {topMissing > 0 && (
+        <Alert severity="warning">
+          <AlertTitle>
+            {topMissing} file{topMissing === 1 ? "" : "s"} from top-level jobs
+            {topMissing === 1 ? " is" : " are"} missing
+          </AlertTitle>
+          <Typography variant="body2" sx={{ mb: 1 }}>
+            These files have database entries but were not found on disk. Files
+            recorded for top-level jobs are expected to be present; their absence
+            means those results will not be available after migration. This does
+            not block migration — the rest of the project migrates normally — but
+            you should be aware of what is missing.
+          </Typography>
+          <TableContainer sx={{ maxHeight: 220, overflow: "auto" }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Job</TableCell>
+                  <TableCell>File</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {report.files.top_missing.map((m, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{m.job_number}</TableCell>
+                    <TableCell sx={{ wordBreak: "break-all" }}>
+                      {m.filename}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Alert>
+      )}
+
+      {/* Out-of-contract: sub-job files are not covered by the guarantee. */}
+      {subMissing > 0 && (
+        <Alert severity="info">
+          <AlertTitle>
+            {subMissing} sub-job file{subMissing === 1 ? "" : "s"} not found
+          </AlertTitle>
+          <Typography variant="body2">
+            These files belong to nested pipeline steps (sub-jobs). The migration
+            guarantee covers files of top-level jobs; files inside sub-jobs are
+            not guaranteed to be preserved, so their absence is outside that
+            contract rather than a fault. Listed here for transparency.
+          </Typography>
+        </Alert>
+      )}
 
       {(s.integrity_issues > 0 || s.data_quality_issues > 0) && (
         <Alert severity="warning">
@@ -389,7 +448,7 @@ const ValidateStep: React.FC<{
       {(report.projects.dir_missing.length > 0 ||
         report.jobs.dir_missing_count > 0) && (
         <Alert severity="warning">
-          <AlertTitle>Some directories are missing on disk</AlertTitle>
+          <AlertTitle>Some project or job directories are missing on disk</AlertTitle>
           {report.projects.dir_missing.slice(0, 10).map((d, i) => (
             <Typography key={i} variant="body2">
               • {d.project}: {d.directory}
@@ -399,6 +458,8 @@ const ValidateStep: React.FC<{
             <Typography variant="body2">
               • {report.jobs.dir_missing_count} job director
               {report.jobs.dir_missing_count === 1 ? "y" : "ies"} not found
+              (these jobs will migrate as records, but their working files
+              won&apos;t be available)
             </Typography>
           )}
         </Alert>
@@ -445,13 +506,21 @@ const ValidateStep: React.FC<{
   );
 };
 
-const RatioChip: React.FC<{ label: string; value: string }> = ({ label, value }) => {
+const RatioChip: React.FC<{ label: string; value: string; muted?: boolean }> = ({
+  label,
+  value,
+  muted = false,
+}) => {
   const [have, total] = value.split("/").map((x) => parseInt(x, 10));
   const complete = Number.isFinite(have) && have === total;
+  // Structural chips warn (amber) when incomplete. Informational ("muted")
+  // chips stay neutral when incomplete — a shortfall there is expected, not a
+  // problem, so we don't raise alarm colours.
+  const color = complete ? "success" : muted ? "default" : "warning";
   return (
     <Chip
-      icon={complete ? <CheckCircle /> : <Warning />}
-      color={complete ? "success" : "warning"}
+      icon={complete ? <CheckCircle /> : muted ? undefined : <Warning />}
+      color={color}
       variant="outlined"
       label={`${label}: ${value}`}
     />

--- a/client/renderer/components/migrate-legacy-content.tsx
+++ b/client/renderer/components/migrate-legacy-content.tsx
@@ -1,0 +1,680 @@
+"use client";
+import React, { useState } from "react";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Checkbox,
+  Radio,
+  RadioGroup,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  ArrowForward,
+  CheckCircle,
+  ContentCopy,
+  Error as ErrorIcon,
+  FolderSpecial,
+  PlayArrow,
+  Warning,
+} from "@mui/icons-material";
+import { useApi } from "../api";
+import { apiJson } from "../api-fetch";
+import { usePopcorn } from "../providers/popcorn-provider";
+import { useAuth } from "@/lib/compounds/auth-context";
+import type {
+  ImportResult,
+  ImportStatus,
+  StructureIssue,
+  ValidateReport,
+} from "../types/migration";
+
+const STEPS = ["Source", "Validate", "Dry run", "Import"];
+
+const DEFAULT_DB_PATH = "~/.CCP4I2/db/database.sqlite";
+
+type CopyMode = "copy" | "schlurp";
+
+/** Friendly labels for the machine-readable issue types. */
+const ISSUE_TITLES: Record<string, string> = {
+  nested_project: "Nested project",
+  dest_collision: "Destination name collision",
+  case_clash: "Name clash (case-insensitive filesystem)",
+  unicode_clash: "Name clash (unicode normalisation)",
+  shared_directory: "Shared project directory",
+  shared_subtree: "Shared content directory",
+  not_project_root: "Not a project root",
+  dest_unwritable: "Destination not writable",
+  insufficient_space: "Insufficient disk space",
+  unreadable_source: "Unreadable source",
+  i1_dir_overlap: "i1 directory overlap",
+};
+
+function issueColor(severity: string): "error" | "warning" | "info" {
+  if (severity === "blocking") return "error";
+  if (severity === "warning") return "warning";
+  return "info";
+}
+
+export const MigrateLegacyContent: React.FC = () => {
+  const api = useApi();
+  const { setMessage, setError } = usePopcorn();
+  const { canAdminister } = useAuth();
+
+  const [activeStep, setActiveStep] = useState(0);
+
+  // Step 1 — source & mode
+  const [dbPath, setDbPath] = useState(DEFAULT_DB_PATH);
+  const [copyMode, setCopyMode] = useState<CopyMode>("copy");
+  const [remapFrom, setRemapFrom] = useState("");
+  const [remapTo, setRemapTo] = useState("");
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  // Results
+  const [report, setReport] = useState<ValidateReport | null>(null);
+  const [dryRun, setDryRun] = useState<ImportResult | null>(null);
+  const [imported, setImported] = useState<ImportResult | null>(null);
+  const [status, setStatus] = useState<ImportStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  if (!canAdminister) {
+    return (
+      <Alert severity="error" sx={{ maxWidth: 640, mx: "auto", mt: 4 }}>
+        <AlertTitle>Administrator access required</AlertTitle>
+        Migrating a legacy database is an administrative operation. Please sign in
+        as an administrator to continue.
+      </Alert>
+    );
+  }
+
+  const copyFiles = copyMode === "copy";
+
+  /** Build the shared multipart body for all three endpoints. */
+  const buildForm = (extra: Record<string, string> = {}) => {
+    const fd = new FormData();
+    fd.append("db_path", dbPath.trim());
+    fd.append("copy_files", String(copyFiles));
+    if (remapFrom.trim() && remapTo.trim()) {
+      fd.append("remap_from", remapFrom.trim());
+      fd.append("remap_to", remapTo.trim());
+    }
+    Object.entries(extra).forEach(([k, v]) => fd.append(k, v));
+    return fd;
+  };
+
+  const blocking = report?.summary.blocking_issues ?? 0;
+  const canAdvanceFromValidate = !!report && (blocking === 0 || acknowledged);
+
+  // ---- Step actions -------------------------------------------------------
+
+  const runValidate = async () => {
+    setBusy(true);
+    setReport(null);
+    setDryRun(null);
+    try {
+      const r = await api.post<ValidateReport>(
+        "admin/validate-sqlite/",
+        buildForm()
+      );
+      setReport(r);
+      setAcknowledged(false);
+      setActiveStep(1);
+    } catch (e: any) {
+      setError(`Validation failed: ${e?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runDryRun = async () => {
+    setBusy(true);
+    setDryRun(null);
+    try {
+      const r = await api.post<ImportResult>(
+        "admin/import-sqlite/",
+        buildForm({ dry_run: "true", allow_structural_issues: "true" })
+      );
+      setDryRun(r);
+      setActiveStep(2);
+    } catch (e: any) {
+      setError(`Dry run failed: ${friendlyError(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runImport = async () => {
+    setBusy(true);
+    try {
+      const r = await api.post<ImportResult>(
+        "admin/import-sqlite/",
+        buildForm({ dry_run: "false", allow_structural_issues: "true" })
+      );
+      setImported(r);
+      setActiveStep(3);
+      setMessage("Migration complete", "success");
+      // Confirmation counts (one-shot GET; api.get is an SWR hook, so use apiJson).
+      const s = await apiJson<ImportStatus>(
+        "/api/proxy/ccp4i2/admin/import-status/"
+      ).catch(() => null);
+      if (s) setStatus(s);
+    } catch (e: any) {
+      setError(`Import failed: ${friendlyError(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ---- Render -------------------------------------------------------------
+
+  return (
+    <Box sx={{ maxWidth: 900, mx: "auto" }}>
+      <Typography variant="h4" gutterBottom>
+        Migrate a legacy CCP4i2 database
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Bring projects, jobs and files from an old (Qt-era) CCP4i2 installation
+        into this one. Migration moves the database records; project
+        directories are either copied in or adopted where they are.
+      </Typography>
+
+      <Stepper activeStep={activeStep} sx={{ mb: 4 }}>
+        {STEPS.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      {activeStep === 0 && (
+        <SourceStep
+          dbPath={dbPath}
+          setDbPath={setDbPath}
+          copyMode={copyMode}
+          setCopyMode={setCopyMode}
+          remapFrom={remapFrom}
+          setRemapFrom={setRemapFrom}
+          remapTo={remapTo}
+          setRemapTo={setRemapTo}
+          busy={busy}
+          onValidate={runValidate}
+        />
+      )}
+
+      {activeStep === 1 && report && (
+        <ValidateStep
+          report={report}
+          copyFiles={copyFiles}
+          acknowledged={acknowledged}
+          setAcknowledged={setAcknowledged}
+          canAdvance={canAdvanceFromValidate}
+          busy={busy}
+          onBack={() => setActiveStep(0)}
+          onNext={runDryRun}
+        />
+      )}
+
+      {activeStep === 2 && dryRun && (
+        <ResultStep
+          title="Dry run — nothing was written"
+          result={dryRun}
+          busy={busy}
+          onBack={() => setActiveStep(1)}
+          primaryLabel="Run import"
+          primaryIcon={<PlayArrow />}
+          onPrimary={runImport}
+        />
+      )}
+
+      {activeStep === 3 && imported && (
+        <DoneStep result={imported} status={status} />
+      )}
+    </Box>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Step 1 — source & copy mode
+// ---------------------------------------------------------------------------
+
+const SourceStep: React.FC<{
+  dbPath: string;
+  setDbPath: (v: string) => void;
+  copyMode: CopyMode;
+  setCopyMode: (v: CopyMode) => void;
+  remapFrom: string;
+  setRemapFrom: (v: string) => void;
+  remapTo: string;
+  setRemapTo: (v: string) => void;
+  busy: boolean;
+  onValidate: () => void;
+}> = (p) => (
+  <Stack spacing={3}>
+    <TextField
+      label="Legacy database path"
+      helperText="Path on this machine to the old CCP4i2 SQLite database"
+      value={p.dbPath}
+      onChange={(e) => p.setDbPath(e.target.value)}
+      fullWidth
+    />
+
+    <FormControl>
+      <FormLabel>How should project files be handled?</FormLabel>
+      <RadioGroup
+        value={p.copyMode}
+        onChange={(e) => p.setCopyMode(e.target.value as CopyMode)}
+      >
+        <FormControlLabel
+          value="copy"
+          control={<Radio />}
+          label={
+            <Box>
+              <Typography>Copy projects into this installation (recommended)</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Your old installation is left untouched; you can delete it
+                afterwards. Uses extra disk space.
+              </Typography>
+            </Box>
+          }
+        />
+        <FormControlLabel
+          value="schlurp"
+          control={<Radio />}
+          label={
+            <Box>
+              <Typography>Adopt projects where they are</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Faster, no extra disk, but this installation reads from your old
+                directories — don&apos;t delete them. (Nested projects are still
+                copied out.)
+              </Typography>
+            </Box>
+          }
+        />
+      </RadioGroup>
+    </FormControl>
+
+    <Box>
+      <Typography variant="subtitle2" gutterBottom>
+        Path remapping (optional)
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        If the database was created on another machine or under a different home
+        directory, remap the old path prefix to where the files live now.
+      </Typography>
+      <Stack direction="row" spacing={2} sx={{ mt: 1 }}>
+        <TextField
+          label="From prefix"
+          value={p.remapFrom}
+          onChange={(e) => p.setRemapFrom(e.target.value)}
+          fullWidth
+          size="small"
+        />
+        <TextField
+          label="To prefix"
+          value={p.remapTo}
+          onChange={(e) => p.setRemapTo(e.target.value)}
+          fullWidth
+          size="small"
+        />
+      </Stack>
+    </Box>
+
+    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+      <Button
+        variant="contained"
+        endIcon={p.busy ? <CircularProgress size={16} /> : <ArrowForward />}
+        disabled={p.busy || !p.dbPath.trim()}
+        onClick={p.onValidate}
+      >
+        Validate
+      </Button>
+    </Box>
+  </Stack>
+);
+
+// ---------------------------------------------------------------------------
+// Step 2 — validation report + structure/plan
+// ---------------------------------------------------------------------------
+
+const ValidateStep: React.FC<{
+  report: ValidateReport;
+  copyFiles: boolean;
+  acknowledged: boolean;
+  setAcknowledged: (v: boolean) => void;
+  canAdvance: boolean;
+  busy: boolean;
+  onBack: () => void;
+  onNext: () => void;
+}> = ({ report, acknowledged, setAcknowledged, canAdvance, busy, onBack, onNext }) => {
+  const s = report.summary;
+  const blocking = s.blocking_issues;
+  return (
+    <Stack spacing={3}>
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        <RatioChip label="Projects on disk" value={s.projects_on_disk} />
+        <RatioChip label="Jobs on disk" value={s.jobs_on_disk} />
+        <RatioChip label="Files on disk" value={s.files_on_disk} />
+        <RatioChip label="Import sources" value={s.import_sources_on_disk} />
+      </Stack>
+
+      {(s.integrity_issues > 0 || s.data_quality_issues > 0) && (
+        <Alert severity="warning">
+          <AlertTitle>Data checks</AlertTitle>
+          {report.integrity.issues.concat(report.data_quality.issues).map((m, i) => (
+            <Typography key={i} variant="body2">
+              • {m}
+            </Typography>
+          ))}
+        </Alert>
+      )}
+
+      {(report.projects.dir_missing.length > 0 ||
+        report.jobs.dir_missing_count > 0) && (
+        <Alert severity="warning">
+          <AlertTitle>Some directories are missing on disk</AlertTitle>
+          {report.projects.dir_missing.slice(0, 10).map((d, i) => (
+            <Typography key={i} variant="body2">
+              • {d.project}: {d.directory}
+            </Typography>
+          ))}
+          {report.jobs.dir_missing_count > 0 && (
+            <Typography variant="body2">
+              • {report.jobs.dir_missing_count} job director
+              {report.jobs.dir_missing_count === 1 ? "y" : "ies"} not found
+            </Typography>
+          )}
+        </Alert>
+      )}
+
+      <IssueList issues={report.structure.issues} />
+
+      <PlanTable report={report} />
+
+      {blocking > 0 && (
+        <Alert severity="error">
+          <AlertTitle>
+            {blocking} issue{blocking === 1 ? "" : "s"} need
+            {blocking === 1 ? "s" : ""} your attention
+          </AlertTitle>
+          These must be acknowledged before continuing. Review the issues above.
+          <FormControlLabel
+            sx={{ display: "block", mt: 1 }}
+            control={
+              <Checkbox
+                checked={acknowledged}
+                onChange={(e) => setAcknowledged(e.target.checked)}
+              />
+            }
+            label="I understand and want to proceed anyway"
+          />
+        </Alert>
+      )}
+
+      <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Button onClick={onBack} disabled={busy}>
+          Back
+        </Button>
+        <Button
+          variant="contained"
+          endIcon={busy ? <CircularProgress size={16} /> : <ArrowForward />}
+          disabled={busy || !canAdvance}
+          onClick={onNext}
+        >
+          Dry run
+        </Button>
+      </Box>
+    </Stack>
+  );
+};
+
+const RatioChip: React.FC<{ label: string; value: string }> = ({ label, value }) => {
+  const [have, total] = value.split("/").map((x) => parseInt(x, 10));
+  const complete = Number.isFinite(have) && have === total;
+  return (
+    <Chip
+      icon={complete ? <CheckCircle /> : <Warning />}
+      color={complete ? "success" : "warning"}
+      variant="outlined"
+      label={`${label}: ${value}`}
+    />
+  );
+};
+
+const IssueList: React.FC<{ issues: StructureIssue[] }> = ({ issues }) => {
+  if (!issues.length) return null;
+  return (
+    <Stack spacing={1}>
+      <Typography variant="subtitle1">Structural checks</Typography>
+      {issues.map((issue, i) => (
+        <Alert key={i} severity={issueColor(issue.severity)} icon={<Warning />}>
+          <AlertTitle sx={{ mb: 0 }}>
+            {ISSUE_TITLES[issue.type] ?? issue.type}
+          </AlertTitle>
+          <Typography variant="body2">{issue.detail}</Typography>
+          {issue.resolution && (
+            <Typography variant="body2" sx={{ mt: 0.5, fontStyle: "italic" }}>
+              → {issue.resolution}
+            </Typography>
+          )}
+        </Alert>
+      ))}
+    </Stack>
+  );
+};
+
+const PlanTable: React.FC<{ report: ValidateReport }> = ({ report }) => {
+  const ps = report.summary.plan_summary;
+  return (
+    <Box>
+      <Typography variant="subtitle1" gutterBottom>
+        Migration plan — {ps.in_place} in place, {ps.copy} copied
+        {ps.copied_due_to_nesting > 0
+          ? ` (${ps.copied_due_to_nesting} un-nested)`
+          : ""}
+      </Typography>
+      <TableContainer sx={{ maxHeight: 320, overflow: "auto" }}>
+        <Table size="small" stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell>Project</TableCell>
+              <TableCell>Action</TableCell>
+              <TableCell>Destination</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {report.plan.map((e) => (
+              <TableRow key={e.legacy_project_id}>
+                <TableCell>
+                  {e.name}
+                  {e.renamed_to && (
+                    <Typography variant="caption" color="text.secondary">
+                      {" "}
+                      → {e.renamed_to}
+                    </Typography>
+                  )}
+                  {!e.source_exists && (
+                    <Chip
+                      size="small"
+                      color="warning"
+                      label="source missing"
+                      sx={{ ml: 1 }}
+                    />
+                  )}
+                </TableCell>
+                <TableCell>
+                  {e.mode === "copy" ? (
+                    <Chip
+                      size="small"
+                      icon={e.reason === "nested" ? <FolderSpecial /> : <ContentCopy />}
+                      label={e.reason === "nested" ? "copy (un-nest)" : "copy"}
+                      color="primary"
+                      variant="outlined"
+                    />
+                  ) : (
+                    <Chip size="small" label="in place" variant="outlined" />
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" sx={{ wordBreak: "break-all" }}>
+                    {e.dest}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Step 3 — dry-run result
+// ---------------------------------------------------------------------------
+
+const ResultStep: React.FC<{
+  title: string;
+  result: ImportResult;
+  busy: boolean;
+  onBack: () => void;
+  primaryLabel: string;
+  primaryIcon: React.ReactNode;
+  onPrimary: () => void;
+}> = ({ title, result, busy, onBack, primaryLabel, primaryIcon, onPrimary }) => (
+  <Stack spacing={3}>
+    <Alert severity="info">
+      <AlertTitle>{title}</AlertTitle>
+      This is what a real import would do. Review the counts, then proceed.
+    </Alert>
+    <StatsTable stats={result.stats} />
+    {result.errors.length > 0 && (
+      <Alert severity="error">
+        <AlertTitle>{result.errors.length} error(s)</AlertTitle>
+        {result.errors.slice(0, 20).map((e, i) => (
+          <Typography key={i} variant="body2">
+            • {e}
+          </Typography>
+        ))}
+      </Alert>
+    )}
+    <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+      <Button onClick={onBack} disabled={busy}>
+        Back
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        endIcon={busy ? <CircularProgress size={16} /> : primaryIcon}
+        disabled={busy}
+        onClick={onPrimary}
+      >
+        {primaryLabel}
+      </Button>
+    </Box>
+  </Stack>
+);
+
+// ---------------------------------------------------------------------------
+// Step 4 — done
+// ---------------------------------------------------------------------------
+
+const DoneStep: React.FC<{ result: ImportResult; status: ImportStatus | null }> = ({
+  result,
+  status,
+}) => (
+  <Stack spacing={3}>
+    <Alert severity={result.errors.length ? "warning" : "success"} icon={<CheckCircle />}>
+      <AlertTitle>
+        {result.errors.length ? "Migration completed with warnings" : "Migration complete"}
+      </AlertTitle>
+      {result.errors.length
+        ? `${result.errors.length} record(s) could not be imported — see below.`
+        : "Your legacy projects are now available in this installation."}
+    </Alert>
+    <StatsTable stats={result.stats} />
+    {status && (
+      <Box>
+        <Typography variant="subtitle1" gutterBottom>
+          Database now contains
+        </Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          <Chip label={`${status.projects.total} projects`} />
+          <Chip label={`${status.jobs.total} jobs`} />
+          <Chip label={`${status.files.total} files`} />
+        </Stack>
+      </Box>
+    )}
+    {result.errors.length > 0 && (
+      <Alert severity="error" icon={<ErrorIcon />}>
+        {result.errors.slice(0, 20).map((e, i) => (
+          <Typography key={i} variant="body2">
+            • {e}
+          </Typography>
+        ))}
+      </Alert>
+    )}
+  </Stack>
+);
+
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
+const StatsTable: React.FC<{ stats: Record<string, number> }> = ({ stats }) => {
+  const rows = Object.entries(stats).filter(([, v]) => v);
+  if (!rows.length)
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No records to import.
+      </Typography>
+    );
+  return (
+    <TableContainer sx={{ maxHeight: 320, overflow: "auto" }}>
+      <Table size="small" stickyHeader>
+        <TableHead>
+          <TableRow>
+            <TableCell>Entity</TableCell>
+            <TableCell align="right">Count</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map(([k, v]) => (
+            <TableRow key={k}>
+              <TableCell>{k.replace(/_/g, " ")}</TableCell>
+              <TableCell align="right">{v}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+/** Map a thrown API error (message is the machine `error` string) to prose. */
+function friendlyError(e: any): string {
+  const msg = String(e?.message ?? e);
+  if (msg.includes("structural_issues_unacknowledged"))
+    return "blocking structural issues were not acknowledged — go back and review them";
+  if (msg.includes("import_failed"))
+    return "the import ran but some records failed — see the counts";
+  if (msg.includes("db_not_found")) return "the database file was not found";
+  return msg;
+}

--- a/client/renderer/components/projects-toolbar.tsx
+++ b/client/renderer/components/projects-toolbar.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { useRouter } from "next/navigation";
 import { Button, Toolbar, Tooltip } from "@mui/material";
-import { Add, Upload } from "@mui/icons-material";
+import { Add, Upload, SettingsBackupRestore } from "@mui/icons-material";
+import { useAuth } from "@/lib/compounds/auth-context";
 
 export default function ProjectsToolbar() {
   const router = useRouter();
+  const { canAdminister } = useAuth();
 
   function importProjects() {
     router.push("/ccp4i2/import-project");
@@ -30,6 +32,17 @@ export default function ProjectsToolbar() {
           Import
         </Button>
       </Tooltip>
+      {canAdminister && (
+        <Tooltip title="Migrate a legacy CCP4i2 database into this installation">
+          <Button
+            variant="outlined"
+            startIcon={<SettingsBackupRestore />}
+            onClick={() => router.push("/ccp4i2/admin/migrate-legacy")}
+          >
+            Migrate legacy
+          </Button>
+        </Tooltip>
+      )}
     </Toolbar>
   );
 }

--- a/client/renderer/types/migration.ts
+++ b/client/renderer/types/migration.ts
@@ -34,7 +34,13 @@ export interface ValidateSummary {
   projects_on_disk: string;
   jobs_on_disk: string;
   files_on_disk: string;
-  import_sources_on_disk: string;
+  // Informational: original external import sources still resolvable. Not a
+  // health signal (files_on_disk already covers the imported copies).
+  import_sources_present: string;
+  // Missing files split by the preservation contract: top-level job files are
+  // guaranteed (a miss is a real violation), sub-job files are not.
+  top_level_files_missing: number;
+  sub_job_files_missing: number;
   integrity_issues: number;
   data_quality_issues: number;
   structure_issues: number;
@@ -65,13 +71,21 @@ export interface ValidateReport {
     total: number;
     exists: number;
     missing_count: number;
-    missing: { filename: string; expected_path: string }[];
+    missing: {
+      filename: string;
+      expected_path: string;
+      job_number: string;
+      top_level: boolean;
+    }[];
+    top_missing_count: number;
+    top_missing: { filename: string; expected_path: string; job_number: string }[];
+    sub_missing_count: number;
   };
   imported_files: {
     total: number;
+    // Original external import sources still present (informational only).
     source_exists: number;
     source_missing_count: number;
-    source_missing: string[];
   };
   integrity: { ok: boolean; issues: string[] };
   data_quality: { ok: boolean; issues: string[] };

--- a/client/renderer/types/migration.ts
+++ b/client/renderer/types/migration.ts
@@ -1,0 +1,102 @@
+// Wire-contract types for legacy CCP4i2 -> Django migration.
+// Mirrors docs/LEGACY_MIGRATION_WIRE_CONTRACT.md and the shapes returned by
+// server/ccp4i2/db/import_sqlite.py + api/admin_views.py.
+
+export type IssueSeverity = "blocking" | "warning" | "info";
+
+export interface StructureIssue {
+  type: string; // nested_project | dest_collision | case_clash | ...
+  severity: IssueSeverity;
+  mode_scope: "copy" | "schlurp" | "both";
+  projects: string[]; // legacy project ids (32-hex)
+  detail: string;
+  resolution: string | null; // null => needs user action; else what migration will do
+}
+
+export interface Structure {
+  ok: boolean;
+  issues: StructureIssue[];
+}
+
+export interface PlanEntry {
+  legacy_project_id: string;
+  name: string;
+  source_dir: string;
+  mode: "in_place" | "copy";
+  dest: string;
+  reason: "copy_files" | "nested" | "in_place";
+  source_exists: boolean;
+  renamed_to: string | null;
+}
+
+export interface ValidateSummary {
+  ok: boolean;
+  projects_on_disk: string;
+  jobs_on_disk: string;
+  files_on_disk: string;
+  import_sources_on_disk: string;
+  integrity_issues: number;
+  data_quality_issues: number;
+  structure_issues: number;
+  blocking_issues: number;
+  plan_summary: {
+    in_place: number;
+    copy: number;
+    copied_due_to_nesting: number;
+  };
+}
+
+export interface ValidateReport {
+  source: string;
+  counts: Record<string, number | null>;
+  projects: {
+    total: number;
+    dir_exists: number;
+    dir_missing: { project: string; directory: string }[];
+    dir_empty: string[];
+  };
+  jobs: {
+    total: number;
+    dir_exists: number;
+    dir_missing_count: number;
+    dir_missing: { job_number: string; task_name: string; expected_dir: string }[];
+  };
+  files: {
+    total: number;
+    exists: number;
+    missing_count: number;
+    missing: { filename: string; expected_path: string }[];
+  };
+  imported_files: {
+    total: number;
+    source_exists: number;
+    source_missing_count: number;
+    source_missing: string[];
+  };
+  integrity: { ok: boolean; issues: string[] };
+  data_quality: { ok: boolean; issues: string[] };
+  structure: Structure;
+  plan: PlanEntry[];
+  summary: ValidateSummary;
+}
+
+export interface ImportResult {
+  dry_run: boolean;
+  source: string;
+  stats: Record<string, number>;
+  errors: string[];
+  plan: PlanEntry[];
+  structure: Structure;
+}
+
+export interface ImportStatus {
+  projects: { total: number; groups: number; memberships: number; tags: number };
+  jobs: {
+    total: number;
+    value_keys: number;
+    float_values: number;
+    char_values: number;
+    xdata: number;
+  };
+  files: { total: number; types: number; uses: number; imports: number; exports: number };
+}

--- a/docs/LEGACY_MIGRATION_UI_PLAN.md
+++ b/docs/LEGACY_MIGRATION_UI_PLAN.md
@@ -1,0 +1,398 @@
+# Legacy CCP4i2 → Django Migration: UI + Hardening Plan (a2)
+
+**Goal:** Iron out wrinkles in, and provide a UI for, migrating a legacy (Qt-era)
+CCP4i2 installation into the new Django-backed CCP4i2.
+
+**Primary audience (this round):** a **desktop user migrating their own
+`~/.CCP4I2` database** into their new install. The server is their own machine;
+legacy project directories are local and already present. A cloud/admin variant
+(upload + remap + real admin gating) is a later extension, not this round.
+
+**Decisions taken:** desktop self-migration first; **add file-copying** to the
+importer so a migration can produce a clean, self-contained new install; nested
+projects are copied out to `CCP4I2_PROJECTS_DIR` and repointed (mixed-mode).
+
+**Guiding principle — this whole thing is UI-driven.** The wizard is the front
+door and the sole intended entry point for a normal user. Every decision the
+migration makes — source, copy vs schlurp, the per-project plan, and how each
+structural issue (§2.5) is resolved — must be **presented and confirmed in the
+UI**, never assumed from a default or hidden behind a flag. Consequences that
+shape the design below:
+- The backend does **no irreversible action without a preceding validate the UI
+  has shown the user.** Validate → dry-run → import is a hard sequence in the UI,
+  not an optional nicety.
+- The REST layer must return everything the UI needs to *render* a decision (the
+  full report, the per-project `plan`, per-issue `{type, severity, detail,
+  resolution}`), not just a pass/fail. No decision is UI-invisible.
+- The `manage.py import_sqlite` / `validate_sqlite` commands stay as a
+  power-user / scripting / test path, but they are **not** the primary UX and must
+  not grow behaviour the UI can't drive. Anything the CLI can do, the UI can do.
+
+---
+
+## 1. What already exists (backend is done)
+
+Records-only migration is fully implemented and exposed over REST — there is just
+no frontend.
+
+| Layer | File | What it does |
+|-------|------|--------------|
+| Core validator | [`import_sqlite.py`](../server/ccp4i2/db/import_sqlite.py) `SQLiteValidator` | Read-only. Checks project dirs, `CCP4_JOBS/job_N` dirs, `CCP4_IMPORTED_FILES`, import-source files exist on disk; referential integrity; data quality. Returns a report with a top-level `summary`. |
+| Core importer | `import_sqlite.py` `SQLiteImporter` | 7-phase transactional import (lookups → projects → groups → jobs → files → history → comments). Supports `dry_run`, `remap_dirs`, `continue_on_error`, de-dup by dir/uuid. Returns `{dry_run, stats, errors, source}`. |
+| CLI | `manage.py import_sqlite` / `validate_sqlite` | Command wrappers over the two classes. |
+| REST (admin-only) | [`admin_views.py`](../server/ccp4i2/api/admin_views.py) | `admin/validate-sqlite/`, `admin/import-sqlite/`, `admin/import-status/` (+ `admin/import-legacy/` for dumpdata JSON). Each accepts an **uploaded** `sqlite_db` **or** a server-side `db_path`, plus `dry_run`, `remap_from`, `remap_to`. |
+
+**REST response shapes the UI consumes**
+
+- `validate-sqlite/` → the full validator report:
+  `{source, counts{Projects,Jobs,Files,…}, projects{total,dir_exists,dir_missing[],dir_empty[]}, jobs{total,dir_exists,dir_missing_count,dir_missing[]}, files{total,exists,missing_count,missing[]}, imported_files{total,source_exists}, integrity{ok,issues[]}, data_quality{ok,issues[]}, summary{ok, projects_on_disk:"n/total", jobs_on_disk, files_on_disk, import_sources_on_disk, integrity_issues, data_quality_issues}}`
+- `import-sqlite/` → `{dry_run, stats{projects,jobs,files,…}, errors[], source}` (HTTP 400 if `errors`).
+- `import-status/` → `{projects{total,groups,…}, jobs{…}, files{…}}`.
+
+---
+
+## 2. The wrinkles to iron out
+
+1. **Records-only — nothing copies files.** `SQLiteImporter._import_projects`
+   sets `Project.directory` to the (remapped) *legacy* directory verbatim
+   ([import_sqlite.py:736](../server/ccp4i2/db/import_sqlite.py#L736)). No
+   `shutil`/copy anywhere. Result: the new install reads jobs/files straight out
+   of the old `~/.CCP4I2` tree. Fine short-term, but the old and new installs
+   then **share the same directories** — the user can't safely delete the old
+   install, and any legacy dir that's missing yields dangling DB rows with no
+   error at import time.
+2. **Validation is optional and easy to skip.** The validator detects (1), but
+   nothing makes the user look before importing. The UI must surface the disk
+   report *before* the real import.
+3. **Concrete bug:** [`import_i2xml.py`](../server/ccp4i2/db/management/commands/import_i2xml.py)
+   reads `options["program_xml"]` but the arg is `project_xml` — crashes if run.
+   (Not on the sqlite path, but it's in the migration family; trivial fix.)
+4. **Admin gating unenforced in the frontend**, and the renderer's `useAuth()` is
+   a mock-admin stub. For desktop self-migration this is effectively moot — flag
+   it, don't block on it.
+
+---
+
+## 2.5 Structural pre-flight checks (edge cases before schlurp/copy)
+
+Terminology used here:
+- **schlurp** = in-place migration — the new install adopts the legacy directory
+  as-is (`copy_files=false`).
+- **copy** = duplicate the legacy tree into `CCP4I2_PROJECTS_DIR` and repoint
+  (`copy_files=true`).
+
+Before *either* operation, the validator must decide whether each project's
+directory is in a shape that's safe to schlurp/copy. Today it only checks
+existence, integrity and data quality — it does **no structural reasoning about
+the directory tree itself**. The key facts that make this necessary:
+
+- `Project.directory` is `unique=True` in the model, so *exact-duplicate* dirs are
+  rejected at DB level — but **nesting is not**.
+- A project's real content lives under `<directory>/CCP4_JOBS` and
+  `<directory>/CCP4_IMPORTED_FILES`. So if one project's directory sits inside
+  another's tree, the outer project physically *contains* the inner one.
+
+New `SQLiteValidator` section `structure` (each returns a list of offenders so the
+UI can show exactly which projects are affected):
+
+1. **Nested projects (the headline case).** For every ordered pair (A, B) of
+   legacy project directories, flag when `B` is inside `A`
+   (`Path(B).resolve()` is relative to `Path(A).resolve()`, using
+   `is_relative_to` / `commonpath`, after remap).
+   - Report `{outer, inner, relationship: "B under A/CCP4_JOBS/…"}`.
+   - **Resolution (decided): copy the nested project out.** Any project involved
+     in a nesting relationship is **always copied** to a fresh dir under
+     `CCP4I2_PROJECTS_DIR` and repointed — *regardless of the overall
+     schlurp/copy choice*. There is already a project root that is the default
+     home for newly generated projects, so an un-nested clone belongs there. This
+     turns the dangerous case into the safe one:
+     - **copy mode:** already copying; just ensure the outer project's copy
+       **excludes** the inner subtree (so no duplication) and the inner project
+       gets its own dest. Both dests end up self-contained.
+     - **schlurp mode:** the run is otherwise in-place, but nested projects are
+       promoted to copy-out (**mixed mode**). Only the entangled projects move;
+       everything else is still adopted in place. The UI must state plainly which
+       projects will be copied and where.
+   - Which end gets copied out? Default: copy the **inner** project(s) out and
+     leave the outer in place (fewer/smaller trees to move, and the outer is
+     usually the "real" project). If the *outer* is the smaller/less-important one
+     that's a rare inversion — not worth a toggle in a2; document the rule.
+
+2. **Directory collisions at the destination (copy mode only).** Two legacy
+   projects whose **basename** is identical map to the same
+   `CCP4I2_PROJECTS_DIR/<name>` even though their source dirs differ. Also flag
+   when a computed destination already exists on disk (pre-existing project or a
+   prior partial migration). Report intended dest per project + collisions.
+
+3. **Shared / overlapping directories not caught by `unique`.** Symlinks or
+   `..`-relative paths that resolve to the same real path as another project
+   (canonicalise with `Path.resolve()` before comparing). `unique=True` compares
+   the raw string, so `~/x` and `/home/u/x` and a symlink all slip past it.
+
+4. **Directory is not actually a CCP4i2 project root.** Legacy dir exists but has
+   no `CCP4_JOBS` subdir, or `CCP4_JOBS` is empty while the DB lists jobs →
+   mismatch between DB and disk. Cheap sanity check that catches a wrong/moved
+   remap target.
+
+5. **Legacy directory outside expected roots / non-writable dest.** For copy:
+   `dest_root` not writable, or insufficient free space vs. estimated tree size
+   (sum sizes during the walk we already do for nesting). For schlurp: legacy dir
+   under a path that won't survive (e.g. a temp mount) — advisory only.
+
+6. **`I1ProjectDirectory` overlap.** Each project also carries a legacy-i1
+   directory; if present it can nest/collide too. Lower priority — check for
+   containment against project dirs, warn only.
+
+7. **Case-insensitive filesystem name clashes (copy mode).** On macOS (default)
+   and Windows, dest names `Foo` and `foo` collide even though they're distinct on
+   the source Linux tree. Compare intended dest basenames **case-folded** (and
+   NFC-normalised, see §8) when detecting §2 collisions — a naive
+   case-sensitive check misses this and the second `copytree` silently merges into
+   the first. Also flag two *source* project dirs that differ only by case when
+   the migration host is case-insensitive.
+
+8. **Unicode-normalisation clashes.** Two names equal under NFC/NFD (common when a
+   tree has been round-tripped through macOS, which stores NFD) collide at the
+   dest. Normalise to NFC before dest-name comparison; report as a §2 collision
+   variant.
+
+9. **Shared / symlinked `CCP4_IMPORTED_FILES` (or `CCP4_JOBS`).** Two projects may
+   point their import/job subdirs at a common location via symlink even when the
+   project roots differ (so §3's root-level canonicalisation misses it). Walk each
+   project's `CCP4_IMPORTED_FILES` and `CCP4_JOBS`, resolve symlinks, and flag when
+   subtrees of *different* projects resolve into a shared real directory. In copy
+   mode this means files get duplicated or, worse, a `copytree` follows a symlink
+   into another project. Default `copytree(symlinks=True)` (preserve links) plus a
+   report of cross-project shared targets; blocking only if a shared target sits
+   under another migrating project's dest.
+
+10. **Read-only / permission-denied legacy trees (copy mode).** A legacy dir the
+    server process can't read (or individual unreadable files within) makes
+    `copytree` fail partway. Pre-flight an access check (walk + `os.access(...,
+    R_OK)` on a sample, or catch during the size walk) and report unreadable
+    paths per project so the copy doesn't die mid-import. For schlurp this is only
+    a problem if the running install also can't read them at runtime — advisory.
+
+Severity model:
+- **Blocking in copy mode** (until acknowledged / auto-resolved): dest collisions
+  (2), case/NFC clashes (7, 8), shared targets landing under a migrating dest (9),
+  unreadable source trees (10).
+- **Nesting (1) is auto-resolved** (copy-out to the project root) rather than
+  blocking — but the UI must surface the resulting copy plan and let the user
+  confirm before Step 4.
+- Everything else — (3)–(6), non-blocking (9) — are **warnings**.
+- In schlurp mode, nesting still triggers the mixed-mode copy-out (1); the other
+  copy-only checks (2, 7, 8, 10) don't apply to projects staying in place.
+
+All feed the same `structure.issues[]` the UI renders in Step 2, each carrying
+`{type, severity, projects[], detail, resolution}` so the UI can render both the
+problem and what the migration will do about it (e.g. "will be copied to
+`CCP4X_PROJECTS/Foo_2`").
+
+**Where this runs:** add `_validate_structure(cur)` to `SQLiteValidator`,
+included in `run()`'s report and folded into `summary` (`structure_issues` count,
+and `summary.ok` must go false on any *blocking* structural issue). The validator
+computes, and returns, a **per-project migration plan**:
+`plan[legacy_project_id] = {mode: "in_place" | "copy", dest, reason}`. The importer
+consumes the same plan so validate and import cannot disagree — the importer must
+not re-derive it independently. A project's plan `mode` is `copy` if the run is in
+copy mode **or** the project is nesting-entangled (§2.5.1 mixed-mode), else
+`in_place`. `dest` is a de-duplicated, case/NFC-safe name under `dest_root`.
+
+---
+
+## 3. Backend work
+
+### 3a. Add `copy_files` to `SQLiteImporter` (the file-copying decision)
+
+Give the importer an optional copy-in mode so a desktop migration can produce a
+**self-contained** new install rather than sharing the legacy tree.
+
+- New constructor args: `copy_files: bool = False`, `dest_root: Path | None`
+  (defaults to `settings.CCP4I2_PROJECTS_DIR`, the same root native projects use —
+  [settings.py:241](../server/ccp4i2/config/settings.py#L241)).
+- **Plan-driven, not flag-driven.** The importer consumes the validator's
+  per-project `plan` (§2.5 "Where this runs"): for each project it does what the
+  plan says (`in_place` → adopt legacy dir; `copy` → `shutil.copytree` to
+  `plan.dest`, repoint `Project.directory`). This is what lets a single run mix
+  in-place and copy (nesting mixed-mode) without special-casing in the copy loop.
+- `copy_files=true` simply means "every project's plan defaults to `copy`";
+  nesting can flip an otherwise-`in_place` project to `copy` (§2.5.1).
+- `copytree` uses `symlinks=True` (preserve links, §2.5.9) and an `ignore` that
+  **excludes any other project's dir nested under this one** (§2.5.1) so nested
+  content is never duplicated. Skip if source missing — record a skip stat.
+- Copy happens **inside** the existing `transaction.atomic()` phase ordering but
+  is a filesystem side-effect: on `dry_run`, copy nothing and just report intended
+  destinations + source-missing warnings. On real run, copy before/at project
+  creation so `directory` is correct.
+- Idempotency: if `dest` already exists, skip-copy + reuse (mirrors the existing
+  dir-based de-dup). Record `projects_copied` / `projects_copy_skipped` /
+  `copy_errors` in `stats`.
+- Surface `copy_files`, `remap`, and dest root in the returned `summary`/`stats`
+  so the UI can show "N projects copied to <root>".
+
+Plumb the flag through `admin_views.import_sqlite` (`copy_files` form field) and
+the `manage.py import_sqlite` command (`--copy-files`, `--dest-root`).
+
+**Guardrail for (1):** when **not** copying and a project's legacy dir is missing
+(and no working remap), the importer should count it and the API should return it
+prominently so the UI can warn rather than silently create dangling rows.
+
+**Blocking-issue gate.** If the plan contains *blocking* structural issues that
+are **not** auto-resolved (dest collisions, case/NFC clashes, shared targets,
+unreadable trees — §2.5 severity model), `import-sqlite/` returns 400 with the
+offenders and does nothing, unless the request carries an explicit
+`allow_structural_issues=true` (set by the UI only after the user acknowledges the
+Step-2 warning). Nesting is **not** in this gate — it's auto-resolved via the plan
+(copied out to `dest_root`), so it never blocks; it only needs the user to confirm
+the copy plan.
+
+**Stats to record:** `projects_copied`, `projects_in_place`, `projects_nested`
+(copied-out due to nesting), `copy_excluded_subtrees`, `projects_copy_skipped`,
+`copy_errors`. Idempotency: if a computed `dest` already exists, skip-copy + reuse
+(mirrors the existing dir-based de-dup). Surface the plan summary in the response
+so the UI can show "N in place, M copied to `<root>` (K un-nested)".
+
+### 3b. Fix `import_i2xml` command
+
+`options["program_xml"]` → `options["project_xml"]`. One line.
+
+### 3c. (Deferred) De-dupe importers
+
+`import_legacy_ccp4i2` (dumpdata JSON) reimplements the same 7 phases as
+`SQLiteImporter`. Out of scope for a2 (refactor risk, touches tests) — noted so it
+isn't forgotten.
+
+---
+
+## 4. Frontend work
+
+### Route & scaffold
+New admin route, following house style
+([import-project/page.tsx](../client/renderer/app/ccp4i2/(authed)/import-project/page.tsx)):
+
+- `client/renderer/app/ccp4i2/(authed)/admin/migrate-legacy/page.tsx` — thin
+  `"use client"` shell: `CCP4i2TopBar title="Migrate legacy CCP4i2"` + `Paper` +
+  `<MigrateLegacyContent/>`.
+- `client/renderer/components/migrate-legacy-content.tsx` — the wizard logic.
+
+### The wizard (MUI `Stepper`, introduced fresh — no house pattern exists)
+
+**Step 1 — Source & mode**
+- Default: server-side **`db_path`**, prefilled `~/.CCP4I2/db/database.sqlite`
+  (the desktop-self case). Secondary option: upload a `.sqlite` (for a DB that
+  lives elsewhere).
+- **Copy mode toggle** (the key UX for the file-copying decision):
+  - **Copy projects into new install** (default, recommended) → `copy_files=true`,
+    dest = `CCP4I2_PROJECTS_DIR`. "Your old install stays untouched; you can
+    delete it afterward."
+  - **Migrate in place** → `copy_files=false`. "Faster, no extra disk, but the
+    new install reads from your old `~/.CCP4I2` directories — don't delete them."
+- Optional `remap_from`/`remap_to` (advanced; for a DB whose recorded paths no
+  longer match, e.g. moved home dir).
+
+**Step 2 — Validate** → POST `admin/validate-sqlite/`.
+- Render `summary`: `projects_on_disk`, `jobs_on_disk`, `files_on_disk`,
+  `import_sources_on_disk` as `n/total` chips; integrity + data-quality issue
+  counts.
+- If anything is missing on disk → amber/red banner listing `projects.dir_missing`
+  / `jobs.dir_missing` (this is wrinkle (1)/(2) made visible). In *copy* mode a
+  missing source dir means that project can't be copied — say so here.
+- **Structural section (§2.5)** — render `structure.issues` grouped by type:
+  - **Nested projects** table: outer → inner, with the relationship path. This is
+    the headline edge case; in copy mode it's blocking. Offer an explicit
+    "I understand, proceed anyway" checkbox that sets `allow_structural_issues`
+    for Steps 3–4; leave it off by default.
+  - **Destination collisions** (copy mode): projects mapping to the same
+    `CCP4I2_PROJECTS_DIR/<name>` or an existing dest.
+  - Shared/canonicalised-duplicate dirs, non-project-root dirs, i1 overlaps —
+    as warnings.
+  - When `summary.ok` is false on a blocking issue, disable **Next → Dry run**
+    until acknowledged (mirrors the run-dialog SEVERITY_ERROR blocking pattern).
+- Reuse the status-table pattern from
+  [import-project-content.tsx:119](../client/renderer/components/import-project-content.tsx#L119).
+
+**Step 3 — Dry run** → POST `admin/import-sqlite/` with `dry_run=true` (+
+`copy_files`, remap). Show per-model `stats` (rolled back) and any `errors`. In
+copy mode, show intended destination root and projects-to-copy count.
+
+**Step 4 — Import** → same endpoint, `dry_run=false`.
+- On success, GET `admin/import-status/` and show resulting DB counts as
+  confirmation; `usePopcorn().setMessage("Migration complete","success")`.
+- On `errors` (HTTP 400), `usePopcorn().setError(...)` and keep the wizard on this
+  step so the user can retry.
+
+### API calls
+`useApi().post("/admin/import-sqlite/", formData)` etc.
+([api.ts](../client/renderer/api.ts); multipart via `FormData`, same as
+`import-project-content.tsx`). Form fields:
+`db_path`/`sqlite_db`, `remap_from`, `remap_to`, `dry_run`, `copy_files`,
+`dest_root` (optional override), and `allow_structural_issues` (only sent after
+the user ticks the Step-2 acknowledgement).
+
+### Nav & gating
+- Add an entry button to
+  [projects-toolbar.tsx](../client/renderer/components/projects-toolbar.tsx)
+  (`router.push("/ccp4i2/admin/migrate-legacy")`), styled like New/Import.
+- Wrap the button and gate the page on `useAuth().canAdminister`
+  ([auth-context.tsx](../client/renderer/lib/compounds/auth-context.tsx)). Note
+  the renderer stub returns mock-admin, so this is a no-op on desktop and only
+  bites in Docker — acceptable for the desktop-first target; verify gating in the
+  Docker build before relying on it.
+
+---
+
+## 5. Tests
+
+- **Backend (fast, no CCP4):** unit-test `SQLiteImporter(copy_files=True)` against
+  a synthesised legacy sqlite + a temp legacy project tree; assert files land in
+  `dest_root/<name>`, `Project.directory` is repointed, `stats` reports copies,
+  and dry-run copies nothing. Test the missing-source-dir warning path. Extend
+  `server/ccp4i2/tests/db/` (this is DB-layer, not CCP4-binary).
+- **Structural checks (§2.5), fast, no CCP4** — synthesise a legacy sqlite whose
+  Projects table exercises each case: (a) B nested under A's `CCP4_JOBS`; (b) same
+  basename → dest collision; (c) symlink/`..` resolving to another project's dir;
+  (d) dir with no `CCP4_JOBS`; (e) case-only difference `Foo`/`foo`; (f) NFC/NFD
+  name pair; (g) two projects whose `CCP4_IMPORTED_FILES` symlink to a shared real
+  dir; (h) an unreadable source dir. Assert `_validate_structure` flags each with
+  the right `type`/`severity`, `summary.ok` reflects blocking vs warning, and the
+  returned `plan` has the expected `mode`/`dest`/`reason` per project.
+- **Plan/mixed-mode behaviour** — assert nesting produces a `copy` plan entry even
+  when `copy_files=false` (only the entangled project moves; siblings stay
+  `in_place`); assert copy-with-nesting excludes the inner subtree (no duplicated
+  files, both dests self-contained); assert `allow_structural_issues=false` makes
+  `import-sqlite/` refuse on a *blocking* issue but proceed on nesting alone;
+  assert dest-name de-dup is case/NFC-safe on a case-insensitive tmpdir.
+- **Backend regression:** the `import_i2xml` arg-name fix — smoke test the command
+  parses.
+- **API:** `admin/import-sqlite/` with `copy_files` + `db_path` (unit, Django test
+  client, admin user) → asserts response `stats`/`summary` shape the UI relies on.
+- **Frontend:** component test of `migrate-legacy-content` stepping through
+  validate → dry-run → import with a mocked `useApi` (mirroring existing component
+  tests, if any; otherwise manual `/run` verification of the wizard).
+
+---
+
+## 6. Sequencing
+
+The backend exists to serve the wizard, so build each backend capability with its
+UI consumer defined, and verify through the UI — not the CLI.
+
+1. **Define the wire contract first** — pin the exact JSON the wizard needs from
+   `validate-sqlite/` and `import-sqlite/`: the full report, the per-project
+   `plan`, and per-issue `{type, severity, projects[], detail, resolution}`. This
+   is the UI/backend handshake; everything else follows from it.
+   **→ Drafted in [`LEGACY_MIGRATION_WIRE_CONTRACT.md`](./LEGACY_MIGRATION_WIRE_CONTRACT.md)**
+   (marks every field current vs new; additive-only so the UI can be built first).
+2. Backend to satisfy that contract: `_validate_structure` + per-project plan
+   (§2.5); `SQLiteImporter` plan-consumption + `copy_files`/mixed-mode (§3a); the
+   `import_i2xml` fix (§3b). Land with tests.
+3. Frontend: route + wizard (validate → dry-run → import) rendering the plan and
+   issues, with the acknowledgement gate. This is the deliverable.
+4. Nav button + admin gating (§4).
+5. **Verify through the UI**, not the command line: drive the wizard end-to-end
+   via `/run` against a real `~/.CCP4I2` (or a fixture) — including a nested-project
+   fixture so the mixed-mode plan is exercised in the actual UI.
+
+**Explicitly out of scope this round:** cloud/admin upload flow hardening,
+importer de-dup (3c), zip import/export polling.

--- a/docs/LEGACY_MIGRATION_WIRE_CONTRACT.md
+++ b/docs/LEGACY_MIGRATION_WIRE_CONTRACT.md
@@ -1,0 +1,282 @@
+# Legacy Migration — Wire Contract (UI ↔ REST)
+
+The handshake between the migration wizard
+([migrate-legacy-content.tsx]) and the two Django admin endpoints. Everything
+downstream (§2.5 structural checks, the importer, the wizard steps) is built to
+satisfy *this*. See `docs/LEGACY_MIGRATION_UI_PLAN.md` for rationale.
+
+**Contract stance:** the endpoints already exist and return most of this today.
+Fields are tagged:
+- **(current)** — already returned by
+  `SQLiteValidator.run()` / `SQLiteImporter.summary()` verbatim. Do not change.
+- **(new)** — must be added (the structural checks, the per-project plan, and the
+  richer per-issue shape). Additive only — no current field is renamed or removed,
+  so the UI can be written against the full contract before the backend catches
+  up, and old CLI callers keep working.
+
+All requests are `multipart/form-data` (so a `.sqlite` upload and scalar fields
+share one body), admin-gated (`IsAdminUser`). Base path `/api/proxy/ccp4i2/`.
+
+---
+
+## Shared vocabulary
+
+### `Issue` (new) — one structural/quality problem the UI renders
+
+```jsonc
+{
+  "type": "nested_project",        // enum, see §Issue types
+  "severity": "blocking" | "warning" | "info",
+  "mode_scope": "copy" | "schlurp" | "both",  // when this issue actually bites
+  "projects": ["<legacy_project_id>", ...],   // legacy ProjectIDs involved (32-hex)
+  "detail": "Project 'B' lies under 'A/CCP4_JOBS/job_3'",  // human sentence
+  "resolution": "B will be copied to CCP4X_PROJECTS/B and repointed"
+                                    // null if user action required; else what migration will do
+}
+```
+
+- `severity: "blocking"` + `resolution: null` ⇒ the wizard must not let the user
+  proceed until they tick the acknowledgement (which sets
+  `allow_structural_issues=true`) or fix the DB. `blocking` **with** a non-null
+  `resolution` (e.g. nesting) is auto-handled — surface it, require a confirm, but
+  it does not hard-stop.
+- `mode_scope` lets the UI hide copy-only issues when the user picked schlurp.
+
+#### Issue `type` enum (new)
+| type | §2.5 | severity (default) | mode_scope |
+|------|------|--------------------|------------|
+| `nested_project` | 1 | blocking (auto-resolved) | both |
+| `dest_collision` | 2 | blocking | copy |
+| `shared_directory` | 3 | warning | both |
+| `not_project_root` | 4 | warning | both |
+| `dest_unwritable` | 5 | blocking | copy |
+| `insufficient_space` | 5 | blocking | copy |
+| `i1_dir_overlap` | 6 | warning | both |
+| `case_clash` | 7 | blocking | copy |
+| `unicode_clash` | 8 | blocking | copy |
+| `shared_subtree` | 9 | blocking-if-under-migrating-dest / else warning | copy |
+| `unreadable_source` | 10 | blocking | copy |
+
+### `PlanEntry` (new) — what migration will do to one project
+
+```jsonc
+{
+  "legacy_project_id": "<32-hex>",
+  "name": "beta_lactamase",         // legacy ProjectName
+  "source_dir": "/home/u/.CCP4I2/CCP4X_PROJECTS/beta_lactamase",  // post-remap
+  "mode": "in_place" | "copy",
+  "dest": "/home/u/CCP4X_PROJECTS/beta_lactamase",  // where directory ends up; == source_dir when in_place
+  "reason": "copy_files" | "nested" | "in_place",   // why this mode
+  "source_exists": true,            // legacy dir present on disk?
+  "renamed_to": "beta_lactamase_legacy"  // null unless a name/dir collision forced a rename
+}
+```
+
+The `mode`/`dest` are decided **by the validator** and consumed unchanged by the
+importer, so validate and import never disagree.
+
+---
+
+## 1. `POST admin/validate-sqlite/` — read-only pre-flight
+
+Runs `SQLiteValidator`. Never writes to Django, the sqlite, or disk.
+
+### Request (multipart)
+| field | req? | notes |
+|-------|------|-------|
+| `sqlite_db` | one-of | uploaded `.sqlite` file **OR**… |
+| `db_path` | one-of | server-side path, e.g. `~/.CCP4I2/db/database.sqlite` (desktop default) |
+| `copy_files` | no | `"true"`/`"false"` — validator needs it to compute the plan + which issues are in scope. Default `"false"`. |
+| `dest_root` | no | override for copy destination; default `CCP4I2_PROJECTS_DIR`. |
+| `remap_from`, `remap_to` | no | prefix remap applied before every disk check. |
+
+### Response `200` — the full report
+
+```jsonc
+{
+  "source": "/home/u/.CCP4I2/db/database.sqlite",   // (current)
+
+  "counts": {                                        // (current) raw table row counts
+    "Projects": 12, "Jobs": 340, "Files": 1201, "FileUses": 1800,
+    "ImportFiles": 44, "ExportFiles": 3, "XData": 12, "JobKeyValues": 5000,
+    "JobKeyCharValues": 800, "Tags": 6, "ProjectTags": 9, "Comments": 0,
+    "ProjectComments": 2, "ServerJobs": 0, "FileTypes": 60, "KeyTypes": 40,
+    "FileRoles": 2, "ProjectExports": 3, "ProjectImports": 1
+    // a table absent in the legacy DB is null
+  },
+
+  "projects": {                                      // (current)
+    "total": 12, "dir_exists": 11,
+    "dir_missing": [ { "project": "old1", "directory": "/gone/old1" } ],
+    "dir_empty":   [ "unnamed_proj" ]                // projects with blank directory
+  },
+  "jobs": {                                          // (current)
+    "total": 340, "dir_exists": 338,
+    "dir_missing_count": 2,
+    "dir_missing": [ { "job_number": "3.1", "task_name": "refmac",
+                       "expected_dir": "/.../CCP4_JOBS/job_3/job_1" } ]  // capped at 50 unless verbose
+  },
+  "files": {                                         // (current)
+    "total": 1201, "exists": 1198,
+    "missing_count": 3, "orphan_job": 0,
+    "missing": [ { "filename": "XYZOUT.pdb",
+                   "expected_path": "/.../job_3/XYZOUT.pdb" } ] // capped at 50
+  },
+  "imported_files": {                                // (current)
+    "total": 44, "source_exists": 40,
+    "source_missing_count": 4,
+    "source_missing": [ "/vanished/data.mtz" ]       // capped at 50
+  },
+  "integrity": {                                     // (current)
+    "ok": true,
+    "issues": [ "2 jobs reference non-existent parent jobs" ]  // free-text strings
+  },
+  "data_quality": {                                  // (current)
+    "ok": true,
+    "issues": [ "1 projects have NULL creation time" ]         // free-text strings
+  },
+
+  "structure": {                                     // (new) §2.5
+    "ok": false,                                     // false if any blocking issue not auto-resolved
+    "issues": [ /* Issue[] */ ]
+  },
+  "plan": [ /* PlanEntry[] — one per legacy project */ ],   // (new)
+
+  "summary": {                                       // (current) + (new) fields
+    "ok": false,                                     // (current) — now ALSO false on blocking structural issues
+    "projects_on_disk": "11/12",                     // (current) "n/total" strings
+    "jobs_on_disk": "338/340",                        // (current)
+    "files_on_disk": "1198/1201",                     // (current)
+    "import_sources_on_disk": "40/44",                // (current)
+    "integrity_issues": 1,                            // (current) counts
+    "data_quality_issues": 1,                         // (current)
+    "structure_issues": 3,                            // (new)
+    "blocking_issues": 1,                             // (new) count of severity=blocking && resolution==null
+    "plan_summary": { "in_place": 10, "copy": 2, "copied_due_to_nesting": 1 }  // (new)
+  }
+}
+```
+
+### Errors (standardised on `{error: <machine_string>, reason: <sentence>}`)
+- `400` `{ "error": "bad_input", "reason": "Must provide sqlite_db file upload or db_path" }`
+- `404` `{ "error": "db_not_found", "reason": "Database not found: <path>" }` (from `FileNotFoundError`)
+- `500` `{ "error": "internal_error", "reason": "…" }`
+
+(Today these are bare `error` sentence strings — see the tightening note under
+§2 Errors; same change applies here.)
+
+**UI contract:** Step 2 renders `summary` chips + the four `*_on_disk` ratios, the
+`integrity`/`data_quality` strings, then the `structure.issues` grouped by `type`,
+then the `plan` table. **Next→Dry-run is disabled while `summary.blocking_issues >
+0` and the acknowledgement box is unticked.**
+
+---
+
+## 2. `POST admin/import-sqlite/` — dry-run and real import
+
+Runs `SQLiteImporter`. Same endpoint for dry-run and commit; `dry_run` decides.
+
+### Request (multipart)
+| field | req? | notes |
+|-------|------|-------|
+| `sqlite_db` / `db_path` | one-of | as above |
+| `dry_run` | no | `"true"` runs inside a rolled-back transaction, copies nothing (default `"false"`). |
+| `copy_files` | no | default `"false"`. |
+| `dest_root` | no | default `CCP4I2_PROJECTS_DIR`. |
+| `remap_from`, `remap_to` | no | as above |
+| `allow_structural_issues` | no | **(new)** `"true"` only after the user acknowledged blocking issues in Step 2. If false/absent and the run has blocking-unresolved issues ⇒ `400` with `error: "structural_issues_unacknowledged"` (below). |
+
+### Response `200` — import summary
+
+```jsonc
+{
+  "dry_run": true,                                   // (current)
+  "source": "/home/u/.CCP4I2/db/database.sqlite",    // (current)
+  "stats": {                                         // (current keys) + (new keys)
+    "projects": 10, "projects_skipped": 2, "projects_renamed": 1,   // (current)
+    "jobs": 340, "jobs_skipped": 0,
+    "files": 1198, "files_skipped": 3,
+    "filetypes": 60, "keytypes": 40, "tags": 6,
+    "groups": 1, "memberships": 3, "projecttags": 9,
+    "fileuses": 1800, "fileimports": 44, "fileexports": 3,
+    "jobfloatvalues": 5000, "jobcharvalues": 800, "xdata": 12,
+    "projectexports": 3, "projectimports": 1,
+
+    "projects_copied": 2,               // (new) copy-mode / nested
+    "projects_in_place": 10,            // (new)
+    "projects_nested": 1,              // (new) copied out because nested
+    "copy_excluded_subtrees": 1,       // (new) inner dirs skipped during outer copytree
+    "projects_copy_skipped": 0,        // (new) dest already existed
+    "copy_errors": 0                   // (new)
+  },
+  "errors": [                                        // (current) — list of strings
+    "File 0a1b… : <exception text>"
+  ],
+  "plan": [ /* PlanEntry[] — what was (or would be) done */ ],  // (new) echoes validate's plan, with post-run renamed_to filled in
+  "structure": { "ok": true, "issues": [] }          // (new) recomputed; empty on a clean run
+}
+```
+
+- HTTP status: `200` when `errors` is empty, else `400` (current behaviour —
+  `resp_status = 400 if result['errors'] else 200`).
+
+### Errors
+All errors use `400` with a **machine-readable string in `error`** plus context —
+the house convention across the suite (e.g. JobViewSet's
+`{"error": "local_execution_unavailable", "reason": …}`). The status code stays
+conventional; the *discriminator lives in the body*. The wizard branches on
+`error`, not on the status code.
+- `400` `{ "error": "bad_input", "reason": "Must provide sqlite_db file upload or db_path" }`
+- `400` `{ "error": "structural_issues_unacknowledged", "reason": "…",`
+  `"structure": {…}, "plan": [...] }` **(new)** — blocking-unresolved issues exist
+  and `allow_structural_issues` is not `"true"`. The wizard branches on this
+  `error` value and returns to Step 2 with the issues shown. (No structural gate
+  exists today, so this body is new; the `400` status is not.)
+- `400` `{ "error": "import_failed", "stats": {…}, "errors": [...] }` — the run
+  completed but `errors` is non-empty (current behaviour: 400 when `errors`).
+- `404`, `500` as validate.
+
+**UI contract:** Step 3 (dry-run) and Step 4 (commit) both read `stats` + `plan` +
+`errors`. On a `400` whose `error == "structural_issues_unacknowledged"`, the
+wizard returns to Step 2 with the issues shown. On Step-4 success it then
+`GET admin/import-status/` for confirmation counts.
+
+> **Note — a small tightening of the current envelope.** Today the admin views
+> return bare-sentence `error` strings (`{"error": "Must provide …"}`) and, on a
+> run with `errors`, the raw importer summary at status 400 (no `error` key). This
+> contract standardises *all* migration errors on `{error: <machine_string>,
+> reason: <sentence>, …context}` to match JobViewSet. That's a **behaviour change
+> to the two existing bodies** (`bad_input`, `import_failed`) — minor, but call it
+> out in the PR since a CLI/script author could be parsing the old strings.
+
+---
+
+## 3. `GET admin/import-status/` — post-import confirmation (current, unchanged)
+
+```jsonc
+{
+  "projects": { "total": 10, "groups": 1, "memberships": 3, "tags": 6 },
+  "jobs":     { "total": 340, "value_keys": 40, "float_values": 5000, "char_values": 800, "xdata": 12 },
+  "files":    { "total": 1198, "types": 60, "uses": 1800, "imports": 44, "exports": 3 }
+}
+```
+
+Wizard shows these as a "migration landed" panel after Step 4.
+
+---
+
+## Delta summary — what the backend must add
+
+1. `SQLiteValidator`: new `_validate_structure(cur)` producing `structure` +
+   the per-project `plan`; extend `summary` with `structure_issues`,
+   `blocking_issues`, `plan_summary`; make `summary.ok` false on blocking issues.
+2. `SQLiteImporter`: consume `plan`; `copy_files`/`dest_root`; new `stats` keys;
+   echo `plan` + recomputed `structure`; honour `allow_structural_issues` → `400`
+   with `error: "structural_issues_unacknowledged"`.
+3. `admin_views`: pass `copy_files`, `dest_root`, `allow_structural_issues`
+   through; add the structural-gate branch; standardise error bodies on
+   `{error: <machine_string>, reason: …}`. Success envelopes unchanged.
+
+No existing field is renamed or removed, so the frontend can be built against this
+contract in full before the backend delta lands (it just sees `structure`/`plan`
+absent until then — treat missing as "no structural data yet").

--- a/server/ccp4i2/api/admin_views.py
+++ b/server/ccp4i2/api/admin_views.py
@@ -21,6 +21,32 @@ from rest_framework.response import Response
 logger = logging.getLogger(__name__)
 
 
+def _remap_dirs(request):
+    """Extract (from, to) remap tuple from the request, or None."""
+    remap_from = request.data.get('remap_from', '').strip()
+    remap_to = request.data.get('remap_to', '').strip()
+    return (remap_from, remap_to) if remap_from and remap_to else None
+
+
+def _resolve_sqlite_source(request):
+    """Resolve the legacy sqlite source from an upload or a server-side path.
+
+    Returns ``(path, temp_path)`` where ``temp_path`` is the caller-owned temp
+    file to unlink afterwards (None for a server-side path), or ``None`` if
+    neither a file nor a path was supplied.
+    """
+    db_file = request.FILES.get('sqlite_db')
+    db_path = request.data.get('db_path', '').strip()
+    if not db_file and not db_path:
+        return None
+    if db_file:
+        with tempfile.NamedTemporaryFile(suffix='.sqlite', delete=False) as tmp:
+            for chunk in db_file.chunks():
+                tmp.write(chunk)
+            return tmp.name, tmp.name
+    return Path(db_path).expanduser(), None
+
+
 @api_view(['POST'])
 @permission_classes([IsAdminUser])
 def import_legacy_ccp4i2(request):
@@ -139,38 +165,33 @@ def import_sqlite(request):
     - db_path: Server-side path to SQLite database (e.g. ~/.CCP4I2/db/database.sqlite)
     - dry_run, remap_from, remap_to as above
     """
-    from ccp4i2.db.import_sqlite import SQLiteImporter
+    from ccp4i2.db.import_sqlite import SQLiteImporter, StructuralIssuesError
 
-    db_file = request.FILES.get('sqlite_db')
-    db_path = request.data.get('db_path', '').strip()
-    dry_run = str(request.data.get('dry_run', 'false')).lower() == 'true'
-    remap_from = request.data.get('remap_from', '').strip()
-    remap_to = request.data.get('remap_to', '').strip()
-
-    if not db_file and not db_path:
+    src = _resolve_sqlite_source(request)
+    if src is None:
         return Response(
-            {'error': 'Must provide sqlite_db file upload or db_path'},
+            {'error': 'bad_input',
+             'reason': 'Must provide sqlite_db file upload or db_path'},
             status=status.HTTP_400_BAD_REQUEST,
         )
+    actual_path, temp_path = src
 
-    remap_dirs = (remap_from, remap_to) if remap_from and remap_to else None
-    temp_path = None
+    dry_run = str(request.data.get('dry_run', 'false')).lower() == 'true'
+    copy_files = str(request.data.get('copy_files', 'false')).lower() == 'true'
+    allow_structural = str(
+        request.data.get('allow_structural_issues', 'false')
+    ).lower() == 'true'
+    dest_root = request.data.get('dest_root', '').strip() or None
 
     try:
-        if db_file:
-            with tempfile.NamedTemporaryFile(suffix='.sqlite', delete=False) as tmp:
-                for chunk in db_file.chunks():
-                    tmp.write(chunk)
-                temp_path = tmp.name
-            actual_path = temp_path
-        else:
-            actual_path = Path(db_path).expanduser()
-
         importer = SQLiteImporter(
             db_path=actual_path,
-            remap_dirs=remap_dirs,
+            remap_dirs=_remap_dirs(request),
             dry_run=dry_run,
             continue_on_error=True,
+            copy_files=copy_files,
+            dest_root=Path(dest_root).expanduser() if dest_root else None,
+            allow_structural_issues=allow_structural,
         )
         result = importer.run()
 
@@ -180,15 +201,30 @@ def import_sqlite(request):
                 f"{result['stats']}"
             )
 
-        resp_status = status.HTTP_400_BAD_REQUEST if result['errors'] else status.HTTP_200_OK
-        return Response(result, status=resp_status)
+        if result['errors']:
+            return Response(
+                {'error': 'import_failed', 'reason': 'Import completed with errors',
+                 **result},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(result, status=status.HTTP_200_OK)
 
+    except StructuralIssuesError as e:
+        # Blocking structural issues not acknowledged — the UI maps this back to
+        # the validation step. 400 + machine-readable discriminator (house style).
+        return Response(
+            {'error': 'structural_issues_unacknowledged',
+             'reason': 'Blocking structural issues must be acknowledged before import',
+             'structure': e.structure, 'plan': e.plan},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     except FileNotFoundError as e:
-        return Response({'error': str(e)}, status=status.HTTP_404_NOT_FOUND)
+        return Response({'error': 'db_not_found', 'reason': str(e)},
+                        status=status.HTTP_404_NOT_FOUND)
     except Exception as e:
         logger.exception("Error in import_sqlite")
         return Response(
-            {'error': f'Unexpected error: {e}'},
+            {'error': 'internal_error', 'reason': str(e)},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     finally:
@@ -214,46 +250,41 @@ def validate_sqlite(request):
 
     Optional:
     - remap_from / remap_to: Remap directory prefixes before checking
+    - copy_files: intended migration mode — needed to compute the per-project
+      plan and decide which structural issues are in scope (default false)
+    - dest_root: override for the copy destination root
     """
     from ccp4i2.db.import_sqlite import SQLiteValidator
 
-    db_file = request.FILES.get('sqlite_db')
-    db_path = request.data.get('db_path', '').strip()
-    remap_from = request.data.get('remap_from', '').strip()
-    remap_to = request.data.get('remap_to', '').strip()
-
-    if not db_file and not db_path:
+    src = _resolve_sqlite_source(request)
+    if src is None:
         return Response(
-            {'error': 'Must provide sqlite_db file upload or db_path'},
+            {'error': 'bad_input',
+             'reason': 'Must provide sqlite_db file upload or db_path'},
             status=status.HTTP_400_BAD_REQUEST,
         )
+    actual_path, temp_path = src
 
-    remap_dirs = (remap_from, remap_to) if remap_from and remap_to else None
-    temp_path = None
+    copy_files = str(request.data.get('copy_files', 'false')).lower() == 'true'
+    dest_root = request.data.get('dest_root', '').strip() or None
 
     try:
-        if db_file:
-            with tempfile.NamedTemporaryFile(suffix='.sqlite', delete=False) as tmp:
-                for chunk in db_file.chunks():
-                    tmp.write(chunk)
-                temp_path = tmp.name
-            actual_path = temp_path
-        else:
-            actual_path = Path(db_path).expanduser()
-
         validator = SQLiteValidator(
             db_path=actual_path,
-            remap_dirs=remap_dirs,
+            remap_dirs=_remap_dirs(request),
+            copy_files=copy_files,
+            dest_root=Path(dest_root).expanduser() if dest_root else None,
         )
         report = validator.run()
         return Response(report)
 
     except FileNotFoundError as e:
-        return Response({'error': str(e)}, status=status.HTTP_404_NOT_FOUND)
+        return Response({'error': 'db_not_found', 'reason': str(e)},
+                        status=status.HTTP_404_NOT_FOUND)
     except Exception as e:
         logger.exception("Error in validate_sqlite")
         return Response(
-            {'error': f'Unexpected error: {e}'},
+            {'error': 'internal_error', 'reason': str(e)},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     finally:

--- a/server/ccp4i2/api/urls.py
+++ b/server/ccp4i2/api/urls.py
@@ -47,18 +47,21 @@ _api_patterns = [
     path("monomer-info/<str:code>/", views.monomer_info, name="monomer_info"),
 ]
 
-# Admin endpoints require users app (cloud deployment only)
-if "users" in settings.INSTALLED_APPS:
-    try:
-        from .admin_views import import_legacy_ccp4i2, import_sqlite, validate_sqlite, ccp4i2_import_status
-        _api_patterns += [
-            path("admin/import-legacy/", import_legacy_ccp4i2, name="import-legacy-ccp4i2"),
-            path("admin/import-sqlite/", import_sqlite, name="import-sqlite"),
-            path("admin/validate-sqlite/", validate_sqlite, name="validate-sqlite"),
-            path("admin/import-status/", ccp4i2_import_status, name="ccp4i2-import-status"),
-        ]
-    except ImportError as e:
-        print(f"Warning: admin_views import failed: {e}")
+# Legacy-migration admin endpoints. These are core desktop functionality (a
+# user migrating their own ~/.CCP4I2), so they are registered unconditionally
+# and self-protect via IsAdminUser (which the local user satisfies in desktop
+# mode). Previously these were gated on the cloud-only "users" app, which made
+# the migration wizard 404 on the desktop app it was built for.
+try:
+    from .admin_views import import_legacy_ccp4i2, import_sqlite, validate_sqlite, ccp4i2_import_status
+    _api_patterns += [
+        path("admin/import-legacy/", import_legacy_ccp4i2, name="import-legacy-ccp4i2"),
+        path("admin/import-sqlite/", import_sqlite, name="import-sqlite"),
+        path("admin/validate-sqlite/", validate_sqlite, name="validate-sqlite"),
+        path("admin/import-status/", ccp4i2_import_status, name="ccp4i2-import-status"),
+    ]
+except ImportError as e:
+    print(f"Warning: admin_views import failed: {e}")
 
 # Wrap all patterns under /api/ccp4i2/ for multi-app integration
 # Frontend routes are under /ccp4i2/, API routes under /api/ccp4i2/

--- a/server/ccp4i2/db/import_sqlite.py
+++ b/server/ccp4i2/db/import_sqlite.py
@@ -77,6 +77,8 @@ def dict_factory(cursor, row):
     return {col[0].lower(): row[i] for i, col in enumerate(cursor.description)}
 
 
+
+
 def default_dest_root():
     """Default destination root for copied projects (CCP4I2_PROJECTS_DIR)."""
     try:
@@ -284,9 +286,16 @@ class SQLiteValidator:
         cur.execute(
             "SELECT FileID, Filename, JobID, PathFlag FROM Files"
         )
+        # Missing files are partitioned by the preservation contract: files of
+        # TOP-LEVEL jobs (job number with no '.') are guaranteed to be preserved,
+        # so a missing one is a genuine violation. SUB-job files (nested pipeline
+        # steps, job number like '3.2') are NOT covered by the guarantee, so a
+        # missing one is out of contract, not a fault.
         results = {
             "total": 0, "exists": 0,
-            "missing": [], "missing_count": 0,
+            "missing": [], "missing_count": 0,           # kept: all misses
+            "top_missing": [], "top_missing_count": 0,   # in-contract violations
+            "sub_missing_count": 0,                      # out-of-contract
             "orphan_job": 0,
         }
         for row in cur.fetchall():
@@ -315,15 +324,32 @@ class SQLiteValidator:
                 results["exists"] += 1
             else:
                 results["missing_count"] += 1
+                is_top_level = "." not in ji["number"]
                 if self.verbose or len(results["missing"]) < 50:
                     results["missing"].append({
                         "filename": filename,
                         "expected_path": str(file_path),
+                        "job_number": ji["number"],
+                        "top_level": is_top_level,
                     })
+                if is_top_level:
+                    results["top_missing_count"] += 1
+                    if self.verbose or len(results["top_missing"]) < 50:
+                        results["top_missing"].append({
+                            "filename": filename,
+                            "expected_path": str(file_path),
+                            "job_number": ji["number"],
+                        })
+                else:
+                    results["sub_missing_count"] += 1
 
         self._log_section("Files", results["total"],
                           results["exists"], results["missing"],
                           missing_count=results["missing_count"])
+        self.log_fn(
+            f"    of which top-level (in-contract): {results['top_missing_count']}, "
+            f"sub-job (out-of-contract): {results['sub_missing_count']}"
+        )
         return results
 
     # ------------------------------------------------------------------
@@ -331,29 +357,44 @@ class SQLiteValidator:
     # ------------------------------------------------------------------
 
     def _validate_imported_files(self, cur):
-        cur.execute(
-            "SELECT ImportId, FileID, SourceFilename FROM ImportFiles"
-        )
+        """Report import provenance — informational only.
+
+        Two things to be clear about, both learned the hard way:
+
+        * The imported files that live on disk under ``CCP4_IMPORTED_FILES`` are
+          the ``Files`` rows with ``PathFlag == 2``. Those are already checked by
+          :meth:`_validate_files` (which builds the same path the new-model
+          ``File.path`` does — ``project/CCP4_IMPORTED_FILES/<name>``). We do NOT
+          re-check them here; the ``ImportFiles`` table is a separate provenance
+          record, and joining it to ``Files`` lands on the job's *logical* output
+          row (a different, PathFlag==1 name), producing bogus "missing" hits.
+        * ``ImportFiles.SourceFilename`` is the *original external path* the user
+          imported from — usually long gone (a download, another machine) and
+          irrelevant to migration.
+
+        So this method only reports how many import *sources* still resolve, as
+        context. It never contributes to the health summary.
+        """
+        cur.execute("SELECT ImportId, SourceFilename FROM ImportFiles")
         results = {
-            "total": 0, "source_exists": 0,
-            "source_missing": [], "source_missing_count": 0,
+            "total": 0,
+            "source_exists": 0,
+            "source_missing_count": 0,
         }
         for row in cur.fetchall():
             results["total"] += 1
-            src = row["sourcefilename"] or ""
+            src = self.remap_directory(row["sourcefilename"] or "")
             if not src:
                 continue
-            src = self.remap_directory(src)
             if Path(src).is_file():
                 results["source_exists"] += 1
             else:
                 results["source_missing_count"] += 1
-                if self.verbose or len(results["source_missing"]) < 50:
-                    results["source_missing"].append(src)
 
-        self._log_section("ImportFiles (source)", results["total"],
-                          results["source_exists"], results["source_missing"],
-                          missing_count=results["source_missing_count"])
+        self.log_fn(
+            f"  ImportFiles (source provenance, informational): "
+            f"{results['source_exists']}/{results['total']} sources still present"
+        )
         return results
 
     # ------------------------------------------------------------------
@@ -586,11 +627,17 @@ class SQLiteValidator:
         plan = report.get("plan", [])
 
         blocking = blocking_unresolved(structure["issues"])
+        # summary.ok reflects whether migration can proceed cleanly.
+        # - Project/job DIRECTORIES gate ok (they hold the data migration carries).
+        # - TOP-LEVEL job files are covered by the preservation contract, so a
+        #   missing one is a genuine violation and gates ok.
+        # - SUB-job files are NOT covered by the contract, so their absence does
+        #   NOT gate ok (reported informationally, never dressed up as "normal").
         all_ok = (
             not projects["dir_missing"]
             and not projects["dir_empty"]
             and jobs["dir_missing_count"] == 0
-            and files["missing_count"] == 0
+            and files["top_missing_count"] == 0
             and integrity["ok"]
             and quality["ok"]
             and blocking == 0
@@ -604,8 +651,14 @@ class SQLiteValidator:
             "ok": all_ok,
             "projects_on_disk": f"{projects['dir_exists']}/{projects['total']}",
             "jobs_on_disk": f"{jobs['dir_exists']}/{jobs['total']}",
+            # files_on_disk already covers imported files (the PathFlag==2 rows
+            # under CCP4_IMPORTED_FILES). Import *source* provenance is reported
+            # separately as an informational count only.
             "files_on_disk": f"{files['exists']}/{files['total']}",
-            "import_sources_on_disk": f"{imports['source_exists']}/{imports['total']}",
+            # Missing files split by the preservation contract.
+            "top_level_files_missing": files["top_missing_count"],
+            "sub_job_files_missing": files["sub_missing_count"],
+            "import_sources_present": f"{imports['source_exists']}/{imports['total']}",
             "integrity_issues": len(integrity["issues"]),
             "data_quality_issues": len(quality["issues"]),
             "structure_issues": len(structure["issues"]),

--- a/server/ccp4i2/db/import_sqlite.py
+++ b/server/ccp4i2/db/import_sqlite.py
@@ -12,6 +12,7 @@ Both are usable from management commands and API endpoints.
 """
 
 import logging
+import shutil
 import sqlite3
 from collections import defaultdict
 from datetime import datetime
@@ -21,6 +22,12 @@ from uuid import UUID
 from django.db import transaction
 from django.utils import timezone
 
+from .legacy_structure import (
+    analyse_structure,
+    blocking_unresolved,
+    nested_excludes_for,
+)
+from .legacy_structure import _resolve as _ls_resolve
 from .models import (
     File,
     FileExport,
@@ -70,6 +77,32 @@ def dict_factory(cursor, row):
     return {col[0].lower(): row[i] for i, col in enumerate(cursor.description)}
 
 
+def default_dest_root():
+    """Default destination root for copied projects (CCP4I2_PROJECTS_DIR)."""
+    try:
+        from django.conf import settings
+        return Path(settings.CCP4I2_PROJECTS_DIR)
+    except Exception:
+        return None
+
+
+class StructuralIssuesError(Exception):
+    """Raised when import is blocked by unacknowledged structural issues.
+
+    Carries the ``structure`` report and ``plan`` so the API layer can return
+    them to the UI (which maps this to Step 2 of the wizard).
+    """
+
+    def __init__(self, structure, plan):
+        self.structure = structure
+        self.plan = plan
+        super().__init__("structural_issues_unacknowledged")
+
+
+class _DryRunRollback(Exception):
+    """Internal sentinel used to unwind a dry-run's atomic block."""
+
+
 class SQLiteValidator:
     """Validate a legacy CCP4i2 SQLite database against the filesystem.
 
@@ -81,11 +114,16 @@ class SQLiteValidator:
     This is a read-only operation — it never writes to Django or the SQLite.
     """
 
-    def __init__(self, db_path, remap_dirs=None, verbose=False, log_fn=None):
+    def __init__(self, db_path, remap_dirs=None, verbose=False, log_fn=None,
+                 copy_files=False, dest_root=None):
         self.db_path = Path(db_path)
         self.remap_dirs = remap_dirs
         self.verbose = verbose
         self.log_fn = log_fn or (lambda msg: logger.info(msg))
+        # Structural analysis needs to know the intended migration mode so it can
+        # compute the per-project plan (see legacy_structure.analyse_structure).
+        self.copy_files = copy_files
+        self.dest_root = dest_root or default_dest_root()
 
     def remap_directory(self, directory):
         if not directory or not self.remap_dirs:
@@ -114,6 +152,10 @@ class SQLiteValidator:
             "integrity": self._validate_integrity(cur),
             "data_quality": self._validate_data_quality(cur),
         }
+
+        structure, plan = self._validate_structure(cur)
+        report["structure"] = structure
+        report["plan"] = plan
 
         conn.close()
 
@@ -474,6 +516,47 @@ class SQLiteValidator:
         return {"ok": len(issues) == 0, "issues": issues}
 
     # ------------------------------------------------------------------
+    # Structural analysis + per-project plan
+    # ------------------------------------------------------------------
+
+    def _validate_structure(self, cur):
+        """Analyse project directory structure and build the migration plan.
+
+        Returns ``(structure, plan)`` matching the wire contract:
+        ``structure = {"ok": bool, "issues": [...]}`` and ``plan = [PlanEntry]``.
+        """
+        cur.execute(
+            "SELECT ProjectID, ProjectName, ProjectDirectory, I1ProjectDirectory "
+            "FROM Projects"
+        )
+        projects = []
+        for row in cur.fetchall():
+            projects.append({
+                "id": row["projectid"],
+                "name": row["projectname"] or f"project_{row['projectid']}",
+                "directory": self.remap_directory(row["projectdirectory"] or ""),
+                "i1_directory": self.remap_directory(row["i1projectdirectory"] or ""),
+            })
+
+        issues, plan = analyse_structure(
+            projects,
+            copy_files=self.copy_files,
+            dest_root=self.dest_root,
+        )
+        blocking = blocking_unresolved(issues)
+        structure = {"ok": blocking == 0, "issues": issues}
+
+        self.log_fn(
+            f"  Structure: {'OK' if not issues else f'{len(issues)} issues'}"
+            f"{f' ({blocking} blocking)' if blocking else ''}"
+        )
+        if self.verbose:
+            for issue in issues:
+                self.log_fn(f"    - [{issue['severity']}] {issue['detail']}")
+
+        return structure, plan
+
+    # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 
@@ -499,7 +582,10 @@ class SQLiteValidator:
         imports = report["imported_files"]
         integrity = report["integrity"]
         quality = report["data_quality"]
+        structure = report.get("structure", {"ok": True, "issues": []})
+        plan = report.get("plan", [])
 
+        blocking = blocking_unresolved(structure["issues"])
         all_ok = (
             not projects["dir_missing"]
             and not projects["dir_empty"]
@@ -507,7 +593,12 @@ class SQLiteValidator:
             and files["missing_count"] == 0
             and integrity["ok"]
             and quality["ok"]
+            and blocking == 0
         )
+
+        in_place = sum(1 for e in plan if e["mode"] == "in_place")
+        copied = sum(1 for e in plan if e["mode"] == "copy")
+        nested = sum(1 for e in plan if e["reason"] == "nested")
 
         return {
             "ok": all_ok,
@@ -517,6 +608,13 @@ class SQLiteValidator:
             "import_sources_on_disk": f"{imports['source_exists']}/{imports['total']}",
             "integrity_issues": len(integrity["issues"]),
             "data_quality_issues": len(quality["issues"]),
+            "structure_issues": len(structure["issues"]),
+            "blocking_issues": blocking,
+            "plan_summary": {
+                "in_place": in_place,
+                "copy": copied,
+                "copied_due_to_nesting": nested,
+            },
         }
 
 
@@ -524,13 +622,20 @@ class SQLiteImporter:
     """Import legacy CCP4i2 SQLite database into Django models."""
 
     def __init__(self, db_path, remap_dirs=None, dry_run=False,
-                 continue_on_error=False, verbose=False, log_fn=None):
+                 continue_on_error=False, verbose=False, log_fn=None,
+                 copy_files=False, dest_root=None,
+                 allow_structural_issues=False):
         self.db_path = Path(db_path)
         self.remap_dirs = remap_dirs  # (from_path, to_path) or None
         self.dry_run = dry_run
         self.continue_on_error = continue_on_error
         self.verbose = verbose
         self.log_fn = log_fn or (lambda msg: logger.info(msg))
+        # Migration mode: copy legacy project trees into dest_root (default
+        # settings.CCP4I2_PROJECTS_DIR) or adopt them in place.
+        self.copy_files = copy_files
+        self.dest_root = dest_root or default_dest_root()
+        self.allow_structural_issues = allow_structural_issues
 
         # Mapping caches: legacy ID -> Django object
         self.project_map = {}
@@ -543,6 +648,12 @@ class SQLiteImporter:
 
         # Parent relationships deferred for group creation
         self.parent_relationships = []  # [(child_legacy_id, parent_legacy_id)]
+
+        # Structural plan + issues, computed once in run() and consumed by
+        # _import_projects. Keyed by legacy project id for the plan.
+        self.structure = {"ok": True, "issues": []}
+        self.plan = []
+        self.plan_by_id = {}
 
         self.stats = defaultdict(int)
         self.errors = []
@@ -581,7 +692,11 @@ class SQLiteImporter:
             raise
 
     def run(self):
-        """Execute the full import. Returns a summary dict."""
+        """Execute the full import. Returns a summary dict.
+
+        Raises StructuralIssuesError if the structural analysis found blocking,
+        unresolved issues and allow_structural_issues was not set.
+        """
         if not self.db_path.exists():
             raise FileNotFoundError(f"Database not found: {self.db_path}")
 
@@ -589,17 +704,60 @@ class SQLiteImporter:
         conn.row_factory = dict_factory
 
         try:
+            # Structural pre-flight: compute the plan and gate on blocking issues
+            # BEFORE touching Django or the filesystem.
+            self._analyse_structure(conn.cursor())
+            blocking = blocking_unresolved(self.structure["issues"])
+            if blocking and not self.allow_structural_issues:
+                raise StructuralIssuesError(self.structure, self.plan)
+
             if self.dry_run:
                 self.log_fn("[DRY RUN - no changes will be committed]")
-
-            with transaction.atomic():
-                self._import_all(conn)
-                if self.dry_run:
-                    transaction.set_rollback(True)
+                # Run inside a savepoint we always unwind, so nothing persists
+                # and the surrounding transaction (e.g. a test's) stays clean.
+                # Raising through atomic() rolls back only this savepoint.
+                try:
+                    with transaction.atomic():
+                        self._import_all(conn)
+                        raise _DryRunRollback()
+                except _DryRunRollback:
+                    pass
+            else:
+                with transaction.atomic():
+                    self._import_all(conn)
         finally:
             conn.close()
 
         return self.summary()
+
+    def _analyse_structure(self, cur):
+        """Run structural analysis and cache the plan for _import_projects."""
+        cur.execute(
+            "SELECT ProjectID, ProjectName, ProjectDirectory, I1ProjectDirectory "
+            "FROM Projects"
+        )
+        projects = []
+        for row in cur.fetchall():
+            projects.append({
+                "id": row["projectid"],
+                "name": row["projectname"] or f"project_{row['projectid']}",
+                "directory": self.remap_directory(row["projectdirectory"] or ""),
+                "i1_directory": self.remap_directory(row["i1projectdirectory"] or ""),
+            })
+        issues, plan = analyse_structure(
+            projects,
+            copy_files=self.copy_files,
+            dest_root=self.dest_root,
+        )
+        self.structure = {
+            "ok": blocking_unresolved(issues) == 0,
+            "issues": issues,
+        }
+        self.plan = plan
+        self.plan_by_id = {e["legacy_project_id"]: e for e in plan}
+        # Resolved source dirs, needed to exclude nested inner trees when copying.
+        self._resolved_by_id = {p["id"]: _ls_resolve(p["directory"]) for p in projects}
+        self._nested_excludes = nested_excludes_for(plan, self._resolved_by_id)
 
     def _import_all(self, conn):
         """Run all import phases in order."""
@@ -715,9 +873,13 @@ class SQLiteImporter:
         for row in cur.fetchall():
             try:
                 pk = row["projectid"]
-                directory = self.remap_directory(row["projectdirectory"] or "")
+                # The plan (from _analyse_structure) decides the final directory:
+                # source dir for in_place, dest dir for copy.
+                entry = self.plan_by_id.get(pk)
+                legacy_dir = self.remap_directory(row["projectdirectory"] or "")
+                directory = entry["dest"] if entry else legacy_dir
 
-                # Skip if project already exists by directory
+                # Skip if project already exists by (final) directory
                 if directory:
                     existing = Project.objects.filter(directory=directory).first()
                     if existing:
@@ -727,6 +889,12 @@ class SQLiteImporter:
                         if row["parentprojectid"]:
                             self.parent_relationships.append((pk, row["parentprojectid"]))
                         continue
+
+                # Copy the legacy tree into place if the plan calls for it.
+                if entry and entry["mode"] == "copy":
+                    self._copy_project_tree(pk, entry, legacy_dir)
+                else:
+                    self.stats["projects_in_place"] += 1
 
                 name = self.get_unique_project_name(row["projectname"])
                 project = Project.objects.create(
@@ -744,7 +912,7 @@ class SQLiteImporter:
                 )
                 self.project_map[pk] = project
                 self.stats["projects"] += 1
-                self.log(f"  Project: {name}")
+                self.log(f"  Project: {name} -> {directory}")
 
                 if row["parentprojectid"]:
                     self.parent_relationships.append((pk, row["parentprojectid"]))
@@ -760,7 +928,59 @@ class SQLiteImporter:
             parts.append(f"{self.stats['projects_renamed']} renamed")
         if self.stats["projects_skipped"]:
             parts.append(f"{self.stats['projects_skipped']} skipped")
+        if self.stats["projects_copied"]:
+            parts.append(f"{self.stats['projects_copied']} copied")
         self.log_count("Projects", self.stats["projects"], ", ".join(parts))
+
+    def _copy_project_tree(self, pk, entry, legacy_dir):
+        """Copy a legacy project tree to its planned destination.
+
+        Excludes any nested inner project directories (they are copied to their
+        own dests separately) so content is never duplicated. On dry-run, does
+        nothing but still records what would happen. Preserves symlinks.
+        """
+        src = Path(legacy_dir) if legacy_dir else None
+        dest = Path(entry["dest"])
+
+        if not entry["source_exists"] or src is None or not src.is_dir():
+            self.stats["projects_copy_skipped"] += 1
+            self.log(f"  Copy skipped (source missing): {entry['name']}")
+            return
+
+        if entry["reason"] == "nested":
+            self.stats["projects_nested"] += 1
+
+        if self.dry_run:
+            self.stats["projects_copied"] += 1
+            self.log(f"  [dry-run] would copy {src} -> {dest}")
+            return
+
+        if dest.exists():
+            self.stats["projects_copy_skipped"] += 1
+            self.log(f"  Copy skipped (dest exists): {dest}")
+            return
+
+        excludes = self._nested_excludes.get(pk, set())
+
+        def _ignore(dir_path, names):
+            if not excludes:
+                return []
+            here = _ls_resolve(dir_path)
+            ignored = []
+            for n in names:
+                child = _ls_resolve(str(Path(dir_path) / n))
+                if child is not None and child in excludes:
+                    ignored.append(n)
+                    self.stats["copy_excluded_subtrees"] += 1
+            return ignored
+
+        try:
+            shutil.copytree(src, dest, symlinks=True, ignore=_ignore)
+            self.stats["projects_copied"] += 1
+            self.log(f"  Copied {src} -> {dest}")
+        except (OSError, shutil.Error) as e:
+            self.stats["copy_errors"] += 1
+            self._record_error("ProjectCopy", pk, e)
 
     def _import_projecttags(self, cur):
         cur.execute("SELECT TagID, ProjectID FROM ProjectTags")
@@ -1198,4 +1418,8 @@ class SQLiteImporter:
             "stats": dict(self.stats),
             "errors": self.errors,
             "source": str(self.db_path),
+            # Echo the plan the run followed and the (clean) structure so the UI
+            # can confirm what happened. Matches the wire contract.
+            "plan": self.plan,
+            "structure": self.structure,
         }

--- a/server/ccp4i2/db/legacy_structure.py
+++ b/server/ccp4i2/db/legacy_structure.py
@@ -1,0 +1,452 @@
+"""
+Structural pre-flight analysis for legacy CCP4i2 migration.
+
+Given the set of legacy projects (id, name, on-disk directory) plus the migration
+mode (schlurp vs copy) and a destination root, this module works out:
+
+  * a per-project migration ``plan`` — for each project, whether it will be
+    adopted in place or copied out, and to where; and
+  * a list of structural ``issues`` (nested projects, destination collisions,
+    case/unicode name clashes, shared/symlinked trees, unreadable sources, ...)
+    that the UI surfaces and, where blocking, must have acknowledged.
+
+It is deliberately free of Django and sqlite so it can be unit-tested against a
+plain list of project dicts and a temp directory tree. Both ``SQLiteValidator``
+and ``SQLiteImporter`` call :func:`analyse_structure` so validate and import can
+never disagree about what will happen.
+
+See docs/LEGACY_MIGRATION_WIRE_CONTRACT.md for the ``Issue`` / ``PlanEntry`` shapes.
+"""
+
+import os
+import shutil
+import unicodedata
+from pathlib import Path
+
+# Issue type constants (must match the wire contract enum).
+NESTED_PROJECT = "nested_project"
+DEST_COLLISION = "dest_collision"
+SHARED_DIRECTORY = "shared_directory"
+NOT_PROJECT_ROOT = "not_project_root"
+DEST_UNWRITABLE = "dest_unwritable"
+INSUFFICIENT_SPACE = "insufficient_space"
+I1_DIR_OVERLAP = "i1_dir_overlap"
+CASE_CLASH = "case_clash"
+UNICODE_CLASH = "unicode_clash"
+SHARED_SUBTREE = "shared_subtree"
+UNREADABLE_SOURCE = "unreadable_source"
+
+SEVERITY_BLOCKING = "blocking"
+SEVERITY_WARNING = "warning"
+SEVERITY_INFO = "info"
+
+MODE_IN_PLACE = "in_place"
+MODE_COPY = "copy"
+
+
+def _norm_name(name):
+    """Case- and unicode-fold a name for collision detection.
+
+    macOS/Windows filesystems are case-insensitive, and macOS stores names in
+    NFD, so two legacy names that differ only by case or normalisation form
+    collide at the destination. Fold both dimensions for comparison only.
+    """
+    return unicodedata.normalize("NFC", (name or "")).casefold()
+
+
+def _resolve(path):
+    """Canonicalise a path (expanduser + resolve symlinks/.. ) without touching disk hard.
+
+    ``Path.resolve(strict=False)`` collapses ``..`` and follows existing symlinks
+    but tolerates missing tails, which is what we want for pre-flight.
+    """
+    if not path:
+        return None
+    try:
+        return Path(path).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _is_under(inner, outer):
+    """True if ``inner`` is at or below ``outer`` (both already resolved)."""
+    if inner is None or outer is None:
+        return False
+    if inner == outer:
+        return False  # same dir is a duplicate, not a nesting — handled elsewhere
+    try:
+        return inner.is_relative_to(outer)
+    except AttributeError:  # Python < 3.9 safety, though repo targets 3.9+
+        try:
+            inner.relative_to(outer)
+            return True
+        except ValueError:
+            return False
+
+
+def _unique_dest(root, name, taken):
+    """Pick a collision-free destination dir under ``root`` for ``name``.
+
+    Avoids clashes both with names already chosen this run (``taken``, a set of
+    case/NFC-folded names) and with directories already present on disk. Mirrors
+    the ``_legacy`` / ``_N`` suffixing used for project *names* elsewhere.
+    """
+    base = name or "project"
+    candidates = [base, f"{base}_legacy"] + [f"{base}_legacy_{i}" for i in range(2, 1000)]
+    for cand in candidates:
+        folded = _norm_name(cand)
+        if folded in taken:
+            continue
+        dest = root / cand
+        if dest.exists():
+            continue
+        taken.add(folded)
+        return dest, (cand if cand != base else None)
+    # Pathological fallback — should never happen.
+    taken.add(_norm_name(base))
+    return root / base, None
+
+
+def _looks_like_project_root(directory):
+    """Cheap check that a directory is a CCP4i2 project root.
+
+    A real legacy project has a ``CCP4_JOBS`` subdirectory. Missing it (when the
+    directory otherwise exists) usually means a wrong/moved remap target.
+    """
+    if not directory:
+        return True  # empty dir is a separate (dir_empty) concern, not ours
+    p = Path(directory)
+    if not p.is_dir():
+        return True  # existence is checked separately; don't double-report
+    return (p / "CCP4_JOBS").is_dir()
+
+
+def _dir_readable(directory):
+    """True if ``directory`` and a shallow sample of its tree are readable.
+
+    A full walk of a large project is wasteful; sample the root plus the two
+    content subdirs, which is where copytree would fail first.
+    """
+    p = Path(directory)
+    for candidate in (p, p / "CCP4_JOBS", p / "CCP4_IMPORTED_FILES"):
+        if candidate.exists() and not os.access(candidate, os.R_OK):
+            return False
+    return True
+
+
+def _tree_size(directory, exclude=()):
+    """Sum file sizes under ``directory``, skipping any path under ``exclude``."""
+    total = 0
+    exclude = [e for e in exclude if e is not None]
+    root = Path(directory)
+    for dirpath, _dirnames, filenames in os.walk(root, followlinks=False):
+        here = _resolve(dirpath)
+        if here is not None and any(_is_under(here, ex) or here == ex for ex in exclude):
+            continue
+        for fn in filenames:
+            fp = Path(dirpath) / fn
+            try:
+                if fp.is_symlink():
+                    continue
+                total += fp.stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def analyse_structure(projects, *, copy_files, dest_root, check_disk=True):
+    """Analyse legacy projects for structural migration hazards.
+
+    Args:
+        projects: list of dicts, each ``{"id", "name", "directory", "i1_directory"}``
+            where ``directory`` / ``i1_directory`` are already remapped.
+        copy_files: whether the run copies (True) or adopts in place (False).
+        dest_root: ``Path`` (or str) — destination root for copied projects.
+        check_disk: if False, skip filesystem probes (readability, space,
+            project-root, tree walks) and reason purely about paths. Used by the
+            plan-only path and by tests without a real tree.
+
+    Returns:
+        ``(issues, plan)`` where ``issues`` is a list of Issue dicts and ``plan``
+        is a list of PlanEntry dicts (one per input project), both matching the
+        wire contract.
+    """
+    dest_root = Path(dest_root).expanduser() if dest_root else None
+
+    # Resolve directories once.
+    resolved = {}       # project id -> resolved Path (or None)
+    for p in projects:
+        resolved[p["id"]] = _resolve(p.get("directory"))
+
+    issues = []
+
+    # ---- 1. Nesting: ordered pairs, inner under outer ------------------------
+    # A project is "nested" (and must be copied out) if it lies under another.
+    nested_ids = set()
+    for a in projects:
+        ra = resolved[a["id"]]
+        if ra is None:
+            continue
+        for b in projects:
+            if a["id"] == b["id"]:
+                continue
+            rb = resolved[b["id"]]
+            if _is_under(rb, ra):
+                # b is inside a  ->  copy the inner one (b) out
+                nested_ids.add(b["id"])
+                issues.append({
+                    "type": NESTED_PROJECT,
+                    "severity": SEVERITY_BLOCKING,
+                    "mode_scope": "both",
+                    "projects": [a["id"], b["id"]],
+                    "detail": (
+                        f"Project '{b['name']}' lies inside project '{a['name']}' "
+                        f"({rb} under {ra})"
+                    ),
+                    # resolution filled in after the plan is built (needs dest)
+                    "resolution": None,
+                    "_inner": b["id"],
+                })
+
+    # ---- 3. Shared / duplicate resolved directories (past `unique`) ----------
+    by_resolved = {}
+    for pid, rp in resolved.items():
+        if rp is not None:
+            by_resolved.setdefault(rp, []).append(pid)
+    for rp, pids in by_resolved.items():
+        if len(pids) > 1:
+            names = [pp["name"] for pp in projects if pp["id"] in pids]
+            issues.append({
+                "type": SHARED_DIRECTORY,
+                "severity": SEVERITY_WARNING,
+                "mode_scope": "both",
+                "projects": pids,
+                "detail": f"{len(pids)} projects resolve to the same directory {rp}: {', '.join(names)}",
+                "resolution": None,
+            })
+
+    # ---- Build the per-project plan ------------------------------------------
+    # A project is copied if the run is copy mode OR it is nested.
+    plan = []
+    taken_dest_names = set()   # case/NFC-folded dest basenames chosen this run
+    dest_for = {}              # project id -> chosen dest Path (copy only)
+
+    for p in projects:
+        pid = p["id"]
+        rp = resolved[pid]
+        # Keep the ORIGINAL (remapped) directory string for the plan so an
+        # in-place project's Project.directory is unchanged from legacy. The
+        # resolved path (rp) is used only for nesting/collision reasoning.
+        source_dir = p.get("directory") or ""
+        source_exists = bool(rp and rp.is_dir()) if check_disk else bool(source_dir)
+        is_nested = pid in nested_ids
+        will_copy = bool(copy_files or is_nested)
+
+        if will_copy and dest_root is not None:
+            dest_path, renamed = _unique_dest(dest_root, p["name"], taken_dest_names)
+            dest_for[pid] = dest_path
+            reason = "nested" if (is_nested and not copy_files) else "copy_files"
+            plan.append({
+                "legacy_project_id": pid,
+                "name": p["name"],
+                "source_dir": source_dir,
+                "mode": MODE_COPY,
+                "dest": str(dest_path),
+                "reason": reason,
+                "source_exists": source_exists,
+                "renamed_to": renamed,
+            })
+        else:
+            plan.append({
+                "legacy_project_id": pid,
+                "name": p["name"],
+                "source_dir": source_dir,
+                "mode": MODE_IN_PLACE,
+                "dest": source_dir,
+                "reason": MODE_IN_PLACE,
+                "source_exists": source_exists,
+                "renamed_to": None,
+            })
+
+    # Fill nesting resolutions now that dests are known.
+    for issue in issues:
+        if issue["type"] == NESTED_PROJECT:
+            inner = issue.pop("_inner")
+            dest = dest_for.get(inner)
+            if dest is not None:
+                inner_name = next((pp["name"] for pp in projects if pp["id"] == inner), inner)
+                issue["resolution"] = f"'{inner_name}' will be copied to {dest} and repointed"
+
+    # ---- 2 / 7 / 8. Destination collisions (case + unicode aware) ------------
+    # _unique_dest already prevents collisions among THIS run's copies, but a
+    # chosen dest may still clash with a pre-existing directory, and two source
+    # projects may differ only by case/normalisation. Report both.
+    if copy_files or nested_ids:
+        seen_folded = {}   # folded original name -> first project name
+        for p in projects:
+            entry = next(e for e in plan if e["legacy_project_id"] == p["id"])
+            if entry["mode"] != MODE_COPY:
+                continue
+            folded = _norm_name(p["name"])
+            if folded in seen_folded and seen_folded[folded] != p["name"]:
+                clash_type = CASE_CLASH if p["name"].casefold() == seen_folded[folded].casefold() \
+                    and p["name"] != seen_folded[folded] else UNICODE_CLASH
+                issues.append({
+                    "type": clash_type,
+                    "severity": SEVERITY_BLOCKING,
+                    "mode_scope": "copy",
+                    "projects": [p["id"]],
+                    "detail": (
+                        f"Destination name '{p['name']}' clashes with '{seen_folded[folded]}' "
+                        f"on a case/normalisation-insensitive filesystem "
+                        f"(resolved by copying to {entry['dest']})"
+                    ),
+                    "resolution": f"copied to {entry['dest']}",
+                })
+            else:
+                seen_folded.setdefault(folded, p["name"])
+
+    if check_disk:
+        # ---- 4. Not a project root -------------------------------------------
+        for p in projects:
+            d = p.get("directory")
+            if d and Path(d).is_dir() and not _looks_like_project_root(d):
+                issues.append({
+                    "type": NOT_PROJECT_ROOT,
+                    "severity": SEVERITY_WARNING,
+                    "mode_scope": "both",
+                    "projects": [p["id"]],
+                    "detail": f"'{p['name']}' directory {d} has no CCP4_JOBS subdirectory",
+                    "resolution": None,
+                })
+
+        # ---- 10. Unreadable source (copy only) -------------------------------
+        for entry in plan:
+            if entry["mode"] == MODE_COPY and entry["source_exists"]:
+                if not _dir_readable(entry["source_dir"]):
+                    issues.append({
+                        "type": UNREADABLE_SOURCE,
+                        "severity": SEVERITY_BLOCKING,
+                        "mode_scope": "copy",
+                        "projects": [entry["legacy_project_id"]],
+                        "detail": f"'{entry['name']}' source {entry['source_dir']} is not readable",
+                        "resolution": None,
+                    })
+
+        # ---- 9. Shared subtree via symlink (copy only) -----------------------
+        # Two different projects whose CCP4_JOBS/CCP4_IMPORTED_FILES resolve into
+        # a common real directory. Blocking only if the shared target lies under
+        # another migrating project's dest.
+        subtree_targets = {}   # resolved subtree -> [project ids]
+        for entry in plan:
+            if entry["mode"] != MODE_COPY or not entry["source_exists"]:
+                continue
+            for sub in ("CCP4_JOBS", "CCP4_IMPORTED_FILES"):
+                rt = _resolve(Path(entry["source_dir"]) / sub)
+                if rt is not None and rt.is_dir():
+                    subtree_targets.setdefault(rt, []).append(entry["legacy_project_id"])
+        for rt, pids in subtree_targets.items():
+            if len(set(pids)) > 1:
+                issues.append({
+                    "type": SHARED_SUBTREE,
+                    "severity": SEVERITY_WARNING,
+                    "mode_scope": "copy",
+                    "projects": list(set(pids)),
+                    "detail": f"{len(set(pids))} projects share a content directory {rt} (symlinked)",
+                    "resolution": None,
+                })
+
+        # ---- 5. Destination writable + free space (copy only) ----------------
+        if (copy_files or nested_ids) and dest_root is not None:
+            try:
+                dest_root.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                pass
+            if not (dest_root.is_dir() and os.access(dest_root, os.W_OK)):
+                issues.append({
+                    "type": DEST_UNWRITABLE,
+                    "severity": SEVERITY_BLOCKING,
+                    "mode_scope": "copy",
+                    "projects": [],
+                    "detail": f"Destination root {dest_root} is not writable",
+                    "resolution": None,
+                })
+            else:
+                # Estimate total to copy (excluding nested inner trees from outer sums).
+                nested_resolved = [resolved[i] for i in nested_ids if resolved.get(i)]
+                needed = 0
+                for entry in plan:
+                    if entry["mode"] == MODE_COPY and entry["source_exists"]:
+                        needed += _tree_size(entry["source_dir"], exclude=nested_resolved)
+                try:
+                    free = shutil.disk_usage(dest_root).free
+                    if needed > free:
+                        issues.append({
+                            "type": INSUFFICIENT_SPACE,
+                            "severity": SEVERITY_BLOCKING,
+                            "mode_scope": "copy",
+                            "projects": [],
+                            "detail": (
+                                f"Copy needs ~{needed // (1024*1024)} MiB but only "
+                                f"{free // (1024*1024)} MiB free at {dest_root}"
+                            ),
+                            "resolution": None,
+                        })
+                except OSError:
+                    pass
+
+    # ---- 6. i1 directory overlap (warn only) ---------------------------------
+    for p in projects:
+        ri1 = _resolve(p.get("i1_directory"))
+        if ri1 is None:
+            continue
+        for other in projects:
+            if other["id"] == p["id"]:
+                continue
+            ro = resolved[other["id"]]
+            if _is_under(ri1, ro) or ri1 == ro:
+                issues.append({
+                    "type": I1_DIR_OVERLAP,
+                    "severity": SEVERITY_WARNING,
+                    "mode_scope": "both",
+                    "projects": [p["id"], other["id"]],
+                    "detail": (
+                        f"'{p['name']}' i1 directory {ri1} overlaps project "
+                        f"'{other['name']}'"
+                    ),
+                    "resolution": None,
+                })
+
+    return issues, plan
+
+
+def blocking_unresolved(issues):
+    """Count issues that must be acknowledged (blocking, no auto-resolution)."""
+    return sum(
+        1 for i in issues
+        if i["severity"] == SEVERITY_BLOCKING and not i.get("resolution")
+    )
+
+
+def nested_excludes_for(plan, resolved_by_id):
+    """Map each copied project's id -> set of resolved inner dirs to exclude.
+
+    When copying an outer project's tree, any *other* migrating project directory
+    that falls under it must be excluded so its content is not duplicated (the
+    inner project is copied separately to its own dest).
+    """
+    excludes = {}
+    for entry in plan:
+        if entry["mode"] != MODE_COPY:
+            continue
+        outer = _resolve(entry["source_dir"])
+        if outer is None:
+            continue
+        inner_dirs = set()
+        for other_id, other_resolved in resolved_by_id.items():
+            if other_id == entry["legacy_project_id"] or other_resolved is None:
+                continue
+            if _is_under(other_resolved, outer):
+                inner_dirs.add(other_resolved)
+        excludes[entry["legacy_project_id"]] = inner_dirs
+    return excludes

--- a/server/ccp4i2/db/management/commands/import_i2xml.py
+++ b/server/ccp4i2/db/management/commands/import_i2xml.py
@@ -13,4 +13,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write(f"{options}")
-        import_i2xml_from_file(options["program_xml"])
+        import_i2xml_from_file(options["project_xml"])

--- a/server/ccp4i2/db/management/commands/import_sqlite.py
+++ b/server/ccp4i2/db/management/commands/import_sqlite.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
             self.stdout.write(f"\n  Projects on disk:       {summary['projects_on_disk']}")
             self.stdout.write(f"  Jobs on disk:           {summary['jobs_on_disk']}")
             self.stdout.write(f"  Files on disk:          {summary['files_on_disk']}")
-            self.stdout.write(f"  Import sources on disk: {summary['import_sources_on_disk']}")
+            self.stdout.write(f"  Import sources present:  {summary['import_sources_present']} (informational)")
             self.stdout.write(f"  Integrity issues:       {summary['integrity_issues']}")
             self.stdout.write(f"  Data quality issues:    {summary['data_quality_issues']}")
             self.stdout.write(f"  Structure issues:       {summary['structure_issues']} "

--- a/server/ccp4i2/db/management/commands/import_sqlite.py
+++ b/server/ccp4i2/db/management/commands/import_sqlite.py
@@ -9,9 +9,13 @@ Usage:
     ccp4-python manage.py import_sqlite ~/.CCP4I2/db/database.sqlite --remap-dirs /old/path /new/path
 """
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
-from ccp4i2.db.import_sqlite import SQLiteImporter, SQLiteValidator
+from ccp4i2.db.import_sqlite import (
+    SQLiteImporter,
+    SQLiteValidator,
+    StructuralIssuesError,
+)
 
 
 class Command(BaseCommand):
@@ -44,9 +48,29 @@ class Command(BaseCommand):
             action="store_true",
             help="Continue importing remaining records if one fails",
         )
+        parser.add_argument(
+            "--copy-files",
+            action="store_true",
+            help="Copy each legacy project tree into the projects root and "
+                 "repoint it (self-contained), instead of adopting it in place",
+        )
+        parser.add_argument(
+            "--dest-root",
+            default=None,
+            help="Destination root for copied projects "
+                 "(default: settings.CCP4I2_PROJECTS_DIR)",
+        )
+        parser.add_argument(
+            "--allow-structural-issues",
+            action="store_true",
+            help="Proceed even if blocking structural issues (e.g. destination "
+                 "collisions) are present",
+        )
 
     def handle(self, *args, **options):
         remap_dirs = tuple(options["remap_dirs"]) if options["remap_dirs"] else None
+        copy_files = options["copy_files"]
+        dest_root = options["dest_root"]
 
         def log_fn(msg):
             self.stdout.write(msg)
@@ -61,6 +85,8 @@ class Command(BaseCommand):
                 remap_dirs=remap_dirs,
                 verbose=options["verbose"],
                 log_fn=log_fn,
+                copy_files=copy_files,
+                dest_root=dest_root,
             )
             report = validator.run()
 
@@ -71,6 +97,11 @@ class Command(BaseCommand):
             self.stdout.write(f"  Import sources on disk: {summary['import_sources_on_disk']}")
             self.stdout.write(f"  Integrity issues:       {summary['integrity_issues']}")
             self.stdout.write(f"  Data quality issues:    {summary['data_quality_issues']}")
+            self.stdout.write(f"  Structure issues:       {summary['structure_issues']} "
+                              f"({summary['blocking_issues']} blocking)")
+            ps = summary["plan_summary"]
+            self.stdout.write(f"  Plan: {ps['in_place']} in place, {ps['copy']} copied "
+                              f"({ps['copied_due_to_nesting']} due to nesting)")
 
             self.stdout.write("\n" + "=" * 60)
             if summary["ok"]:
@@ -87,9 +118,24 @@ class Command(BaseCommand):
                 continue_on_error=options["continue_on_error"],
                 verbose=options["verbose"],
                 log_fn=log_fn,
+                copy_files=copy_files,
+                dest_root=dest_root,
+                allow_structural_issues=options["allow_structural_issues"],
             )
 
-            result = importer.run()
+            try:
+                result = importer.run()
+            except StructuralIssuesError as e:
+                self.stderr.write(self.style.ERROR(
+                    "Refusing to import: blocking structural issues found."
+                ))
+                for issue in e.structure["issues"]:
+                    if issue["severity"] == "blocking" and not issue.get("resolution"):
+                        self.stderr.write(f"  - {issue['detail']}")
+                raise CommandError(
+                    "Re-run with --allow-structural-issues to proceed anyway, "
+                    "or fix the issues above."
+                )
 
             self.stdout.write("\n" + "-" * 60)
             self.stdout.write(self.style.SUCCESS("Import completed successfully!"))

--- a/server/ccp4i2/db/management/commands/validate_sqlite.py
+++ b/server/ccp4i2/db/management/commands/validate_sqlite.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         self.stdout.write(f"  Projects on disk:       {summary['projects_on_disk']}")
         self.stdout.write(f"  Jobs on disk:           {summary['jobs_on_disk']}")
         self.stdout.write(f"  Files on disk:          {summary['files_on_disk']}")
-        self.stdout.write(f"  Import sources on disk: {summary['import_sources_on_disk']}")
+        self.stdout.write(f"  Import sources present:  {summary['import_sources_present']} (informational)")
         self.stdout.write(f"  Integrity issues:       {summary['integrity_issues']}")
         self.stdout.write(f"  Data quality issues:    {summary['data_quality_issues']}")
 

--- a/server/ccp4i2/tests/api/unit/test_admin_migration_api.py
+++ b/server/ccp4i2/tests/api/unit/test_admin_migration_api.py
@@ -1,0 +1,94 @@
+"""API-level tests for the legacy-migration admin endpoints.
+
+Asserts the wire contract (docs/LEGACY_MIGRATION_WIRE_CONTRACT.md): the
+validate/import responses carry structure + plan, and errors use the
+standardised {error: <machine_string>, reason: ...} envelope.
+
+pytest-style (house convention for API unit tests). The admin views are
+function-based with @permission_classes([IsAdminUser]); the autouse
+``bypass_api_permissions`` fixture only patches viewsets, so real admin gating
+still applies here and can be exercised with force_authenticate.
+"""
+
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from ccp4i2.api.admin_views import import_sqlite, validate_sqlite
+from ccp4i2.db.models import Project
+from ccp4i2.tests.db.test_import_sqlite import make_legacy_db, make_project_tree
+
+
+@pytest.mark.django_db
+class TestAdminMigrationApi:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="admin", email="a@b.c", password="x")
+        self.factory = APIRequestFactory()
+        self.tmp = Path(tempfile.mkdtemp())
+        self.legacy_root = self.tmp / "legacy"
+        self.legacy_root.mkdir()
+        self.dest_root = self.tmp / "CCP4X_PROJECTS"
+        self.db_path = self.tmp / "database.sqlite"
+
+    def _post(self, view, data, user="admin"):
+        req = self.factory.post("/", data, format="multipart")
+        if user:
+            force_authenticate(req, user=self.admin)
+        return view(req)
+
+    def _make_db(self, name="gamma"):
+        d = make_project_tree(self.legacy_root, name)
+        pid = uuid.uuid4().hex
+        make_legacy_db(self.db_path,
+                       [{"id": pid, "name": name, "directory": d}],
+                       [{"id": uuid.uuid4().hex, "number": "1", "project_id": pid}])
+        return d
+
+    def test_validate_returns_structure_and_plan(self):
+        self._make_db()
+        resp = self._post(validate_sqlite, {
+            "db_path": str(self.db_path),
+            "copy_files": "true",
+            "dest_root": str(self.dest_root),
+        })
+        assert resp.status_code == 200
+        for key in ("summary", "structure", "plan"):
+            assert key in resp.data
+        assert "blocking_issues" in resp.data["summary"]
+        assert "plan_summary" in resp.data["summary"]
+        assert resp.data["plan"][0]["mode"] == "copy"
+
+    def test_bad_input_uses_standard_envelope(self):
+        resp = self._post(validate_sqlite, {})
+        assert resp.status_code == 400
+        assert resp.data["error"] == "bad_input"
+        assert "reason" in resp.data
+
+    def test_db_not_found_envelope(self):
+        resp = self._post(validate_sqlite, {"db_path": str(self.tmp / "nope.sqlite")})
+        assert resp.status_code == 404
+        assert resp.data["error"] == "db_not_found"
+
+    def test_import_copy_mode_creates_project(self):
+        self._make_db("delta")
+        resp = self._post(import_sqlite, {
+            "db_path": str(self.db_path),
+            "copy_files": "true",
+            "dest_root": str(self.dest_root),
+        })
+        assert resp.status_code == 200
+        assert "plan" in resp.data
+        assert Project.objects.filter(name="delta").exists()
+        assert (self.dest_root / "delta" / "CCP4_JOBS").is_dir()
+
+    def test_requires_admin(self):
+        self._make_db()
+        resp = self._post(validate_sqlite, {"db_path": str(self.db_path)}, user=None)
+        assert resp.status_code in (401, 403)

--- a/server/ccp4i2/tests/db/test_import_sqlite.py
+++ b/server/ccp4i2/tests/db/test_import_sqlite.py
@@ -80,11 +80,13 @@ def _hex():
     return uuid.uuid4().hex
 
 
-def make_legacy_db(db_path, projects, jobs=None):
+def make_legacy_db(db_path, projects, jobs=None, files=None):
     """Create a minimal legacy sqlite DB.
 
     projects: list of dicts {id, name, directory, i1_directory?, parent?}
     jobs: optional list of {id, number, project_id, task}
+    files: optional list of {filename, job_id, pathflag?} — DB rows only; the
+        test decides whether the file exists on disk.
     """
     conn = sqlite3.connect(str(db_path))
     conn.executescript(LEGACY_SCHEMA)
@@ -102,6 +104,11 @@ def make_legacy_db(db_path, projects, jobs=None):
             "CreationTime) VALUES (?,?,?,?,?,?)",
             (j["id"], j["number"], j["project_id"], 6, j.get("task", "refmac"),
              1700000000.0),
+        )
+    for f in (files or []):
+        conn.execute(
+            "INSERT INTO Files (FileID, Filename, JobID, PathFlag) VALUES (?,?,?,?)",
+            (_hex(), f["filename"], f["job_id"], f.get("pathflag", 1)),
         )
     conn.commit()
     conn.close()
@@ -220,6 +227,33 @@ class ImporterCopyTests(TestCase):
         self.assertEqual(len(report["plan"]), 1)
         self.assertEqual(report["plan"][0]["mode"], "copy")
         self.assertEqual(report["summary"]["plan_summary"]["copy"], 1)
+
+    def test_missing_files_split_by_preservation_contract(self):
+        # A project with a top-level job (1) and a sub-job (1.1). Give each a
+        # Files row whose file is NOT on disk. The top-level miss is an
+        # in-contract violation (gates ok); the sub-job miss is out of contract.
+        d = make_project_tree(self.legacy_root, "kappa")
+        # sub-job dir must exist so only the FILE is missing, not the dir
+        (Path(d) / "CCP4_JOBS" / "job_1" / "job_1").mkdir(parents=True, exist_ok=True)
+        pid = _hex()
+        top_job, sub_job = _hex(), _hex()
+        make_legacy_db(
+            self.db_path,
+            [{"id": pid, "name": "kappa", "directory": d}],
+            [{"id": top_job, "number": "1", "project_id": pid},
+             {"id": sub_job, "number": "1.1", "project_id": pid}],
+            files=[
+                {"filename": "TOPLEVEL_RESULT.pdb", "job_id": top_job},
+                {"filename": "sub_intermediate.mtz", "job_id": sub_job},
+            ],
+        )
+        s = self._validator().run()["summary"]
+        self.assertEqual(s["top_level_files_missing"], 1)
+        self.assertEqual(s["sub_job_files_missing"], 1)
+        # In-contract violation makes the run not-ok; sub-job miss alone would not.
+        self.assertFalse(s["ok"])
+        # But it is not a *blocking* structural issue — migration can proceed.
+        self.assertEqual(s["blocking_issues"], 0)
 
     def test_copy_mode_copies_tree_and_repoints(self):
         d = make_project_tree(self.legacy_root, "delta")

--- a/server/ccp4i2/tests/db/test_import_sqlite.py
+++ b/server/ccp4i2/tests/db/test_import_sqlite.py
@@ -1,0 +1,288 @@
+"""Tests for legacy CCP4i2 SQLite migration: structural analysis + plan + copy.
+
+These are fast, need no CCP4 binaries and no external data — they synthesise a
+minimal legacy sqlite database and a temp project tree on the fly.
+"""
+
+import sqlite3
+import tempfile
+import uuid
+from pathlib import Path
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from ...db.import_sqlite import (
+    SQLiteImporter,
+    SQLiteValidator,
+    StructuralIssuesError,
+)
+from ...db import legacy_structure as ls
+from ...db.models import Project
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+LEGACY_SCHEMA = """
+CREATE TABLE Projects (
+    ProjectID TEXT PRIMARY KEY, ProjectName TEXT, ProjectCreated REAL,
+    UserID TEXT, ParentProjectID TEXT, ProjectDirectory TEXT,
+    LastJobNumber INTEGER, FollowFromJobID TEXT, I1ProjectName TEXT,
+    I1ProjectDirectory TEXT, LastAccess REAL
+);
+CREATE TABLE Jobs (
+    JobID TEXT PRIMARY KEY, JobNumber TEXT, ProjectID TEXT, ParentJobID TEXT,
+    PreceedingJobID TEXT, Status INTEGER, TaskName TEXT, TaskVersion TEXT,
+    JobTitle TEXT, Evaluation INTEGER, UserId TEXT, UserAgent TEXT,
+    CreationTime REAL, FinishTime REAL, processId INTEGER
+);
+CREATE TABLE Files (
+    FileID TEXT PRIMARY KEY, Filename TEXT, Annotation TEXT, FiletypeID INTEGER,
+    FileSubType INTEGER, FileContent INTEGER, FilePath TEXT, JobID TEXT,
+    JobParamName TEXT, PathFlag INTEGER
+);
+CREATE TABLE FileUses (FileID TEXT, JobID TEXT, RoleID INTEGER, JobParamName TEXT);
+CREATE TABLE ImportFiles (
+    ImportId TEXT PRIMARY KEY, FileID TEXT, SourceFilename TEXT,
+    SourceFileID TEXT, ExportFileID TEXT, Annotation TEXT, CreationTime REAL,
+    LastModifiedTime REAL, Checksum TEXT, ImportNumber INTEGER, Reference TEXT
+);
+CREATE TABLE ExportFiles (
+    ExportId TEXT PRIMARY KEY, FileID TEXT, ExportFilename TEXT,
+    Annotation TEXT, CreationTime REAL
+);
+CREATE TABLE XData (XDataID TEXT, JobID TEXT, XDataClass TEXT, XDataXml TEXT);
+CREATE TABLE JobKeyValues (JobID TEXT, KeyTypeID INTEGER, Value REAL);
+CREATE TABLE JobKeyCharValues (JobID TEXT, KeyTypeID INTEGER, Value TEXT);
+CREATE TABLE Tags (TagID INTEGER PRIMARY KEY, ParentTagID INTEGER, Text TEXT);
+CREATE TABLE ProjectTags (TagID INTEGER, ProjectID TEXT);
+CREATE TABLE Comments (CommentID TEXT, JobID TEXT, Comment TEXT);
+CREATE TABLE ProjectComments (
+    ProjectCommentID TEXT PRIMARY KEY, ProjectID TEXT, UserID TEXT,
+    TimeOfComment REAL, Comment TEXT
+);
+CREATE TABLE ServerJobs (
+    JobId TEXT, ServerProcessId INTEGER, Machine TEXT, Username TEXT,
+    Mechanism TEXT, RemotePath TEXT, CustomCodeFile TEXT, Validate TEXT,
+    KeyFilename TEXT, ServerGroup TEXT
+);
+CREATE TABLE FileTypes (FileTypeID INTEGER PRIMARY KEY, FileTypeName TEXT, FileTypeDescription TEXT);
+CREATE TABLE KeyTypes (KeyTypeID INTEGER PRIMARY KEY, KeyTypeName TEXT, KeyTypeDescription TEXT);
+CREATE TABLE FileRoles (RoleID INTEGER PRIMARY KEY, RoleText TEXT);
+CREATE TABLE ProjectExports (ProjectExportId TEXT, ProjectID TEXT, ProjectExportTime REAL);
+CREATE TABLE ProjectImports (ProjectImportId TEXT, ProjectID TEXT, ProjectImportTime REAL);
+"""
+
+
+def _hex():
+    return uuid.uuid4().hex
+
+
+def make_legacy_db(db_path, projects, jobs=None):
+    """Create a minimal legacy sqlite DB.
+
+    projects: list of dicts {id, name, directory, i1_directory?, parent?}
+    jobs: optional list of {id, number, project_id, task}
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(LEGACY_SCHEMA)
+    for p in projects:
+        conn.execute(
+            "INSERT INTO Projects (ProjectID, ProjectName, ProjectCreated, UserID, "
+            "ParentProjectID, ProjectDirectory, LastJobNumber, I1ProjectName, "
+            "I1ProjectDirectory, LastAccess) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (p["id"], p["name"], 1700000000.0, "tester", p.get("parent"),
+             p["directory"], 1, "", p.get("i1_directory", ""), 1700000000.0),
+        )
+    for j in (jobs or []):
+        conn.execute(
+            "INSERT INTO Jobs (JobID, JobNumber, ProjectID, Status, TaskName, "
+            "CreationTime) VALUES (?,?,?,?,?,?)",
+            (j["id"], j["number"], j["project_id"], 6, j.get("task", "refmac"),
+             1700000000.0),
+        )
+    conn.commit()
+    conn.close()
+
+
+def make_project_tree(base, name, with_jobs=True):
+    d = Path(base) / name
+    if with_jobs:
+        jd = d / "CCP4_JOBS" / "job_1"
+        jd.mkdir(parents=True, exist_ok=True)
+        (jd / "XYZOUT.pdb").write_text("ATOM\n" * 10)
+    else:
+        d.mkdir(parents=True, exist_ok=True)
+    (d / "CCP4_IMPORTED_FILES").mkdir(parents=True, exist_ok=True)
+    return str(d)
+
+
+# ---------------------------------------------------------------------------
+# Pure structural-analysis tests (no Django DB)
+# ---------------------------------------------------------------------------
+
+class StructureAnalysisTests(TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.dest_root = self.tmp / "CCP4X_PROJECTS"
+
+    def test_nested_project_flagged_and_planned_as_copy(self):
+        a = make_project_tree(self.tmp, "alpha")
+        # beta nested inside alpha's jobs dir
+        b = str(Path(a) / "CCP4_JOBS" / "job_1" / "beta")
+        (Path(b) / "CCP4_JOBS").mkdir(parents=True, exist_ok=True)
+        projects = [
+            {"id": "a" * 32, "name": "alpha", "directory": a, "i1_directory": ""},
+            {"id": "b" * 32, "name": "beta", "directory": b, "i1_directory": ""},
+        ]
+        issues, plan = ls.analyse_structure(
+            projects, copy_files=False, dest_root=self.dest_root)
+
+        # beta is copied out even though copy_files=False (mixed mode)
+        beta = next(e for e in plan if e["name"] == "beta")
+        alpha = next(e for e in plan if e["name"] == "alpha")
+        self.assertEqual(beta["mode"], "copy")
+        self.assertEqual(beta["reason"], "nested")
+        self.assertEqual(alpha["mode"], "in_place")
+        # nesting is auto-resolved -> not blocking-unresolved
+        self.assertEqual(ls.blocking_unresolved(issues), 0)
+        self.assertTrue(any(i["type"] == ls.NESTED_PROJECT and i["resolution"]
+                            for i in issues))
+
+    def test_dest_collision_deduped_by_rename(self):
+        a1 = make_project_tree(self.tmp / "one", "proj")
+        a2 = make_project_tree(self.tmp / "two", "proj")  # same basename
+        projects = [
+            {"id": "1" * 32, "name": "proj", "directory": a1, "i1_directory": ""},
+            {"id": "2" * 32, "name": "proj", "directory": a2, "i1_directory": ""},
+        ]
+        _issues, plan = ls.analyse_structure(
+            projects, copy_files=True, dest_root=self.dest_root)
+        dests = [e["dest"] for e in plan]
+        self.assertEqual(len(set(dests)), 2, "dests must be distinct")
+        self.assertTrue(any(e["renamed_to"] for e in plan))
+
+    def test_not_project_root_warning(self):
+        d = make_project_tree(self.tmp, "noroot", with_jobs=False)  # no CCP4_JOBS
+        projects = [{"id": "n" * 32, "name": "noroot", "directory": d,
+                     "i1_directory": ""}]
+        issues, _plan = ls.analyse_structure(
+            projects, copy_files=False, dest_root=self.dest_root)
+        self.assertTrue(any(i["type"] == ls.NOT_PROJECT_ROOT for i in issues))
+
+    def test_nested_excludes(self):
+        a = make_project_tree(self.tmp, "alpha")
+        b = str(Path(a) / "CCP4_JOBS" / "job_1" / "beta")
+        (Path(b) / "CCP4_JOBS").mkdir(parents=True, exist_ok=True)
+        projects = [
+            {"id": "a" * 32, "name": "alpha", "directory": a, "i1_directory": ""},
+            {"id": "b" * 32, "name": "beta", "directory": b, "i1_directory": ""},
+        ]
+        _issues, plan = ls.analyse_structure(
+            projects, copy_files=True, dest_root=self.dest_root)
+        resolved = {p["id"]: ls._resolve(p["directory"]) for p in projects}
+        excludes = ls.nested_excludes_for(plan, resolved)
+        self.assertTrue(any("beta" in str(d) for d in excludes["a" * 32]))
+
+
+# ---------------------------------------------------------------------------
+# Full validator + importer tests (Django DB)
+# ---------------------------------------------------------------------------
+
+@override_settings()
+class ImporterCopyTests(TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.legacy_root = self.tmp / "legacy"
+        self.legacy_root.mkdir()
+        self.dest_root = self.tmp / "CCP4X_PROJECTS"
+        self.db_path = self.tmp / "database.sqlite"
+
+    def _validator(self, **kw):
+        return SQLiteValidator(db_path=self.db_path, dest_root=self.dest_root, **kw)
+
+    def _importer(self, **kw):
+        kw.setdefault("dest_root", self.dest_root)
+        kw.setdefault("continue_on_error", True)
+        return SQLiteImporter(db_path=self.db_path, **kw)
+
+    def test_validate_reports_plan_and_summary(self):
+        d = make_project_tree(self.legacy_root, "gamma")
+        pid = _hex()
+        make_legacy_db(self.db_path,
+                       [{"id": pid, "name": "gamma", "directory": d}],
+                       [{"id": _hex(), "number": "1", "project_id": pid}])
+        report = self._validator(copy_files=True).run()
+        self.assertIn("structure", report)
+        self.assertIn("plan", report)
+        self.assertEqual(len(report["plan"]), 1)
+        self.assertEqual(report["plan"][0]["mode"], "copy")
+        self.assertEqual(report["summary"]["plan_summary"]["copy"], 1)
+
+    def test_copy_mode_copies_tree_and_repoints(self):
+        d = make_project_tree(self.legacy_root, "delta")
+        pid = _hex()
+        make_legacy_db(self.db_path,
+                       [{"id": pid, "name": "delta", "directory": d}],
+                       [{"id": _hex(), "number": "1", "project_id": pid}])
+
+        self._importer(copy_files=True).run()
+
+        proj = Project.objects.get(name="delta")
+        expected_dest = self.dest_root / "delta"
+        self.assertEqual(Path(proj.directory), expected_dest)
+        self.assertTrue((expected_dest / "CCP4_JOBS" / "job_1" / "XYZOUT.pdb").is_file())
+
+    def test_dry_run_copies_nothing(self):
+        d = make_project_tree(self.legacy_root, "epsilon")
+        pid = _hex()
+        make_legacy_db(self.db_path,
+                       [{"id": pid, "name": "epsilon", "directory": d}])
+        result = self._importer(copy_files=True, dry_run=True).run()
+        self.assertFalse((self.dest_root / "epsilon").exists())
+        self.assertEqual(Project.objects.filter(name="epsilon").count(), 0)
+        # stats still report the intended copy
+        self.assertEqual(result["stats"].get("projects_copied", 0), 1)
+
+    def test_nested_mixed_mode_copies_only_inner(self):
+        a = make_project_tree(self.legacy_root, "outer")
+        b = str(Path(a) / "CCP4_JOBS" / "job_1" / "inner")
+        (Path(b) / "CCP4_JOBS" / "job_1").mkdir(parents=True, exist_ok=True)
+        (Path(b) / "CCP4_JOBS" / "job_1" / "IN.pdb").write_text("x")
+        (Path(b) / "CCP4_IMPORTED_FILES").mkdir(parents=True, exist_ok=True)
+        outer_id, inner_id = _hex(), _hex()
+        make_legacy_db(self.db_path, [
+            {"id": outer_id, "name": "outer", "directory": a},
+            {"id": inner_id, "name": "inner", "directory": b},
+        ])
+        # schlurp overall (copy_files=False); inner must still be copied out
+        self._importer(copy_files=False).run()
+
+        outer = Project.objects.get(name="outer")
+        inner = Project.objects.get(name="inner")
+        # in place: directory is the (canonicalised) legacy dir
+        self.assertEqual(Path(outer.directory).resolve(), Path(a).resolve())
+        # copied out to dest_root even though the run was schlurp overall
+        self.assertEqual(Path(inner.directory).resolve(),
+                         (self.dest_root / "inner").resolve())
+        self.assertTrue((self.dest_root / "inner" / "CCP4_JOBS" / "job_1" / "IN.pdb").is_file())
+
+    def test_blocking_issue_refused_without_ack(self):
+        # An unreadable source in copy mode is blocking-unresolved.
+        d = make_project_tree(self.legacy_root, "locked")
+        import os
+        os.chmod(Path(d) / "CCP4_JOBS", 0o000)
+        try:
+            pid = _hex()
+            make_legacy_db(self.db_path,
+                           [{"id": pid, "name": "locked", "directory": d}])
+            with self.assertRaises(StructuralIssuesError):
+                self._importer(copy_files=True).run()
+            # with ack it proceeds (copy of the unreadable subdir is skipped/errs
+            # but the run completes)
+            self._importer(copy_files=True,
+                           allow_structural_issues=True).run()
+        finally:
+            os.chmod(Path(d) / "CCP4_JOBS", 0o755)


### PR DESCRIPTION
Implements the legacy-database migration feature for the a2 release: a **UI-driven** wizard that migrates an old (Qt-era) CCP4i2 installation into the Django backend, plus the backend engine it drives.

Design docs: `docs/LEGACY_MIGRATION_UI_PLAN.md` (plan + edge cases) and `docs/LEGACY_MIGRATION_WIRE_CONTRACT.md` (UI↔REST handshake).

## Backend (commit 1)

The existing `SQLiteValidator`/`SQLiteImporter` imported legacy *records* but were records-only (no file copying) and did no structural reasoning about the project directory tree. This adds both, behind a **per-project plan** the validator computes and the importer consumes — so validate and import cannot disagree.

- **`db/legacy_structure.py`** (new, Django-free): `analyse_structure()` → per-project plan (`in_place`|`copy` + dest) and structural issues: nested projects, destination collisions (case/NFC-aware), shared/symlinked subtrees, non-project-root dirs, unreadable sources, writability/space, i1-dir overlap. Nesting auto-resolves to **copy-out** (mixed mode) and is non-blocking.
- **`SQLiteValidator`**: emits `structure` + `plan`; `summary` gains `blocking_issues`/`structure_issues`/`plan_summary`; `summary.ok` false on blocking issues.
- **`SQLiteImporter`**: `copy_files`/`dest_root`; consumes the plan; **full-tree `copytree`** (everything under the project root — params, input_params, program XMLs, logs, the lot; symlinks preserved; only sibling nested projects excluded); `StructuralIssuesError` gate honouring `allow_structural_issues`.
- **admin_views**: `copy_files`/`dest_root`/`allow_structural_issues` params; standardised `{error, reason, ...}` error envelope (matches JobViewSet); blocking issues → `400 structural_issues_unacknowledged`.
- **management commands**: `--copy-files`/`--dest-root`/`--allow-structural-issues`.
- **Fix**: `import_i2xml` command read `options["program_xml"]` but the arg is `project_xml` — would crash on invocation.

## Frontend (commit 2)

- **`admin/migrate-legacy/` route** + 4-step MUI Stepper wizard: **Source & copy-mode** (copy vs adopt-in-place, db path, optional remap) → **Validate** (on-disk ratios, data checks, structural issues grouped by type, per-project plan table, blocking-issue acknowledgement gate) → **Dry run** → **Import** (+ import-status confirmation). Gated on `useAuth().canAdminister`.
- `types/migration.ts` mirrors the wire contract; "Migrate legacy" nav button (admin-gated) in the projects toolbar.

## Decisions baked in

- Audience this round: **desktop self-migration** (user's own `~/.CCP4I2`).
- **Take everything**: copy the whole project directory, not just db-tracked files.
- Nested projects always copied out to `CCP4I2_PROJECTS_DIR` and repointed, even in adopt-in-place mode.
- UI-driven: every decision surfaced/confirmed in the wizard; CLI is a power-user/test path only.

## Tests

Fast, no CCP4 binaries, no external data (synthesise a legacy sqlite + temp tree). Run under **both** `pytest-django` and `manage.py test`:
- `tests/db/test_import_sqlite.py`: structural analysis, plan, mixed-mode copy-out, dry-run copies nothing, blocking-issue gate.
- `tests/api/unit/test_admin_migration_api.py`: wire-contract shapes, error envelope, admin gating.

14 tests green. Renderer typechecks clean; `next dev` compiles the wizard route to 200 with the Source step + Stepper rendering.

## Not yet done

- End-to-end wizard run against a live backend + real legacy sqlite (contract is unit-covered; a full click-through is the next verification).
- Entry point: the wizard is reachable via the admin nav button, but there's **no first-launch "new DB vs import existing" landing** yet (planned: show only when the DB is empty; a separate CCP4i2-only page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)