### PR TITLE
Export MTZ (Phase 1): wire the button to the per-plugin export contract

### DIFF
--- a/client/renderer/components/tool-bar.tsx
+++ b/client/renderer/components/tool-bar.tsx
@@ -34,7 +34,7 @@ import { mutate } from "swr";
 interface ToolbarButton {
   label: string;
   icon: React.ReactNode;
-  onClick: () => void;
+  onClick: (e: React.MouseEvent<HTMLElement>) => void;
   disabled?: boolean;
   show: boolean;
 }
@@ -49,6 +49,16 @@ export default function ToolBar() {
     id: jobId,
     endpoint: "",
   });
+
+  // Exportable data-file (MTZ) menu for this job. `result` is a list of
+  // [mode, label, mimeType] items; empty => nothing to export (hide button).
+  const { data: exportMenuData } = api.get_endpoint<{
+    result: [string, string, string][];
+  }>(jobId ? { type: "jobs", id: jobId, endpoint: "export_job_file_menu" } : null);
+  const exportItems = useMemo(
+    () => exportMenuData?.result ?? [],
+    [exportMenuData]
+  );
   const { mutateJobs } = useProjectJobs(projectId);
   const router = useRouter();
   const [showHelpPanel, setShowHelpPanel] = useState(false);
@@ -142,6 +152,27 @@ export default function ToolBar() {
 
   const handleLog = () => setJobTabValue(10);
 
+  const [exportMenuAnchor, setExportMenuAnchor] =
+    useState<null | HTMLElement>(null);
+
+  // Trigger a browser download of a given export mode via the proxy endpoint.
+  const downloadExportMode = (mode: string) => {
+    if (!job) return;
+    const url = `/api/proxy/ccp4i2/jobs/${job.id}/export_job_file/?mode=${encodeURIComponent(
+      mode
+    )}`;
+    window.open(url, "_blank");
+  };
+
+  const handleExportMtz = (e: React.MouseEvent<HTMLElement>) => {
+    if (exportItems.length === 1) {
+      downloadExportMode(exportItems[0][0]);
+    } else if (exportItems.length > 1) {
+      // Multiple exportable files: let the user pick.
+      setExportMenuAnchor(e.currentTarget);
+    }
+  };
+
   // Button definitions with breakpoints
   const toolbarButtons: ToolbarButton[] = useMemo(
     () => [
@@ -185,9 +216,10 @@ export default function ToolBar() {
       {
         label: "Export MTZ",
         icon: <SystemUpdateAlt />,
-        onClick: () => {},
-        disabled: job?.status !== 6,
-        show: panelWidth > 950,
+        onClick: handleExportMtz,
+        // Shown only when the server reports an exportable MTZ for this job
+        // (which already implies a finished job with a real output file).
+        show: panelWidth > 950 && exportItems.length > 0,
       },
       {
         label: "Show log file",
@@ -203,7 +235,7 @@ export default function ToolBar() {
         show: panelWidth > 1200,
       },
     ],
-    [panelWidth, job, projectId, router]
+    [panelWidth, job, projectId, router, exportItems]
   );
 
   const visibleButtons = toolbarButtons.filter((btn) => btn.show);
@@ -246,8 +278,8 @@ export default function ToolBar() {
                 {hiddenButtons.map((btn) => (
                   <MenuItem
                     key={btn.label}
-                    onClick={() => {
-                      btn.onClick();
+                    onClick={(e) => {
+                      btn.onClick(e);
                       setMenuAnchor(null);
                     }}
                     disabled={btn.disabled}
@@ -259,6 +291,24 @@ export default function ToolBar() {
               </MuiMenu>
             </>
           )}
+          {/* Export MTZ: picker shown only when >1 exportable file */}
+          <MuiMenu
+            anchorEl={exportMenuAnchor}
+            open={Boolean(exportMenuAnchor)}
+            onClose={() => setExportMenuAnchor(null)}
+          >
+            {exportItems.map(([mode, label]) => (
+              <MenuItem
+                key={mode}
+                onClick={() => {
+                  downloadExportMode(mode);
+                  setExportMenuAnchor(null);
+                }}
+              >
+                {label}
+              </MenuItem>
+            ))}
+          </MuiMenu>
           <HelpIframe
             url={`/help/html/tasks/${job?.task_name}/index.html`}
             open={showHelpPanel}

--- a/docs/EXPORT_MTZ_PLAN.md
+++ b/docs/EXPORT_MTZ_PLAN.md
@@ -121,16 +121,71 @@ Net after Phase 1: Export MTZ correct for `servalcat_pipe` / `prosmart_refmac`
 (the screenshot cases) + any task with a tracked output MTZ; truthfully
 **absent** where there is nothing to export.
 
-### Phase 2 — reconstructors
+### Phase 1 — IMPLEMENTED (2026-07-10)
 
-4. Write **`merge_mtz_files_gemmi`** (gemmi column-preserving join) and repoint
-   `aimless_pipe` / `import_merged` `exportJobFile` at it (or run those in the
-   job env). Keep the intensity-vs-amplitude + FreeR-base logic they already
-   encode.
+Shipped:
+
+- `core/tasks.py`: new `get_plugin_module(task_name)` accessor (imports the
+  module holding the plugin class, to reach module-level export functions).
+- `lib/utils/jobs/export.py`: `export_job_file_menu(job)` and
+  `export_job_file(pk, mode)` + helpers. Menu prefers the plugin contract,
+  **validates each declared mode by resolving it to an on-disk file** (the
+  plugin `exportJobFileMenu` is optimistic and advertises a mode even when the
+  file is absent), and falls back to the job's tracked output MTZ `File`s
+  (`_FALLBACK_PREFIX = "file:"`). Reconstructor tasks return HTTP 501.
+- `api/JobViewSet.py`: un-stubbed `export_job_file_menu`; cleaned debug prints
+  from `export_job_file`.
+- `servalcat_pipe.exportJobFile`: made robust — searches **all** `servalcat`
+  subjobs (not the fragile `childJobs[-1]`/`[-2]` positional assumption) and
+  covers **SPA mode** (`refined_diffmap.mtz`) as well as xtal (`refined.mtz`).
+- `tool-bar.tsx`: fetches the menu; **hides the button when empty** (replaces
+  the misleading blanket `status===6` gate); single mode → download, multiple →
+  pick menu.
+
+Verified end-to-end against a real Django DB (in-memory test runner): servalcat
+xtal + SPA locators, refmac generic fallback (FileResponse 200), parrot
+(menu-but-no-`exportJobFile`) → empty, aimless reconstructor → 501.
+
+### Phase 2 — reconstructors + tracked unsplit MTZ
+
+**2a. Reconstructors.** Write **`merge_mtz_files_gemmi`** (gemmi
+column-preserving join, no `cad` binary — the slim-server guard forbids it) and
+repoint `aimless_pipe` / `import_merged` `exportJobFile` at it (or run those in
+the job env). Keep the intensity-vs-amplitude + FreeR-base logic they encode.
+
+**2b. Track the unsplit MTZ as a `CMtzDataFile` output.** *(recommended — makes
+export robust and purge-safe)*
+
+Today the natural unsplit files our locators serve are **untracked** and, worse,
+**on the default purge kill-list**:
+
+- `refmac.py:238` reads `hklout.mtz` only as the *source* to split; the def.xml
+  `outputData` declares only the split mini-MTZs (FPHIOUT/DIFFPHIOUT/…). So
+  `hklout.mtz` is never gleaned.
+- `servalcat.py` likewise splits `refined.mtz` / `refined_diffmap.mtz` and
+  declares only the mini-MTZs.
+- `core/CPurgeProject.py SEARCHLIST` puts **`hklin.mtz` and `hklout.mtz` in
+  category 1** ("scratch, always safe to delete") — purged in **every** context
+  including the gentlest `script_finish` `[1,2]`. So the instant a job/project is
+  purged, the locator's target vanishes and Export MTZ silently breaks.
+
+Fix per task (**refmac, servalcat, aimless, dimple**):
+
+1. **def.xml** — add an `outputData` `CMtzDataFile` (e.g. `COMPLETE_MTZ` /
+   `HKLOUT_UNSPLIT`).
+2. **wrapper** — in `processOutputFiles`, set + annotate it to the unsplit path
+   *before* splitting, so the gleaner tracks it as a `File` row.
+3. **purge** — ensure its filename is **not** matched by the category-1
+   SEARCHLIST globs. `hklout.mtz` currently IS — so either write the tracked copy
+   under a non-scratch name (e.g. `complete.mtz`) or add an explicit keep rule.
+   Reconcile the `hklout.mtz`/`hklin.mtz` category-1 entries so we never declare
+   an output and then purge it.
+
+Once tracked, the **generic fallback finds it** and the plugin **locator becomes
+a fallback for legacy (pre-tracking) jobs**. For aimless/dimple this depends on
+2a (there is no single unsplit file until the gemmi join produces one).
 
 ## Open questions
 
-- Should the reconstructed / natural export MTZ be **database-tracked** as a job
-  output `File`, or remain an ephemeral download artifact? (Currently
-  `exportMtz.mtz` is written into the job dir but not gleaned.)
-- Multiple output MTZs in the generic fallback: pick-list vs. zip-all.
+- Multiple output MTZs in the generic fallback: pick-list (current) vs. zip-all.
+- Naming of the tracked unsplit output + whether to backfill legacy jobs.

--- a/server/ccp4i2/api/JobViewSet.py
+++ b/server/ccp4i2/api/JobViewSet.py
@@ -1933,10 +1933,16 @@ class JobViewSet(ModelViewSet):
             - Handles CCP4 Task Manager initialization errors
             - Provides detailed error messages for debugging
         """
-        logger.warning(
-            "exportJobFiles not available in TaskManager - returning empty menu"
-        )
-        return api_success({"result": []})
+        try:
+            job = models.Job.objects.get(id=pk)
+        except models.Job.DoesNotExist as err:
+            logger.exception("Failed to retrieve job with id %s", pk, exc_info=err)
+            return api_error(str(err), status=404)
+
+        from ..lib.utils.jobs.export import export_job_file_menu
+
+        menu = export_job_file_menu(job)
+        return api_success({"result": menu})
 
     @action(
         detail=True,
@@ -1969,30 +1975,14 @@ class JobViewSet(ModelViewSet):
         Example:
             GET /api/jobs/123/export_job_file/?mode=pdb
         """
-        print("In export job file")
-        print(f"Request: pk={pk}, mode={request.GET.get('mode')}")
-        # Get the export mode from query parameters
         export_mode = request.GET.get("mode")
         if not export_mode:
-            print("Missing export mode parameter")
             return api_error("Missing required 'mode' parameter", status=400)
 
-        print(f"About to call utility function with pk={pk}, export_mode={export_mode}")
-        # Import the utility function locally to avoid unused import lint error
         from ..lib.utils.jobs.export import export_job_file
 
-        # Use the refactored utility function
         file_response, error_response = export_job_file(pk, export_mode)
-        print(
-            f"Utility function returned: file_response={file_response is not None}, error_response={error_response is not None}"
-        )
-
-        # Return either the file response or error response
-        if error_response:
-            print(f"Returning error response: {error_response}")
-            return error_response
-        print(f"Returning file response: {file_response}")
-        return file_response
+        return error_response if error_response else file_response
 
     @action(
         detail=True,

--- a/server/ccp4i2/core/tasks.py
+++ b/server/ccp4i2/core/tasks.py
@@ -1490,6 +1490,28 @@ def get_import_error(task_name: str) -> str | None:
 
 
 @cache
+def get_plugin_module(task_name: str):
+    """Return the imported module that holds a task's plugin class.
+
+    Useful for reaching module-level functions a plugin script may define
+    outside its class (e.g. the legacy ``exportJobFileMenu`` /
+    ``exportJobFile`` export contract). Returns None if the task is unknown
+    or the module fails to import.
+    """
+    task = TASKS.get(task_name)
+    if task is None or not task.pluginPath:
+        return None
+    module_name = task.pluginPath.split(":")[0]
+    try:
+        return importlib.import_module(module_name)
+    except Exception as e:
+        logger = logging.getLogger(f"ccp4i2:{__name__}")
+        logger.error(f"Failed to import plugin module for {task_name}: {e}")
+        _import_errors[task_name] = str(e)
+        return None
+
+
+@cache
 def get_plugin_class(task_name: str):
     return _get_task_class(task_name, "plugin")
 

--- a/server/ccp4i2/lib/utils/jobs/export.py
+++ b/server/ccp4i2/lib/utils/jobs/export.py
@@ -1,16 +1,29 @@
 """
 Job export utilities.
 
-Provides functions to export jobs as ZIP archives.
+Provides functions to export jobs as ZIP archives, and to serve a job's
+exportable data files (MTZ) via the per-plugin export contract or a
+generic fallback. See docs/EXPORT_MTZ_PLAN.md for the design.
 """
 
 import logging
+import os
 from pathlib import Path
+from django.http import FileResponse
 from ccp4i2.db import models
-from ccp4i2.lib.response import Result
+from ccp4i2.lib.response import Result, api_error
 from ccp4i2.db.export_project import export_project_to_zip
 
 logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+# FileType.name prefix shared by every MTZ variant (full, mini, observed,
+# freerflag, phases, map). Used by the generic export fallback.
+MTZ_TYPE_PREFIX = "application/CCP4-mtz"
+
+# Tasks whose exportJobFile reconstructs via the (now-absent) runCad. Until a
+# gemmi join utility lands (EXPORT_MTZ_PLAN Phase 2) these would crash, so we
+# skip their plugin export and let the generic fallback handle them instead.
+_RECONSTRUCTOR_TASKS = {"aimless_pipe", "import_merged"}
 
 
 def export_job(job: models.Job, output_path: Path) -> Result[Path]:
@@ -61,3 +74,151 @@ def export_job(job: models.Job, output_path: Path) -> Result[Path]:
                 "error_type": type(err).__name__
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# Data-file (MTZ) export — per-plugin contract + generic fallback
+# ---------------------------------------------------------------------------
+
+# Prefix for generic-fallback modes, to distinguish them from plugin modes.
+_FALLBACK_PREFIX = "file:"
+
+
+def _output_mtz_files(job: models.Job):
+    """Output MTZ File rows produced by this job, whose file exists on disk."""
+    files = (
+        models.File.objects.filter(
+            job=job, type__name__startswith=MTZ_TYPE_PREFIX
+        )
+        .select_related("type", "job")
+        .order_by("job_param_name", "name")
+    )
+    result = []
+    for f in files:
+        try:
+            if f.path and Path(f.path).exists():
+                result.append(f)
+        except Exception:
+            continue
+    return result
+
+
+def _generic_menu(job: models.Job):
+    """Fallback export menu: one entry per tracked output MTZ file on disk."""
+    menu = []
+    for f in _output_mtz_files(job):
+        label = f.annotation or f.job_param_name or f.name
+        menu.append([f"{_FALLBACK_PREFIX}{f.uuid}", f"MTZ file: {label}", "application/CCP4-mtz"])
+    return menu
+
+
+def export_job_file_menu(job: models.Job):
+    """Return the list of exportable-file menu items for a job.
+
+    Prefers the plugin's module-level ``exportJobFileMenu(jobId)`` contract;
+    falls back to the job's tracked output MTZ file(s). Each item is
+    ``[mode, label, mimeType]``. Empty list => nothing to export
+    (frontend hides the button).
+    """
+    from ccp4i2.core.tasks import get_plugin_module
+
+    task_name = job.task_name
+    module = get_plugin_module(task_name)
+    if (
+        module is not None
+        and task_name not in _RECONSTRUCTOR_TASKS
+        and hasattr(module, "exportJobFileMenu")
+        and hasattr(module, "exportJobFile")
+    ):
+        try:
+            declared = module.exportJobFileMenu(jobId=str(job.uuid)) or []
+        except Exception as err:
+            logger.warning(
+                "Plugin exportJobFileMenu failed for task %s (job %s): %s",
+                task_name, job.uuid, err,
+            )
+            declared = []
+        # The plugin menu is optimistic — it advertises a mode regardless of
+        # whether the file exists. For these (non-reconstructor) tasks
+        # exportJobFile is a cheap path resolve, so validate each mode by
+        # confirming it yields a file on disk before offering it.
+        menu = []
+        for item in declared:
+            mode = item[0] if item else None
+            if mode and _plugin_export_path(module, job, mode):
+                menu.append(item)
+        if menu:
+            return menu
+    # Generic fallback (also covers reconstructor tasks and any task whose
+    # plugin export produced nothing).
+    return _generic_menu(job)
+
+
+def _plugin_export_path(module, job: models.Job, mode):
+    """Resolve a plugin export mode to an existing path, or None."""
+    try:
+        path = module.exportJobFile(jobId=str(job.uuid), mode=mode)
+    except Exception as err:
+        logger.warning(
+            "Plugin exportJobFile(mode=%s) failed for task %s (job %s): %s",
+            mode, job.task_name, job.uuid, err,
+        )
+        return None
+    if path and os.path.exists(str(path)):
+        return Path(path)
+    return None
+
+
+def export_job_file(pk, mode):
+    """Resolve and stream a job's exportable file for the given mode.
+
+    Returns ``(file_response, error_response)`` — exactly one is non-None,
+    matching the JobViewSet.export_job_file action contract.
+    """
+    if not mode:
+        return None, api_error("Missing required 'mode' parameter", status=400)
+
+    try:
+        job = models.Job.objects.get(id=pk)
+    except models.Job.DoesNotExist:
+        return None, api_error(f"Job {pk} not found", status=404)
+
+    export_path = None
+
+    # Generic-fallback mode: serve a specific tracked output File as-is.
+    if str(mode).startswith(_FALLBACK_PREFIX):
+        file_uuid = str(mode)[len(_FALLBACK_PREFIX):]
+        try:
+            f = models.File.objects.get(uuid=file_uuid, job=job)
+        except models.File.DoesNotExist:
+            return None, api_error(f"Export file {file_uuid} not found for job", status=404)
+        export_path = f.path
+    else:
+        # Plugin mode: call the module-level exportJobFile contract.
+        if job.task_name in _RECONSTRUCTOR_TASKS:
+            return None, api_error(
+                "MTZ reconstruction for this task is not yet available "
+                "(pending a gemmi CAD replacement).",
+                status=501,
+            )
+        from ccp4i2.core.tasks import get_plugin_module
+
+        module = get_plugin_module(job.task_name)
+        if module is None or not hasattr(module, "exportJobFile"):
+            return None, api_error(
+                f"Task {job.task_name} does not support file export", status=400
+            )
+        export_path = _plugin_export_path(module, job, mode)
+
+    if not export_path or not os.path.exists(str(export_path)):
+        return None, api_error("No exportable file was produced", status=404)
+
+    export_path = Path(export_path)
+    download_name = f"{job.project.name}_job_{job.number}_{export_path.name}"
+    response = FileResponse(
+        open(export_path, "rb"),
+        as_attachment=True,
+        filename=download_name,
+        content_type="application/octet-stream",
+    )
+    return response, None

--- a/server/ccp4i2/pipelines/servalcat_pipe/script/servalcat_pipe.py
+++ b/server/ccp4i2/pipelines/servalcat_pipe/script/servalcat_pipe.py
@@ -1209,18 +1209,22 @@ def exportJobFile(jobId=None, mode=None, fileInfo={}):
 
     theDb = CCP4Modules.PROJECTSMANAGER().db()
     if mode == 'complete_mtz':
+        # The inner servalcat subjob writes the unsplit reflection file
+        # ("refined.mtz" for xtal, "refined_diffmap.mtz" for spa) before
+        # splitting it into the map-coefficient mini-MTZs. That unsplit file
+        # persists on disk, so locate the servalcat subjob and return it.
+        # Take the last servalcat subjob (there is normally one; a trailing
+        # validate_protein subjob does not produce it).
         childJobs = theDb.getChildJobs(jobId=jobId, details=True)
-        if childJobs[-1][2] == 'servalcat':
+        servalcat_jobs = [cj for cj in childJobs if cj[2] == 'servalcat']
+        for cj in reversed(servalcat_jobs):
             jobDir = CCP4Modules.PROJECTSMANAGER().jobDirectory(
-                jobId=childJobs[-1][1], create=False)
-            if os.path.exists(os.path.join(jobDir, 'refined.mtz')):
-                return os.path.join(jobDir, 'refined.mtz')
-        elif childJobs[-1][2] == 'validate_protein':
-            if childJobs[-2][2] == 'servalcat':
-                jobDir = CCP4Modules.PROJECTSMANAGER().jobDirectory(
-                    jobId=childJobs[-2][1], create=False)
-                if os.path.exists(os.path.join(jobDir, 'refined.mtz')):
-                    return os.path.join(jobDir, 'refined.mtz')
+                jobId=cj[1], create=False)
+            for name in ('refined.mtz', 'refined_diffmap.mtz'):
+                candidate = os.path.join(jobDir, name)
+                if os.path.exists(candidate):
+                    return candidate
+    return None
 
 
 # Function to return list of names of exportable MTZ(s)


### PR DESCRIPTION
## What

The job-toolbar **Export MTZ** button was a no-op (`onClick: () => {}`) gated by a misleading `status===6` check. This wires it to the real per-plugin export contract, with a generic tracked-output-MTZ fallback, and hides the button when a job has nothing to export.

## Server

- **`core/tasks.py`** — new `get_plugin_module(task_name)` accessor to reach a plugin's module-level export functions.
- **`lib/utils/jobs/export.py`** — `export_job_file_menu(job)` + `export_job_file(pk, mode)`:
  - Prefers the plugin's `exportJobFileMenu`/`exportJobFile` contract, but **validates each declared mode by resolving it to an on-disk file** — the plugin menu is optimistic and advertises a mode even when the file is absent (found via test).
  - **Generic fallback**: the job's tracked output MTZ `File`s (mode prefix `file:`).
  - Reconstructor tasks (`aimless_pipe`/`import_merged`) return **501** until a gemmi CAD replacement lands (`runCad` is gone from the branch).
- **`api/JobViewSet.py`** — un-stubbed `export_job_file_menu` (was hardcoded `[]`); dropped debug prints from `export_job_file`.
- **`servalcat_pipe.exportJobFile`** — hardened: searches **all** `servalcat` subjobs (not the fragile `childJobs[-1]`/`[-2]`) and covers **SPA mode** (`refined_diffmap.mtz`) as well as xtal (`refined.mtz`).

## Frontend

- **`tool-bar.tsx`** — fetches the export menu; **hides the button when empty** (the server menu already implies a finished job with a real file, so this replaces the blanket `status===6` gate). Single mode → direct download; multiple → pick menu.

## Verification

End-to-end against a real Django DB (in-memory test runner): servalcat xtal + SPA locators, refmac generic fallback (FileResponse 200), parrot (menu-but-no-`exportJobFile`) → empty, aimless reconstructor → 501.

## Follow-up (documented, not in this PR)

`docs/EXPORT_MTZ_PLAN.md` records **Phase 2**:
- **2a** — write `merge_mtz_files_gemmi` (no `cad` binary) for the reconstructor tasks.
- **2b** — **track the unsplit MTZ as a `CMtzDataFile` output** for refmac/servalcat/aimless/dimple. Today `hklout.mtz`/`refined.mtz` are untracked **and** on the `CPurgeProject` **category-1 scratch list** (purged in every context), so purge silently breaks export. Fix: declare it as an `outputData` file, glean it, and keep its filename off the category-1 purge globs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)