### PR TITLE
Toolbar/menu honesty pass + Export MTZ & Bibliography design plans

### DIFF
--- a/client/renderer/components/edit-menu.tsx
+++ b/client/renderer/components/edit-menu.tsx
@@ -9,12 +9,14 @@ import {
   Typography,
 } from "@mui/material";
 import { Search, Settings } from "@mui/icons-material";
+import { useRouter } from "next/navigation";
 import { useFindInPage } from "../providers/find-in-page-provider";
 
 export default function EditMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const findInPage = useFindInPage();
+  const router = useRouter();
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -25,6 +27,11 @@ export default function EditMenu() {
   const handleFind = () => {
     handleClose();
     findInPage?.open();
+  };
+
+  const handlePreferences = () => {
+    handleClose();
+    router.push("/ccp4i2/config");
   };
 
   return (
@@ -42,7 +49,7 @@ export default function EditMenu() {
             ({typeof navigator !== "undefined" && navigator?.platform?.includes("Mac") ? "\u2318" : "Ctrl+"}F)
           </Typography>
         </MenuItem>
-        <MenuItem onClick={handleClose}>
+        <MenuItem onClick={handlePreferences}>
           <ListItemIcon>
             <Settings fontSize="small" />
           </ListItemIcon>

--- a/client/renderer/components/file-menu.tsx
+++ b/client/renderer/components/file-menu.tsx
@@ -160,18 +160,9 @@ export default function FileMenu() {
                 {project.name} - {`${new Date(project.last_access)}`}
               </MenuItem>
             ))}
-        <MenuItem key="MoreProjects" onClick={handleClose}>
-          More Projects
-        </MenuItem>
         <Divider />
-        <MenuItem key="CCP4i" onClick={handleClose}>
-          View old CCP4i projects
-        </MenuItem>
         <MenuItem key="Browser" onClick={handleBrowser}>
           Browser
-        </MenuItem>
-        <MenuItem key="Quit" onClick={handleClose}>
-          Quit CCP4i2
         </MenuItem>
       </Menu>
 

--- a/client/renderer/components/help-menu.tsx
+++ b/client/renderer/components/help-menu.tsx
@@ -1,23 +1,60 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Link,
   ListItemIcon,
   ListItemText,
   Menu,
   MenuItem,
+  Stack,
   Typography,
 } from "@mui/material";
-import { Help, PlayCircle } from "@mui/icons-material";
+import { Help, Info, MenuBook } from "@mui/icons-material";
+
+const CCP4I2_HELP_URL = "https://www.ccp4.ac.uk/html/ccp4i2.html";
+
+interface VersionInfo {
+  web?: { buildTimestamp?: string; gitCommit?: string };
+}
 
 export default function HelpMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
+  const [aboutOpen, setAboutOpen] = useState(false);
+  const [version, setVersion] = useState<VersionInfo | null>(null);
+
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  // Fetch build info once the About dialog is first opened.
+  useEffect(() => {
+    if (aboutOpen && !version) {
+      fetch("/api/version")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => data && setVersion(data))
+        .catch(() => {
+          /* build info is best-effort */
+        });
+    }
+  }, [aboutOpen, version]);
+
+  const handleAbout = () => {
+    handleClose();
+    setAboutOpen(true);
+  };
+
+  const handleHelp = () => {
+    handleClose();
+    window.open(CCP4I2_HELP_URL, "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -26,31 +63,66 @@ export default function HelpMenu() {
         Help/Tutorials
       </Button>
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        <MenuItem onClick={handleClose}>About</MenuItem>
-        <MenuItem onClick={handleClose}>Tutorials</MenuItem>
-        <MenuItem onClick={handleClose}>Quickstart - 10 minute intro</MenuItem>
-        <MenuItem onClick={handleClose}>
-          Quick expert - more quick hints
-        </MenuItem>
-        <MenuItem onClick={handleClose}>
+        <MenuItem onClick={handleHelp}>
           <ListItemIcon>
-            <PlayCircle fontSize="small" />
+            <MenuBook fontSize="small" />
           </ListItemIcon>
-          <ListItemText>View YouTube video</ListItemText>
-        </MenuItem>
-        <MenuItem>Task documentation</MenuItem>
-        <MenuItem>Task info from ccp4i2</MenuItem>
-        <MenuItem>
-          <ListItemIcon>
-            <Help fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>CCP4i2 Help</ListItemText>
+          <ListItemText>CCP4i2 documentation</ListItemText>
           <Typography variant="body2" color="textSecondary">
             (F1)
           </Typography>
         </MenuItem>
-        <MenuItem>Tips of the day</MenuItem>
+        <MenuItem onClick={handleAbout}>
+          <ListItemIcon>
+            <Info fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>About CCP4i2</ListItemText>
+        </MenuItem>
       </Menu>
+
+      <Dialog
+        open={aboutOpen}
+        onClose={() => setAboutOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Help color="primary" />
+          About CCP4i2
+        </DialogTitle>
+        <DialogContent>
+          <Stack spacing={1.5} sx={{ pt: 1 }}>
+            <Typography variant="body1">
+              CCP4i2 &mdash; a graphical environment for crystallographic
+              computing.
+            </Typography>
+            {version?.web?.buildTimestamp &&
+              version.web.buildTimestamp !== "dev" && (
+                <Typography variant="body2" color="text.secondary">
+                  <strong>Build:</strong> {version.web.buildTimestamp}
+                </Typography>
+              )}
+            {version?.web?.gitCommit &&
+              version.web.gitCommit !== "unknown" && (
+                <Typography variant="body2" color="text.secondary">
+                  <strong>Commit:</strong> {version.web.gitCommit}
+                </Typography>
+              )}
+            <Typography variant="body2" color="text.secondary">
+              <Link
+                href="https://www.ccp4.ac.uk"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                www.ccp4.ac.uk
+              </Link>
+            </Typography>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAboutOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/client/renderer/components/util-menu.tsx
+++ b/client/renderer/components/util-menu.tsx
@@ -1,24 +1,17 @@
 "use client";
 import { useCallback, useState } from "react";
 import { Button, Menu, MenuItem } from "@mui/material";
-import { useRouter } from "next/navigation";
 import { useRunningProcesses } from "../providers/running-processes";
 
 export default function UtilMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { jobsAndProcessesDialogOpen, setJobsAndProcessesDialogOpen } =
-    useRunningProcesses();
-  const router = useRouter();
+  const { setJobsAndProcessesDialogOpen } = useRunningProcesses();
   const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
   const handleClose = () => {
     setAnchorEl(null);
-  };
-  const handleSystemAdministratorToolsClick = () => {
-    router.push("/ccp4i2/config");
-    handleClose();
   };
   const handleRunningJobsClick = useCallback(async () => {
     setJobsAndProcessesDialogOpen(true);
@@ -31,16 +24,9 @@ export default function UtilMenu() {
         Utilities
       </Button>
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        <MenuItem onClick={handleClose}>Copy demo data to project</MenuItem>
         <MenuItem onClick={handleRunningJobsClick}>
-          Running jobs and processes {`${jobsAndProcessesDialogOpen}`}
+          Running jobs and processes
         </MenuItem>
-        <MenuItem onClick={handleClose}>Manage imported files</MenuItem>
-        <MenuItem onClick={handleClose}>Send error report</MenuItem>
-        <MenuItem onClick={handleSystemAdministratorToolsClick}>
-          System administrator tools
-        </MenuItem>
-        <MenuItem onClick={handleClose}>Developer tools</MenuItem>
       </Menu>
     </>
   );

--- a/docs/BIBLIOGRAPHY_PLAN.md
+++ b/docs/BIBLIOGRAPHY_PLAN.md
@@ -1,0 +1,95 @@
+# Bibliography — design & wiring plan
+
+Status: **design, not yet implemented** (2026-07-10, `django` branch).
+
+The job-panel toolbar (`client/renderer/components/tool-bar.tsx`) has a
+**Bibliography** button that is currently a no-op (`onClick: () => {}`). This doc
+captures the truth about how bibliographic references already flow into reports,
+and the plan to expose them on demand (modally) at job and project scope.
+
+## The truth: references already power task reports
+
+Every task report already renders a bibliography via the report metadata layer:
+
+```python
+# server/ccp4i2/report/core.py (add-standard-sections)
+from ccp4i2.report.metadata import ReferenceGroup
+referenceGroup = ReferenceGroup()
+referenceGroup.loadFromMedLine(self.TASKNAME)   # <- the mechanism
+```
+
+`ReferenceGroup.loadFromMedLine(taskName)`
+(`server/ccp4i2/report/metadata.py:214`) reads:
+
+```
+I2_TOP / "references" / f"{taskName}.medline.txt"
+```
+
+and parses **MedLine** format (`PMID- / TI - / SO - / AU - / URL -`) into
+`Reference` objects (`articleTitle`, `authorList`, `source`, `articleLink`).
+
+- **34 `*.medline.txt` files** live in `server/ccp4i2/references/` — this is the
+  live, working source of truth used by every report today.
+- There is a **second, partly-redundant** source: per-plugin
+  `*.bibtex.txt` / `*.bibtxt.txt` files in the wrapper/pipeline `script/` dirs
+  (22 files, BibTeX-with-PMIDs). These are **not** what `loadFromMedLine` reads.
+  For this feature we standardise on the **MedLine `references/` dir** (the one
+  reports actually consume); the bibtex files are a legacy parallel we can
+  reconcile later, not depend on.
+- The `CBibReference*` container classes in `core/CCP4Annotation.py` are **empty
+  stubs** on this branch — ignore them; the report `metadata.ReferenceGroup` is
+  the real machinery.
+
+## Scope semantics (per the toolbar context)
+
+The button lives on the job panel but should also work project-scoped:
+
+| Context | Bibliography returned |
+|---------|-----------------------|
+| **Job selected** | Union of references for the job's `task_name` **+ all subjobs** (`Job.children`, recursively). This is the honest bibliography of what actually ran. |
+| **Job + progenitors** *(optional richer mode)* | Also include tasks of `FileUse`-linked input progenitors (walk the input side of the `FileUse` graph). Gives "everything that contributed to this result." |
+| **Project scope (no job)** | Union over the `task_name` of **all jobs in the project** → compiled project bibliography. |
+
+Model facts that make this expressible (`server/ccp4i2/db/models.py`):
+- `Job.parent` / `Job.children` (subjobs, numbered `1.1`) — for subjob burrowing.
+- `FileUse(file, job, role)` with `Role` (input/output) — for progenitor walking.
+  `JobViewSet.dependent_jobs` already walks the *forward* (consumer) direction;
+  progenitors are the reverse (input-role) walk.
+
+## Plan
+
+1. **`lib/utils/jobs/bibliography.py`** (new) — pure, report-free helper:
+   - `references_for_tasks(task_names: set[str]) -> list[dict]`: call
+     `ReferenceGroup.loadFromMedLine` per task, collect `Reference` objects,
+     dedupe (by PMID / title), return plain dicts
+     (`title`, `authors[]`, `source`, `link`).
+   - `task_names_for_job(job, include_subjobs=True, include_progenitors=False)`.
+   - `task_names_for_project(project)`.
+2. **API** on `JobViewSet` / `ProjectViewSet`:
+   - `GET /api/jobs/{id}/bibliography/?progenitors=0|1` → job (+subjobs
+     [+progenitors]) references.
+   - `GET /api/projects/{id}/bibliography/` → compiled project references.
+   - Return structured JSON (not rendered HTML) so the modal owns presentation.
+3. **Frontend** — `tool-bar.tsx`:
+   - Wire the Bibliography button to open a **modal** listing references
+     (title, authors, source, clickable DOI/PubMed link).
+   - When a job is selected → job endpoint; when project-scoped → project
+     endpoint. Optionally a toggle for "include progenitors".
+   - Reuse an existing MUI `Dialog` pattern (cf. the `I2RunDialog` /
+     export-success dialog) for consistency.
+
+## Notes / open questions
+
+- **Missing `references/{task}.medline.txt`**: `loadFromMedLine` appends error
+  code 100 and returns empty — treat as "no refs for this task", don't fail the
+  whole request.
+- Reconcile the **bibtex vs medline** duplication eventually (single source);
+  out of scope for the first wiring.
+- Dedup key: prefer PMID where present; fall back to normalised title.
+- This shares its shape with Export MTZ: *call plugin/report metadata via a
+  server util, expose through an endpoint, render in a frontend modal.*
+
+## Implementation note
+
+Per agreed plan, **Bibliography is implemented in a separate conversation** to
+keep context parsimonious; this doc is the handoff.

--- a/docs/EXPORT_MTZ_PLAN.md
+++ b/docs/EXPORT_MTZ_PLAN.md
@@ -1,0 +1,136 @@
+# Export MTZ — design & wiring plan
+
+Status: **design, not yet implemented** (2026-07-10, `django` branch).
+
+The job-panel toolbar (`client/renderer/components/tool-bar.tsx`) has an **Export
+MTZ** button that is currently a no-op (`onClick: () => {}`), gated by a
+misleading blanket `job.status === 6` check. This doc captures the truth we
+discovered about how MTZ export *should* work, and the plan to wire it.
+
+## The pre-existing per-plugin contract
+
+Some plugin scripts already declare how to export their MTZ, via two
+**module-level functions** (a legacy Qt-era contract, never re-wired after the
+Django move):
+
+```python
+def exportJobFileMenu(jobId=None):
+    # -> [[mode, label, mimeType], ...]
+    return [['complete_mtz', 'MTZ file', 'application/CCP4-mtz']]
+
+def exportJobFile(jobId=None, mode=None, fileInfo={}):
+    # -> absolute path to the file to serve
+    ...
+```
+
+**6 tasks implement it** (`grep -rl "def exportJobFileMenu"`):
+`aimless_pipe`, `import_merged`, `servalcat_pipe`, `prosmart_refmac`, `parrot`,
+`AlternativeImportXIA2`.
+
+They fall into two behaviours:
+
+| Kind | Tasks | What `exportJobFile` returns |
+|------|-------|------------------------------|
+| **Locator** | `servalcat_pipe`, `prosmart_refmac` | The **natural, never-split** output — burrows into child jobs and returns `refined.mtz` / `hklout.mtz` as-is. |
+| **Reconstructor** | `aimless_pipe`, `import_merged` | A **catenation** — there is no single natural file, so it recombines subjob outputs (ctruncate intensities/amplitudes + FreeR column) via `runCad` into a fresh `exportMtz.mtz`, with intensity-vs-amplitude logic and FreeR-as-base-dataset handling. |
+
+`parrot` / `AlternativeImportXIA2` are further locator-style variants.
+
+### Design principle: natural unsplit file first
+
+The priority within any job is:
+
+1. **Serve the natural unsplit output** where one genuinely exists (locator
+   tasks, and the generic fallback below). Lossless, no recombination.
+2. **Reconstruct** only where the data was genuinely produced across subjobs and
+   there is no single file (import/scaling pipelines). Reconstruction is the
+   *correct* answer there, not a compromise.
+3. **Generic fallback** for any task that declares nothing: offer the job's
+   tracked output-MTZ `File`(s) directly (still natural, just not task-curated).
+   Button **hidden** only when there is genuinely no MTZ to export.
+
+## What already exists (reuse, don't rebuild)
+
+- **API routes** in `server/ccp4i2/api/JobViewSet.py`:
+  - `export_job_file_menu` (`GET /api/jobs/{id}/export_job_file_menu/`) — **stub**:
+    hardcoded to log "not available" and return `[]`.  *(the reason the button
+    is dead)*
+  - `export_job_file` (`GET /api/jobs/{id}/export_job_file/?mode=…`) — imports
+    `export_job_file` from `lib/utils/jobs/export.py`, **which does not define
+    it** → would `ImportError` at call time.
+- **Django compat layer** `server/ccp4i2/db/ccp4i2_django_dbapi.py`
+  (`class CCP4i2DjangoDbApi`) already exposes the exact methods the legacy
+  functions call, backed by the ORM:
+  - `getChildJobs(jobId, details=True) -> [(number, uuid, task_name), ...]`
+    (same tuple shape the plugins unpack)
+  - `jobDirectory(jobId=…) -> path`
+  - `getJobFilesInfo(jobId=…, jobParamName=…)`
+- **`PROJECTSMANAGER().db()`** (`core/CCP4ProjectsManager.py:120`) returns a
+  `CCP4i2DjangoDbApi()` instance. So the legacy `exportJobFile` functions —
+  which call `CCP4Modules.PROJECTSMANAGER().db().getChildJobs(...)` — resolve
+  against Django **essentially unmodified**. The "rewrite" collapses to "verify
+  they run + tidy"; do **not** touch the crystallographic reconstruction logic.
+- Task registry (`core/tasks.py: get_plugin_class`, plugin module import) to
+  reach the module-level functions.
+- Streaming-download pattern to mirror: the existing `export_job` ZIP action.
+
+## The one real gap: `runCad` is gone
+
+The reconstructor tasks call `m.runCad(...)` on a `CMtzDataFile`. **`runCad` has
+no definition anywhere in the Django branch** — so `aimless_pipe` /
+`import_merged` export would crash today. Nearest replacements:
+
+| Utility | Direction | gemmi? | Notes |
+|---------|-----------|--------|-------|
+| `lib/utils/formats/mtz_utils.extract_columns` | split | ✅ gemmi | replacement for `splitHklout`/`sftools` |
+| `CCP4Utils.merge_mtz_files_cad` | join/merge | ❌ | **still shells out to the `cad` binary** (`shutil.which('cad')`) |
+| `CCP4PluginScript.makeHklin` | join | ✅ gemmi | targets mini-MTZ *program input*, not general column-preserving CAD catenation |
+
+So there is **no gemmi CAD-equivalent for the join direction yet**. This matters
+because a CCP4-binary dependency conflicts with the slim-server architecture
+(server is CCP4-free; jobs run in ccp4-python — see
+`memory: project_slim_env_separation_guard`).
+
+**Consequence for phasing:** locators + generic fallback serve a real file
+directly and have **no binary dependency** → ship first. Reconstructors need
+either (a) a new `merge_mtz_files_gemmi` (preferred), or (b) to run export in the
+ccp4-python job environment, not the CCP4-free server.
+
+## Plan
+
+### Phase 1 — locators + generic fallback (no binary dependency)
+
+1. **`lib/utils/jobs/export.py`** — add the missing glue:
+   - `export_job_file_menu(job)`: import the plugin *module* via the registry;
+     if it defines `exportJobFileMenu`, call it. **Else** synthesise a menu from
+     the job's tracked output-MTZ `File`s (generic fallback).
+   - `export_job_file(pk, mode)`: for a plugin mode, call the module's
+     `exportJobFile(jobId, mode)` (runs against `CCP4i2DjangoDbApi`); for a
+     fallback mode, resolve `File.path` directly. Stream via `FileResponse`.
+     Guard against reconstructor tasks until Phase 2 (detect the dead `runCad`
+     path / catch and report a clear "reconstruction not yet available" error).
+2. **`JobViewSet.export_job_file_menu`** — un-stub: call the util instead of
+   returning `[]`.
+3. **`tool-bar.tsx`** — fetch `export_job_file_menu` for the job; **hide the
+   button when the menu is empty** (replaces the blanket `status===6` gate — the
+   plugin menu already checks file existence, which implies finished). Single
+   mode → direct download; multiple → small pick menu. Wire `onClick` to
+   `export_job_file?mode=…`.
+
+Net after Phase 1: Export MTZ correct for `servalcat_pipe` / `prosmart_refmac`
+(the screenshot cases) + any task with a tracked output MTZ; truthfully
+**absent** where there is nothing to export.
+
+### Phase 2 — reconstructors
+
+4. Write **`merge_mtz_files_gemmi`** (gemmi column-preserving join) and repoint
+   `aimless_pipe` / `import_merged` `exportJobFile` at it (or run those in the
+   job env). Keep the intensity-vs-amplitude + FreeR-base logic they already
+   encode.
+
+## Open questions
+
+- Should the reconstructed / natural export MTZ be **database-tracked** as a job
+  output `File`, or remain an ephemeral download artifact? (Currently
+  `exportMtz.mtz` is written into the job dir but not gleaned.)
+- Multiple output MTZs in the generic fallback: pick-list vs. zip-all.


### PR DESCRIPTION
## Menu honesty pass (code)

The main nav appbar menus advertised many actions that did nothing. This wires the wireable and hides the rest so the UI stops promising features that aren't there.

- **Edit → Preferences** → config page (was a no-op)
- **Help** → replaced 9 dead items with a working CCP4i2 docs link + an **About** dialog (build info from `/api/version`)
- **Utilities** → keep only "Running jobs and processes"; drop 4 dead stubs + the redundant/mislabelled sysadmin entry; remove leaked debug state (`...true`) from the label
- **File** → drop *More Projects* / *View old CCP4i projects* / *Quit* stubs

## Design plans (docs only)

Capture the truth behind the two remaining dead **job-toolbar** buttons (Export MTZ, Bibliography) and the plan to wire them to real mechanisms rather than hide them:

- **`docs/EXPORT_MTZ_PLAN.md`** — per-plugin `exportJobFileMenu`/`exportJobFile` contract (6 tasks). `PROJECTSMANAGER().db()` already returns the Django `CCP4i2DjangoDbApi`, so the legacy functions run ~unmodified. API routes already exist (menu is a stub, file endpoint imports a missing fn). Principle: **serve the natural unsplit file first**, reconstruct only where data is genuinely split across subjobs. Gap: `runCad` is gone and there's no gemmi join util yet → locators (servalcat/refmac) + generic fallback ship first; reconstructors (aimless_pipe/import_merged) are Phase 2.
- **`docs/BIBLIOGRAPHY_PLAN.md`** — reuse the report metadata `ReferenceGroup.loadFromMedLine` over `I2_TOP/references/{task}.medline.txt` (the same source every report uses). Scopes: job+subjobs / optional FileUse progenitors / whole-project. To be implemented in a follow-up.

No behavioural change from the docs; the code change is confined to the four menu components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)