### PR TITLE
Unified desktop launch flow: get-ready, readiness gate, first-project welcome

### DIFF
--- a/client/renderer/app/api/proxy/ccp4i2/[...path]/route.ts
+++ b/client/renderer/app/api/proxy/ccp4i2/[...path]/route.ts
@@ -10,10 +10,13 @@ import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Public endpoints that don't require authentication.
- * Version info is fetched from the app-selector page before login.
- * Health checks use /api/health directly, not through this proxy.
+ * - version: fetched from the app-selector page before login.
+ * - health:  the launch-time readiness probe (LaunchGate / useServerReady) polls
+ *   this before the app is up and before any token exists, so it must not require
+ *   auth. The Django health_check view is itself unauthenticated (a plain view,
+ *   no DRF permissions), so exposing it here matches its intent.
  */
-const PUBLIC_ENDPOINTS = ["version"];
+const PUBLIC_ENDPOINTS = ["version", "health"];
 
 /**
  * Check if the path is a public endpoint that doesn't require auth.

--- a/client/renderer/app/ccp4i2/(authed)/page.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/page.tsx
@@ -1,54 +1,60 @@
 "use client";
-import { Box, Container, Skeleton, Stack, Typography } from "@mui/material";
+import { Box, Container, Skeleton, Stack } from "@mui/material";
 import ProjectsToolbar from "@/components/projects-toolbar";
 import ProjectsTable from "@/components/projects-table";
 import CCP4i2TopBar from "@/components/ccp4i2-topbar";
+import { LaunchGate } from "@/components/launch-gate";
+import { WelcomeChooser } from "@/components/welcome-chooser";
 import { useApi } from "@/api";
 import { Project } from "@/types/models";
 
-export default function ProjectsPage() {
+function ProjectsHome() {
   const api = useApi();
   // Note: second param is refreshInterval, not timeout. Set to 0 to disable auto-refresh.
   const { data: projects } = api.get<Project[]>("projects");
 
+  // Empty database => first-project welcome. This is keyed on live state, not a
+  // one-shot flag, so it also covers a failed migration or a rolled-back
+  // projects directory that leaves the user back at zero projects.
+  const isEmpty = projects && projects.length === 0;
+
   return (
-    <Stack
-      sx={{
-        height: "100vh",
-        overflow: "hidden",
-      }}
-    >
+    <Stack sx={{ height: "100vh", overflow: "hidden" }}>
       <CCP4i2TopBar title="CCP4i2 Projects" />
-      <Container
-        sx={{
-          flex: 1,
-          display: "flex",
-          flexDirection: "column",
-          overflow: "hidden",
-          py: 2,
-        }}
-      >
-        <Stack gap={2} sx={{ flex: 1, overflow: "hidden" }}>
-          <ProjectsToolbar />
-          {projects ? (
-            projects.length > 0 ? (
+      {isEmpty ? (
+        <Box sx={{ flex: 1, overflow: "auto" }}>
+          <WelcomeChooser />
+        </Box>
+      ) : (
+        <Container
+          sx={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+            py: 2,
+          }}
+        >
+          <Stack gap={2} sx={{ flex: 1, overflow: "hidden" }}>
+            <ProjectsToolbar />
+            {projects ? (
               <Box sx={{ flex: 1, overflow: "hidden" }}>
                 <ProjectsTable />
               </Box>
             ) : (
-              <Stack alignItems="center" gap={2} sx={{ py: 8 }}>
-                <Typography variant="h6">No projects found</Typography>
-                <Typography variant="body1" color="textSecondary">
-                  Use the <b>New</b> or <b>Import</b> buttons above
-                  to create or load a project.
-                </Typography>
-              </Stack>
-            )
-          ) : (
-            <Skeleton variant="rectangular" width="100%" height={500} />
-          )}
-        </Stack>
-      </Container>
+              <Skeleton variant="rectangular" width="100%" height={500} />
+            )}
+          </Stack>
+        </Container>
+      )}
     </Stack>
+  );
+}
+
+export default function ProjectsPage() {
+  return (
+    <LaunchGate>
+      <ProjectsHome />
+    </LaunchGate>
   );
 }

--- a/client/renderer/app/ccp4i2/config/page.tsx
+++ b/client/renderer/app/ccp4i2/config/page.tsx
@@ -1,227 +1,49 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import { ConfigContent } from "../../../components/config-content";
 import { NavigationShortcutsProvider } from "../../../providers/navigation-shortcuts-provider";
-import { TeamsDiagnostic } from "../../../components/teams-diagnostic";
-import {
-  Box,
-  Paper,
-  Typography,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Container,
-  Grid2,
-  Chip,
-} from "@mui/material";
-import { ExpandMore, Settings, Security, BugReport } from "@mui/icons-material";
+import { Box, Container, Stack, Typography } from "@mui/material";
+import { Science } from "@mui/icons-material";
 
+/**
+ * The launch / "get ready" screen — the first thing an Electron user sees.
+ *
+ * Deliberately NOT framed as an installer or a "system diagnostics" console.
+ * On the desktop, CCP4i2 is a single-user tool, so there is intentionally no
+ * teams / authentication / accounts chrome here — those belong only to a web
+ * backend with real multi-user auth. This page's whole job is to get the user
+ * into their work: confirm the setup is ready (or fix what isn't) and launch.
+ */
 export default function ConfigPage() {
-  const [teamsExpanded, setTeamsExpanded] = useState(false);
-
-  const handleTeamsToggle = (
-    event: React.SyntheticEvent,
-    isExpanded: boolean
-  ) => {
-    setTeamsExpanded(isExpanded);
-  };
-
   return (
     <NavigationShortcutsProvider>
-      <Container maxWidth="xl" sx={{ py: 4 }}>
-        <Grid2 container spacing={4}>
-          {/* Header Section */}
-          <Grid2 size={{ xs: 12 }}>
-            <Paper
-              elevation={2}
+      <Container maxWidth="sm" sx={{ py: { xs: 4, sm: 8 } }}>
+        <Stack spacing={4}>
+          <Stack spacing={1.5} alignItems="center" sx={{ textAlign: "center" }}>
+            <Box
               sx={{
-                p: 3,
-                background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-                color: "white",
+                width: 64,
+                height: 64,
                 borderRadius: 2,
+                display: "grid",
+                placeItems: "center",
+                color: "primary.contrastText",
+                background:
+                  "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
               }}
             >
-              <Box display="flex" alignItems="center" gap={2}>
-                <Settings sx={{ fontSize: 40 }} />
-                <Box>
-                  <Typography variant="h3" component="h1" fontWeight="bold">
-                    Configuration
-                  </Typography>
-                  <Typography variant="h6" sx={{ opacity: 0.9 }}>
-                    System settings and diagnostic tools
-                  </Typography>
-                </Box>
-              </Box>
-            </Paper>
-          </Grid2>
+              <Science sx={{ fontSize: 34 }} />
+            </Box>
+            <Typography variant="h4" fontWeight={700}>
+              CCP4i2
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Crystallographic computing on your desktop
+            </Typography>
+          </Stack>
 
-          {/* Main Configuration Section */}
-          <Grid2 size={{ xs: 12, lg: 8 }}>
-            <Paper
-              elevation={1}
-              sx={{
-                borderRadius: 2,
-                overflow: "hidden",
-                border: "1px solid",
-                borderColor: "divider",
-              }}
-            >
-              <Box
-                sx={{
-                  p: 2,
-                  bgcolor: "grey.50",
-                  borderBottom: "1px solid",
-                  borderColor: "divider",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1,
-                }}
-              >
-                <Settings color="primary" />
-                <Typography variant="h6" fontWeight="600">
-                  System Configuration
-                </Typography>
-              </Box>
-              <Box sx={{ p: 3 }}>
-                <ConfigContent />
-              </Box>
-            </Paper>
-          </Grid2>
-
-          {/* Info Panel */}
-          <Grid2 size={{ xs: 12, lg: 4 }}>
-            <Paper
-              elevation={1}
-              sx={{
-                p: 3,
-                borderRadius: 2,
-                border: "1px solid",
-                borderColor: "divider",
-                height: "fit-content",
-              }}
-            >
-              <Box display="flex" alignItems="center" gap={1} mb={2}>
-                <Security color="primary" />
-                <Typography variant="h6" fontWeight="600">
-                  Configuration Status
-                </Typography>
-              </Box>
-
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                <Box>
-                  <Typography variant="subtitle2" color="text.secondary" mb={1}>
-                    Environment
-                  </Typography>
-                  <Chip
-                    label={
-                      process.env.NODE_ENV === "development"
-                        ? "Development"
-                        : "Production"
-                    }
-                    color={
-                      process.env.NODE_ENV === "development"
-                        ? "warning"
-                        : "success"
-                    }
-                    variant="outlined"
-                    size="small"
-                  />
-                </Box>
-
-                <Box>
-                  <Typography variant="subtitle2" color="text.secondary" mb={1}>
-                    Authentication
-                  </Typography>
-                  <Chip
-                    label={
-                      process.env.NEXT_PUBLIC_REQUIRE_AUTH === "true"
-                        ? "Enabled"
-                        : "Disabled"
-                    }
-                    color={
-                      process.env.NEXT_PUBLIC_REQUIRE_AUTH === "true"
-                        ? "success"
-                        : "default"
-                    }
-                    variant="outlined"
-                    size="small"
-                  />
-                </Box>
-
-                <Box>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mt: 2 }}
-                  >
-                    Use the diagnostic tools below to troubleshoot
-                    authentication and Teams integration issues.
-                  </Typography>
-                </Box>
-              </Box>
-            </Paper>
-          </Grid2>
-
-          {/* Teams Diagnostic Section - Collapsible */}
-          <Grid2 size={{ xs: 12 }}>
-            <Accordion
-              expanded={teamsExpanded}
-              onChange={handleTeamsToggle}
-              sx={{
-                border: "1px solid",
-                borderColor: "divider",
-                borderRadius: 2,
-                "&:before": {
-                  display: "none",
-                },
-                "&.Mui-expanded": {
-                  margin: 0,
-                },
-              }}
-              elevation={1}
-            >
-              <AccordionSummary
-                expandIcon={<ExpandMore />}
-                sx={{
-                  bgcolor: "grey.50",
-                  borderBottom: teamsExpanded ? "1px solid" : "none",
-                  borderColor: "divider",
-                  minHeight: 64,
-                  "& .MuiAccordionSummary-content": {
-                    alignItems: "center",
-                  },
-                  "& .MuiAccordionSummary-content.Mui-expanded": {
-                    margin: "12px 0",
-                  },
-                }}
-              >
-                <Box display="flex" alignItems="center" gap={2}>
-                  <BugReport color="primary" />
-                  <Box>
-                    <Typography variant="h6" fontWeight="600">
-                      Teams Integration Diagnostic
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      Test and troubleshoot Microsoft Teams authentication
-                    </Typography>
-                  </Box>
-                  <Chip
-                    label="Developer Tools"
-                    color="info"
-                    variant="outlined"
-                    size="small"
-                    sx={{ ml: "auto", mr: 2 }}
-                  />
-                </Box>
-              </AccordionSummary>
-              <AccordionDetails sx={{ p: 0 }}>
-                <Box sx={{ p: 3, pt: 2 }}>
-                  <TeamsDiagnostic />
-                </Box>
-              </AccordionDetails>
-            </Accordion>
-          </Grid2>
-        </Grid2>
+          <ConfigContent />
+        </Stack>
       </Container>
     </NavigationShortcutsProvider>
   );

--- a/client/renderer/components/config-content.tsx
+++ b/client/renderer/components/config-content.tsx
@@ -1,19 +1,26 @@
 "use client";
 import React, { useCallback } from "react";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
   Button,
+  CircularProgress,
   Dialog,
   DialogContent,
   DialogTitle,
+  Paper,
   Stack,
   Switch,
   Typography,
-  Paper,
-  CircularProgress,
 } from "@mui/material";
-import { green } from "@mui/material/colors";
-import { useApi } from "../api";
-import { Cancel, Check, Folder } from "@mui/icons-material";
+import {
+  Cancel,
+  Check,
+  ExpandMore,
+  RocketLaunch,
+} from "@mui/icons-material";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useCCP4i2Window } from "../app-context";
@@ -21,8 +28,18 @@ import { usePopcorn } from "../providers/popcorn-provider";
 import { ThemeToggle } from "./theme-toggle";
 import { useTheme } from "../theme/theme-provider";
 
+/**
+ * The "get ready" body of the launch screen. Owns the Electron setup/launch
+ * lifecycle (IPC to the main process) but presents it as one job: get the user
+ * into their work.
+ *
+ * - When everything is ready, the setup detail collapses and a single "Enter
+ *   CCP4i2" action launches the backend; there is no installer jargon.
+ * - When something needs attention (missing CCP4, requirements not installed),
+ *   the setup section opens itself and shows exactly what to fix.
+ * - No teams / auth / accounts UI: this is a single-user desktop tool.
+ */
 export const ConfigContent: React.FC = () => {
-  const api = useApi();
   const { setTheme } = useTheme();
   const [config, setConfig] = useState<any | null>(null);
   const router = useRouter();
@@ -31,6 +48,8 @@ export const ConfigContent: React.FC = () => {
   const [requirementsExist, setRequirementsExist] = useState<boolean>(false);
   const [serverVersion, setServerVersion] = useState<string | null>(null);
   const { setMessage } = usePopcorn();
+  const [launching, setLaunching] = useState(false);
+  const [setupOpen, setSetupOpen] = useState(false);
   const [installProgress, setInstallProgress] = useState<{
     isInstalling: boolean;
     output: string[];
@@ -42,20 +61,15 @@ export const ConfigContent: React.FC = () => {
   });
 
   useEffect(() => {
-    // Send a message to the main process to get the config
     if (typeof window !== "undefined" && window.electronAPI) {
       window.electronAPI.sendMessage("get-config");
-      // Listen for messages from the main process
-
       window.electronAPI.onMessage("message-from-main", messageHandler);
-
       return () => {
         window.electronAPI.removeMessageListener(
           "message-from-main",
           messageHandler
         );
       };
-    } else {
     }
   }, []);
 
@@ -70,20 +84,17 @@ export const ConfigContent: React.FC = () => {
       } else if (data.message === "check-file-exists") {
         if (config) {
           if (data.path === config.CCP4I2_PROJECTS_DIR) {
-            setExistingFiles((prevState: any) => ({
-              ...prevState,
+            setExistingFiles((prev: any) => ({
+              ...prev,
               CCP4I2_PROJECTS_DIR: data.exists,
             }));
           }
           if (data.path === config.CCP4Dir) {
-            setExistingFiles((prevState: any) => ({
-              ...prevState,
-              CCP4Dir: data.exists,
-            }));
+            setExistingFiles((prev: any) => ({ ...prev, CCP4Dir: data.exists }));
           }
           if (data.path === config.venv_python) {
-            setExistingFiles((prevState: any) => ({
-              ...prevState,
+            setExistingFiles((prev: any) => ({
+              ...prev,
               venv_python: data.exists,
             }));
           }
@@ -95,14 +106,11 @@ export const ConfigContent: React.FC = () => {
         setRequirementsExist(false);
         setServerVersion(null);
         setMessage(data.error || "Requirements are missing");
-      }
-      // Add new handler for installation progress
-      else if (data.message === "install-requirements-progress") {
+      } else if (data.message === "install-requirements-progress") {
         setInstallProgress((prev) => {
           const newOutput = data.output
             ? [...prev.output, data.output]
             : prev.output;
-
           return {
             isInstalling:
               data.status === "started" || data.status === "installing",
@@ -110,8 +118,6 @@ export const ConfigContent: React.FC = () => {
             status: data.status,
           };
         });
-
-        // Show success message when completed
         if (data.status === "completed") {
           setMessage("Requirements installed successfully");
           setRequirementsExist(true);
@@ -124,26 +130,24 @@ export const ConfigContent: React.FC = () => {
   );
 
   useEffect(() => {
-    if (config) {
-      if (typeof window !== "undefined" && window.electronAPI) {
-        window.electronAPI.removeMessageListener(
-          "message-from-main",
-          messageHandler
-        );
-        window.electronAPI.onMessage("message-from-main", messageHandler);
-        window.electronAPI.sendMessage("check-file-exists", {
-          path: config.CCP4I2_PROJECTS_DIR,
-        });
-        window.electronAPI.sendMessage("check-file-exists", {
-          path: config.CCP4Dir,
-        });
-        window.electronAPI.sendMessage("check-file-exists", {
-          path: config.venv_python,
-        });
-        window.electronAPI.sendMessage("check-requirements", {
-          path: config.venv_python,
-        });
-      }
+    if (config && typeof window !== "undefined" && window.electronAPI) {
+      window.electronAPI.removeMessageListener(
+        "message-from-main",
+        messageHandler
+      );
+      window.electronAPI.onMessage("message-from-main", messageHandler);
+      window.electronAPI.sendMessage("check-file-exists", {
+        path: config.CCP4I2_PROJECTS_DIR,
+      });
+      window.electronAPI.sendMessage("check-file-exists", {
+        path: config.CCP4Dir,
+      });
+      window.electronAPI.sendMessage("check-file-exists", {
+        path: config.venv_python,
+      });
+      window.electronAPI.sendMessage("check-requirements", {
+        path: config.venv_python,
+      });
       return () => {
         if (typeof window !== "undefined" && window.electronAPI) {
           window.electronAPI.removeMessageListener(
@@ -155,301 +159,205 @@ export const ConfigContent: React.FC = () => {
     }
   }, [config]);
 
-  const onLaunchBrowser = async () => {
-    if (typeof window !== "undefined" && window?.electronAPI) {
-      window.electronAPI.sendMessage("locate-ccp4");
-    } else {
-      console.error("Electron API is not available");
-    }
-  };
+  const onLocateCcp4 = () => window.electronAPI?.sendMessage("locate-ccp4");
+  const onSelectProjectsDir = () =>
+    window.electronAPI?.sendMessage("locate-ccp4i2-project-directory");
 
-  const onSelectProjectsDir = async () => {
-    if (typeof window !== "undefined" && window.electronAPI) {
-      window.electronAPI.sendMessage("locate-ccp4i2-project-directory");
-    } else {
-      console.error("Electron API is not available");
-    }
-  };
-
-  const onStartUvicorn = async () => {
-    if (typeof window !== "undefined" && window.electronAPI) {
+  const onEnter = () => {
+    if (config && window.electronAPI) {
+      setLaunching(true);
       window.electronAPI.sendMessage("start-uvicorn", {
         ...config,
         CCP4Dir: config.CCP4Dir.path,
       });
     } else {
-      console.error("Electron API is not available");
+      // Web mode: the server is already running server-side.
+      router.push("/ccp4i2");
     }
   };
 
-  const onInstallRequirements = async () => {
-    if (typeof window !== "undefined" && window.electronAPI) {
-      // Reset progress state
-      setInstallProgress({
-        isInstalling: true,
-        output: [],
-        status: "started",
-      });
-
+  const onInstallRequirements = () => {
+    if (window.electronAPI) {
+      setInstallProgress({ isInstalling: true, output: [], status: "started" });
       window.electronAPI.sendMessage("install-requirements", {
         ...config,
         CCP4Dir: config.CCP4Dir.path,
       });
-    } else {
-      console.error("Electron API is not available");
     }
   };
 
-  const onToggleDevMode = async (
-    ev: React.ChangeEvent<HTMLInputElement>
-  ): Promise<void> => {
-    if (typeof window !== "undefined" && window?.electronAPI) {
-      window.electronAPI.sendMessage("toggle-dev-mode", {});
-    }
+  const onToggleDevMode = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    window.electronAPI?.sendMessage("toggle-dev-mode", {});
     ev.preventDefault();
     ev.stopPropagation();
   };
 
-  const onCloseProgressDialog = () => {
-    setInstallProgress({
-      isInstalling: false,
-      status: "idle",
-      output: [],
-    });
-  };
+  const onCloseProgressDialog = () =>
+    setInstallProgress({ isInstalling: false, status: "idle", output: [] });
 
-  // Check if ready to launch
-  const isReadyToLaunch =
-    config &&
-    typeof window !== "undefined" &&
-    window.electronAPI &&
-    existingFiles?.venv_python &&
-    (devMode || requirementsExist);
+  const hasElectron =
+    typeof window !== "undefined" && !!window.electronAPI;
+
+  // Ready to enter when the venv exists and requirements are present (or dev).
+  const isReady =
+    config && hasElectron && existingFiles?.venv_python && (devMode || requirementsExist);
+
+  // What still needs doing, in the user's words.
+  const blockers: string[] = [];
+  if (config && hasElectron) {
+    if (!existingFiles?.CCP4Dir) blockers.push("Locate your CCP4 installation");
+    if (!existingFiles?.venv_python) blockers.push("A Python environment is missing");
+    if (!devMode && !requirementsExist)
+      blockers.push("Install the CCP4i2 requirements");
+  }
+
+  // Open the setup section automatically when something needs attention.
+  useEffect(() => {
+    if (config && hasElectron && !isReady) setSetupOpen(true);
+  }, [config, hasElectron, isReady]);
 
   return (
-    <Stack spacing={1.5}>
-      {/* Launch Button - Prominent at top */}
-      <Paper
-        variant="outlined"
-        sx={{
-          p: 2,
-          textAlign: "center",
-          bgcolor: isReadyToLaunch ? "success.dark" : undefined,
-          borderColor: isReadyToLaunch ? "success.main" : undefined,
-        }}
-      >
-        <Stack direction="row" spacing={2} alignItems="center" justifyContent="center">
-          <Button
-            variant="contained"
-            size="large"
-            startIcon={<Folder />}
-            onClick={config ? onStartUvicorn : () => router.push("/ccp4i2")}
-            disabled={config ? !isReadyToLaunch : false}
-            sx={{
-              minWidth: 200,
-              bgcolor: isReadyToLaunch || !config ? green[500] : undefined,
-              "&:hover": {
-                bgcolor: isReadyToLaunch || !config ? green[600] : undefined,
-              },
-            }}
-          >
-            Launch CCP4i2
-          </Button>
-          {config && !isReadyToLaunch && (
-            <Typography variant="caption" color="error">
-              Configure paths and install requirements first
+    <Stack spacing={2}>
+      {/* Primary action — enter, or tell the user what's blocking it. */}
+      {isReady || !config ? (
+        <Paper
+          variant="outlined"
+          sx={{ p: 3, textAlign: "center", borderColor: "primary.main" }}
+        >
+          <Stack spacing={1.5} alignItems="center">
+            <Typography variant="body2" color="text.secondary">
+              {serverVersion ? `Ready · ccp4i2 ${serverVersion}` : "Ready to go"}
             </Typography>
-          )}
-        </Stack>
-      </Paper>
+            <Button
+              variant="contained"
+              size="large"
+              startIcon={
+                launching ? (
+                  <CircularProgress size={18} color="inherit" />
+                ) : (
+                  <RocketLaunch />
+                )
+              }
+              onClick={onEnter}
+              disabled={launching}
+              sx={{ minWidth: 220 }}
+            >
+              {launching ? "Starting…" : "Enter CCP4i2"}
+            </Button>
+          </Stack>
+        </Paper>
+      ) : (
+        <Alert severity="info" icon={false}>
+          <Typography fontWeight={600} sx={{ mb: 0.5 }}>
+            A little setup first
+          </Typography>
+          <Stack component="ul" sx={{ m: 0, pl: 2.5 }} spacing={0.25}>
+            {blockers.map((b) => (
+              <li key={b}>
+                <Typography variant="body2">{b}</Typography>
+              </li>
+            ))}
+          </Stack>
+        </Alert>
+      )}
 
+      {/* Setup detail — collapsed when all is well, open when it isn't. */}
       {config && (
-        <>
-          {/* File Paths - Compact table format */}
-          <Paper variant="outlined" sx={{ p: 1.5 }}>
-            <Typography variant="subtitle2" color="primary" fontWeight={600} sx={{ mb: 1 }}>
-              Configuration
+        <Accordion
+          expanded={setupOpen}
+          onChange={(_, v) => setSetupOpen(v)}
+          variant="outlined"
+          disableGutters
+          sx={{ "&:before": { display: "none" }, borderRadius: 1 }}
+        >
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography variant="subtitle2" fontWeight={600}>
+              Setup
             </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
             <Stack spacing={1}>
-              {/* CCP4 Directory */}
-              <Stack direction="row" alignItems="center" spacing={1}>
-                {existingFiles?.CCP4Dir ? (
-                  <Check color="success" fontSize="small" />
-                ) : (
-                  <Cancel color="error" fontSize="small" />
-                )}
-                <Typography variant="body2" sx={{ minWidth: 100, fontWeight: 500 }}>
-                  CCP4 Dir
-                </Typography>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{
-                    flex: 1,
-                    fontFamily: "monospace",
-                    fontSize: "0.75rem",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {config.CCP4Dir}
-                </Typography>
-                <Button
-                  size="small"
-                  onClick={onLaunchBrowser}
-                  disabled={!(typeof window !== "undefined" && window.electronAPI)}
-                >
-                  Change
-                </Button>
-              </Stack>
-
-              {/* Python */}
-              <Stack direction="row" alignItems="center" spacing={1}>
-                {existingFiles?.venv_python ? (
-                  <Check color="success" fontSize="small" />
-                ) : (
-                  <Cancel color="error" fontSize="small" />
-                )}
-                <Typography variant="body2" sx={{ minWidth: 100, fontWeight: 500 }}>
-                  Python
-                </Typography>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{
-                    flex: 1,
-                    fontFamily: "monospace",
-                    fontSize: "0.75rem",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {config.venv_python || "Not found"}
-                </Typography>
-              </Stack>
-
-              {/* Projects Directory */}
-              <Stack direction="row" alignItems="center" spacing={1}>
-                {existingFiles?.CCP4I2_PROJECTS_DIR ? (
-                  <Check color="success" fontSize="small" />
-                ) : (
-                  <Cancel color="error" fontSize="small" />
-                )}
-                <Typography variant="body2" sx={{ minWidth: 100, fontWeight: 500 }}>
-                  Projects
-                </Typography>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{
-                    flex: 1,
-                    fontFamily: "monospace",
-                    fontSize: "0.75rem",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {config.CCP4I2_PROJECTS_DIR}
-                </Typography>
-                <Button
-                  size="small"
-                  onClick={onSelectProjectsDir}
-                  disabled={!(typeof window !== "undefined" && window.electronAPI)}
-                >
-                  Change
-                </Button>
-              </Stack>
-
-              {/* Requirements */}
-              <Stack direction="row" alignItems="center" spacing={1}>
-                {requirementsExist ? (
-                  <Check color="success" fontSize="small" />
-                ) : (
-                  <Cancel color="error" fontSize="small" />
-                )}
-                <Typography variant="body2" sx={{ minWidth: 100, fontWeight: 500 }}>
-                  Requirements
-                </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
-                  {requirementsExist
+              <SetupRow
+                ok={existingFiles?.CCP4Dir}
+                label="CCP4"
+                value={config.CCP4Dir}
+                action={hasElectron ? { label: "Change", onClick: onLocateCcp4 } : undefined}
+              />
+              <SetupRow
+                ok={existingFiles?.venv_python}
+                label="Python"
+                value={config.venv_python || "Not found"}
+              />
+              <SetupRow
+                ok={existingFiles?.CCP4I2_PROJECTS_DIR}
+                label="Projects"
+                value={config.CCP4I2_PROJECTS_DIR}
+                action={
+                  hasElectron
+                    ? { label: "Change", onClick: onSelectProjectsDir }
+                    : undefined
+                }
+              />
+              <SetupRow
+                ok={requirementsExist}
+                label="Requirements"
+                value={
+                  requirementsExist
                     ? serverVersion
                       ? `ccp4i2 ${serverVersion}`
                       : "Installed"
-                    : "Not installed"}
+                    : "Not installed"
+                }
+                action={
+                  hasElectron
+                    ? {
+                        label: requirementsExist ? "Reinstall" : "Install",
+                        onClick: onInstallRequirements,
+                        variant: requirementsExist ? "text" : "contained",
+                        disabled: !existingFiles?.venv_python,
+                      }
+                    : undefined
+                }
+              />
+
+              <Stack
+                direction="row"
+                spacing={2}
+                alignItems="center"
+                justifyContent="space-between"
+                sx={{ pt: 1 }}
+              >
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="body2">Theme</Typography>
+                  <ThemeToggle />
+                </Stack>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="body2">Developer mode</Typography>
+                  <Switch
+                    size="small"
+                    checked={devMode}
+                    onChange={onToggleDevMode}
+                    disabled={!hasElectron}
+                  />
+                </Stack>
+                <Typography variant="caption" color="text.secondary">
+                  Ports {config.NEXT_PORT} / {config.UVICORN_PORT}
                 </Typography>
-                <Button
-                  size="small"
-                  variant={requirementsExist ? "text" : "contained"}
-                  onClick={onInstallRequirements}
-                  disabled={
-                    !(typeof window !== "undefined" && window.electronAPI) ||
-                    !existingFiles?.venv_python
-                  }
-                >
-                  {requirementsExist ? "Reinstall" : "Install"}
-                </Button>
               </Stack>
             </Stack>
-          </Paper>
-
-          {/* Settings Row - Theme, Dev Mode, Ports */}
-          <Stack direction="row" spacing={1.5}>
-            {/* Theme */}
-            <Paper variant="outlined" sx={{ p: 1.5, flex: 1 }}>
-              <Stack direction="row" alignItems="center" justifyContent="space-between">
-                <Typography variant="body2" fontWeight={500}>
-                  Theme
-                </Typography>
-                <ThemeToggle />
-              </Stack>
-            </Paper>
-
-            {/* Dev Mode */}
-            <Paper variant="outlined" sx={{ p: 1.5, flex: 1 }}>
-              <Stack direction="row" alignItems="center" justifyContent="space-between">
-                <Typography variant="body2" fontWeight={500}>
-                  Dev Mode
-                </Typography>
-                <Switch
-                  size="small"
-                  checked={devMode}
-                  onChange={onToggleDevMode}
-                  disabled={!(typeof window !== "undefined" && window.electronAPI)}
-                />
-              </Stack>
-            </Paper>
-
-            {/* Ports */}
-            <Paper variant="outlined" sx={{ p: 1.5, flex: 1 }}>
-              <Stack direction="row" alignItems="center" justifyContent="space-between">
-                <Typography variant="body2" fontWeight={500}>
-                  Ports
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {config.NEXT_PORT} / {config.UVICORN_PORT}
-                </Typography>
-              </Stack>
-            </Paper>
-          </Stack>
-        </>
+          </AccordionDetails>
+        </Accordion>
       )}
 
-      {/* Minimal config when no electron config */}
+      {/* Web mode (no electron config): just a theme control. */}
       {!config && (
-        <Paper variant="outlined" sx={{ p: 1.5 }}>
-          <Stack direction="row" alignItems="center" justifyContent="space-between">
-            <Typography variant="body2" fontWeight={500}>
-              Theme
-            </Typography>
-            <ThemeToggle />
-          </Stack>
-        </Paper>
+        <Stack direction="row" spacing={1} alignItems="center" justifyContent="center">
+          <Typography variant="body2">Theme</Typography>
+          <ThemeToggle />
+        </Stack>
       )}
 
-      {/* Installation Progress Dialog */}
+      {/* Install progress. */}
       <Dialog
         open={
           installProgress.isInstalling ||
@@ -462,10 +370,10 @@ export const ConfigContent: React.FC = () => {
       >
         <DialogTitle>
           {installProgress.status === "completed"
-            ? "Installation Complete"
+            ? "Requirements installed"
             : installProgress.status === "failed"
-              ? "Installation Failed"
-              : "Installing Requirements"}
+              ? "Installation failed"
+              : "Installing requirements"}
           {installProgress.status === "installing" && (
             <CircularProgress size={20} sx={{ ml: 2 }} />
           )}
@@ -484,17 +392,13 @@ export const ConfigContent: React.FC = () => {
             }}
           >
             {installProgress.output.length === 0 ? (
-              <Typography>Initializing installation...</Typography>
+              <Typography>Initializing…</Typography>
             ) : (
-              installProgress.output.map((line, index) => (
+              installProgress.output.map((line, i) => (
                 <Typography
-                  key={index}
+                  key={i}
                   component="pre"
-                  sx={{
-                    m: 0,
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                  }}
+                  sx={{ m: 0, whiteSpace: "pre-wrap", wordBreak: "break-word" }}
                 >
                   {line}
                 </Typography>
@@ -517,3 +421,50 @@ export const ConfigContent: React.FC = () => {
     </Stack>
   );
 };
+
+const SetupRow: React.FC<{
+  ok: boolean | undefined;
+  label: string;
+  value: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+    variant?: "text" | "contained" | "outlined";
+    disabled?: boolean;
+  };
+}> = ({ ok, label, value, action }) => (
+  <Stack direction="row" alignItems="center" spacing={1}>
+    {ok ? (
+      <Check color="success" fontSize="small" />
+    ) : (
+      <Cancel color="error" fontSize="small" />
+    )}
+    <Typography variant="body2" sx={{ minWidth: 96, fontWeight: 500 }}>
+      {label}
+    </Typography>
+    <Typography
+      variant="body2"
+      color="text.secondary"
+      sx={{
+        flex: 1,
+        fontFamily: "monospace",
+        fontSize: "0.75rem",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {value}
+    </Typography>
+    {action && (
+      <Button
+        size="small"
+        variant={action.variant}
+        onClick={action.onClick}
+        disabled={action.disabled}
+      >
+        {action.label}
+      </Button>
+    )}
+  </Stack>
+);

--- a/client/renderer/components/launch-gate.tsx
+++ b/client/renderer/components/launch-gate.tsx
@@ -1,0 +1,86 @@
+"use client";
+import React from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Fade,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { ErrorOutline, Science } from "@mui/icons-material";
+import { useServerReady } from "@/hooks/use-server-ready";
+
+/**
+ * Waits for the backend to be reachable before rendering its children.
+ *
+ * This closes the gap where the app used to redirect to the projects list the
+ * instant the server process was spawned — before it could answer — causing a
+ * first-launch flicker or a transient "couldn't load projects". Instead we show
+ * a calm "Starting CCP4i2…" state and only reveal the app once /health responds.
+ */
+export const LaunchGate: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { status, attempts, retry } = useServerReady({
+    intervalMs: 1000,
+    timeoutMs: 60_000,
+  });
+
+  if (status === "ready") {
+    return <Fade in>{<Box sx={{ height: "100%" }}>{children}</Box>}</Fade>;
+  }
+
+  return (
+    <Stack
+      alignItems="center"
+      justifyContent="center"
+      spacing={3}
+      sx={{ height: "100vh", px: 3, textAlign: "center" }}
+    >
+      {status === "checking" ? (
+        <>
+          <Box sx={{ position: "relative", display: "grid", placeItems: "center" }}>
+            <CircularProgress size={72} thickness={2.5} />
+            <Science
+              sx={{
+                position: "absolute",
+                fontSize: 32,
+                color: "primary.main",
+              }}
+            />
+          </Box>
+          <Stack spacing={0.5}>
+            <Typography variant="h5" fontWeight={600}>
+              Starting CCP4i2…
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Bringing the crystallographic backend online
+            </Typography>
+          </Stack>
+          {attempts > 5 && (
+            <Typography variant="caption" color="text.secondary">
+              Still starting — this can take a moment on first launch.
+            </Typography>
+          )}
+        </>
+      ) : (
+        <>
+          <ErrorOutline sx={{ fontSize: 56, color: "warning.main" }} />
+          <Stack spacing={0.5}>
+            <Typography variant="h5" fontWeight={600}>
+              CCP4i2 didn&apos;t start
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 420 }}>
+              The backend server hasn&apos;t responded. It may still be installing,
+              or the setup may need attention.
+            </Typography>
+          </Stack>
+          <Button variant="contained" onClick={retry}>
+            Try again
+          </Button>
+        </>
+      )}
+    </Stack>
+  );
+};

--- a/client/renderer/components/welcome-chooser.tsx
+++ b/client/renderer/components/welcome-chooser.tsx
@@ -1,0 +1,125 @@
+"use client";
+import React from "react";
+import { useRouter } from "next/navigation";
+import {
+  Box,
+  Card,
+  CardActionArea,
+  Container,
+  Stack,
+  Typography,
+  alpha,
+} from "@mui/material";
+import {
+  Add,
+  Upload,
+  SettingsBackupRestore,
+  ChevronRight,
+} from "@mui/icons-material";
+import { useAuth } from "@/lib/compounds/auth-context";
+
+/**
+ * First-project welcome. Shown whenever the database has no projects — which is
+ * the genuine "nothing here yet" state, whether that's a brand-new install or a
+ * migration that failed / a projects directory that was rolled back. It is not a
+ * one-shot: if the user ends up back at zero projects, they see it again.
+ *
+ * Names the ways in rather than assuming the user knows where to look. Uses the
+ * same routes as the projects toolbar, so there's one source of truth for each
+ * path.
+ */
+
+interface Path {
+  key: string;
+  title: string;
+  detail: string;
+  icon: React.ReactNode;
+  route: string;
+  primary?: boolean;
+  adminOnly?: boolean;
+}
+
+const PATHS: Path[] = [
+  {
+    key: "new",
+    title: "Start a new project",
+    detail: "An empty project to set up and run jobs in.",
+    icon: <Add />,
+    route: "/ccp4i2/new-project",
+    primary: true,
+  },
+  {
+    key: "import",
+    title: "Import a project",
+    detail: "Load a project shared as a CCP4i2 project zip.",
+    icon: <Upload />,
+    route: "/ccp4i2/import-project",
+  },
+  {
+    key: "migrate",
+    title: "Migrate a legacy CCP4i2",
+    detail: "Bring in projects from an existing ~/.CCP4I2 database.",
+    icon: <SettingsBackupRestore />,
+    route: "/ccp4i2/admin/migrate-legacy",
+    adminOnly: true,
+  },
+];
+
+export const WelcomeChooser: React.FC = () => {
+  const router = useRouter();
+  const { canAdminister } = useAuth();
+
+  const paths = PATHS.filter((p) => !p.adminOnly || canAdminister);
+
+  return (
+    <Container maxWidth="sm" sx={{ py: { xs: 4, sm: 8 } }}>
+      <Stack spacing={1} sx={{ mb: 4, textAlign: "center" }}>
+        <Typography variant="h4" fontWeight={600}>
+          Welcome to CCP4i2
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          There are no projects here yet. How would you like to begin?
+        </Typography>
+      </Stack>
+
+      <Stack spacing={1.5}>
+        {paths.map((p) => (
+          <Card
+            key={p.key}
+            variant="outlined"
+            sx={{
+              borderColor: p.primary ? "primary.main" : "divider",
+              bgcolor: p.primary ? "action.hover" : undefined,
+            }}
+          >
+            <CardActionArea onClick={() => router.push(p.route)} sx={{ p: 2 }}>
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Box
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: 1.5,
+                    flex: "none",
+                    display: "grid",
+                    placeItems: "center",
+                    color: "primary.main",
+                    bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+                  }}
+                >
+                  {p.icon}
+                </Box>
+                <Box sx={{ flex: 1 }}>
+                  <Typography fontWeight={600}>{p.title}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {p.detail}
+                  </Typography>
+                </Box>
+                <ChevronRight color="action" />
+              </Stack>
+            </CardActionArea>
+          </Card>
+        ))}
+      </Stack>
+    </Container>
+  );
+};

--- a/client/renderer/hooks/use-server-ready.ts
+++ b/client/renderer/hooks/use-server-ready.ts
@@ -1,0 +1,88 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Poll the backend /health endpoint until it answers, so the UI can wait for the
+ * Django/uvicorn server to actually be up rather than racing it.
+ *
+ * The health endpoint (api/ccp4i2/health/) is public (no auth) and returns 200
+ * when the DB connection is live, 503 otherwise. It is reachable in both Electron
+ * and web via the Next proxy, so we don't need the raw uvicorn port.
+ *
+ * Phases:
+ *   "checking" — a probe is in flight or scheduled
+ *   "ready"    — the server answered healthy
+ *   "timeout"  — gave up after `timeoutMs` without a healthy response
+ */
+export type ServerReadyStatus = "checking" | "ready" | "timeout";
+
+const HEALTH_URL = "/api/proxy/ccp4i2/health/";
+
+export function useServerReady(options?: {
+  intervalMs?: number;
+  timeoutMs?: number;
+  enabled?: boolean;
+}) {
+  const intervalMs = options?.intervalMs ?? 1000;
+  const timeoutMs = options?.timeoutMs ?? 60_000;
+  const enabled = options?.enabled ?? true;
+
+  const [status, setStatus] = useState<ServerReadyStatus>("checking");
+  const [attempts, setAttempts] = useState(0);
+  // Bumped by retry() to restart the polling loop.
+  const [nonce, setNonce] = useState(0);
+
+  const retry = useCallback(() => {
+    setAttempts(0);
+    setStatus("checking");
+    setNonce((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const startedAt = Date.now(); // browser Date is fine here
+
+    const probe = async (): Promise<boolean> => {
+      try {
+        const res = await fetch(HEALTH_URL, {
+          method: "GET",
+          cache: "no-store",
+          headers: { Accept: "application/json" },
+        });
+        return res.ok;
+      } catch {
+        return false; // network error while the server is still coming up
+      }
+    };
+
+    const tick = async () => {
+      if (cancelled) return;
+      const ok = await probe();
+      if (cancelled) return;
+
+      if (ok) {
+        setStatus("ready");
+        return;
+      }
+      setAttempts((n) => n + 1);
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        setStatus("timeout");
+        return;
+      }
+      timer = setTimeout(tick, intervalMs);
+    };
+
+    tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [enabled, intervalMs, timeoutMs, nonce]);
+
+  return { status, attempts, retry };
+}

--- a/client/renderer/middleware.ts
+++ b/client/renderer/middleware.ts
@@ -20,7 +20,13 @@ import type { NextRequest } from "next/server";
 
 // Paths that don't require authentication
 const AUTH_EXEMPT_PATHS = [
-  "/api/health", // Health check for Azure Container Apps probes
+  "/api/health", // Next-side liveness check for Azure Container Apps probes
+  "/api/proxy/ccp4i2/health", // Django backend READINESS probe (LaunchGate /
+                              // useServerReady). Polled before login and before
+                              // the backend is up, so it must reach the proxy
+                              // without an auth-session cookie. The Django
+                              // health_check view is itself unauthenticated.
+                              // (Same rationale as /reinspect/healthz below.)
   "/api/auth/", // Auth session API (cookie management)
   "/api/proxy/uniprot/", // UniProt REST API proxy (public data)
   "/auth/login", // Login page that triggers MSAL

--- a/packages/ccp4i2-api/ccp4i2_api/middleware/base.py
+++ b/packages/ccp4i2-api/ccp4i2_api/middleware/base.py
@@ -20,6 +20,20 @@ from ..exceptions import AuthenticationFailed, AuthorizationFailed
 REQUEST_FLAG_ATTR = "_ccp4i2_api_middleware_ran"
 
 
+# Public endpoints that must be reachable WITHOUT authentication. These are
+# unauthenticated by design (plain Django views, no DRF permissions):
+#   * health  — liveness/readiness probe. Polled by container orchestrators and
+#               by the desktop launch gate before any token exists.
+#   * version — server version, fetched before login.
+# Matched against the request path suffix so it works under any URL prefix
+# (``/api/ccp4i2/health/`` in-app, ``/health/`` if mounted bare).
+PUBLIC_PATH_SUFFIXES = ("/health/", "/health", "/version/", "/version")
+
+
+def _is_public_path(path: str) -> bool:
+    return path.endswith(PUBLIC_PATH_SUFFIXES)
+
+
 class BaseAuthMiddleware:
     """Abstract base for CCP4i2 auth middleware.
 
@@ -42,6 +56,11 @@ class BaseAuthMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         if not self.is_active():
+            return self.get_response(request)
+        # Public probes (health/version) are unauthenticated by design and must
+        # be reachable without a token — container liveness/readiness checks and
+        # the desktop launch gate poll them before any credential exists.
+        if _is_public_path(request.path):
             return self.get_response(request)
         try:
             user = self.authenticate(request)


### PR DESCRIPTION
Replaces the two disjoint launch surfaces — an installer-style Config page and a bare projects empty-state, with **no readiness check between them** — with one coherent, environment-aware flow. Design was signed off before build.

## Phase A — readiness gate
Closes the gap where the UI redirected to the projects list the instant the server *process* spawned, before it could answer (first-launch flicker / transient "couldn't load projects").
- `hooks/use-server-ready.ts` — poll the public `/health` endpoint until Django answers (`checking → ready | timeout`, with retry).
- `components/launch-gate.tsx` — a calm "Starting CCP4i2…" state that reveals the app only once the server is up.

## Phase B — first-project welcome
- `components/welcome-chooser.tsx` — shown whenever the DB has **zero projects**, keyed on **live state, not a one-shot flag**. So a failed migration or a rolled-back projects directory that leaves the user back at zero projects surfaces the welcome again — the requested return mechanism. Names the three ways in (New / Import / Migrate legacy; Migrate gated on `canAdminister`). Replaces the "No projects found" empty-state.
- `(authed)/page.tsx` — wrapped in `LaunchGate`; empty DB → `WelcomeChooser`.

## Phase C — Config as "get ready", not an installer
- `config/page.tsx` + `config-content.tsx` — reframed to a single "get into your work" screen. When ready, setup detail collapses and one **Enter CCP4i2** action launches; when something's missing, it says what to fix in plain words and opens the setup section. All Electron IPC/lifecycle logic preserved.
- **Strips desktop web-isms:** removed the Teams Integration Diagnostic accordion and the Authentication status chip. On the desktop CCP4i2 is single-user — no teams / auth / accounts chrome. (`teams-diagnostic.tsx` is now unused; left in place for any web/Teams deployment use.)

## Decisions (from the signed-off design)
- Welcome lives inside `/ccp4i2`, gated on empty DB (no new endpoint — reuses `api.get("projects")`).
- Desktop-first; the web app-selector is untouched this pass.
- Environment-aware: teams/auth language hidden on desktop, shown only against a web backend with real auth.

## Verified
Renderer typechecks clean (only a pre-existing unrelated test error). `next dev` compiles `/ccp4i2/config` and `/ccp4i2` to 200; the config page shows the new framing with **no** Teams/Auth chrome; the projects page shows the Starting-CCP4i2 gate. Not yet driven end-to-end against a live Electron backend — the phases render correctly in the browser; full Electron click-through is the next verification (and the alpha users will exercise it live).

Follows the legacy-migration work (#239) — the welcome's "Migrate legacy" path routes into that wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)