### PR TITLE
Export MTZ (Phase 2a): reconstructor export via gemmi + task-author guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,6 +330,16 @@ consolidated into `tasks.py`.) Output files are persisted to the project by the
 gleaner (`db/async_db_handler.py: glean_job_files`) for any `outputData`
 `CDataFile` that is set and exists on disk — there is no `saveToDb` gate.
 
+### Making a task's data files exportable
+
+To let the job panel's **Export MTZ** button offer a task's principal reflection
+file, either declare a tracked `outputData` `CMtzDataFile` (preferred — the
+generic fallback then offers it automatically) or implement the module-level
+`exportJobFileMenu` / `exportJobFile` contract (for pipelines needing subjob
+lookup or reconstruction). Never shell out to `cad` — use
+`lib/utils/jobs/export.py: combine_mtz_files` for gemmi-based joins. Full guide:
+`wrappers/EXPORT_TASK_GUIDE.md`.
+
 ## Files Preserved from Legacy
 
 - `wrappers/`, `pipelines/` - Crystallographic logic

--- a/docs/EXPORT_MTZ_PLAN.md
+++ b/docs/EXPORT_MTZ_PLAN.md
@@ -148,10 +148,16 @@ xtal + SPA locators, refmac generic fallback (FileResponse 200), parrot
 
 ### Phase 2 — reconstructors + tracked unsplit MTZ
 
-**2a. Reconstructors.** Write **`merge_mtz_files_gemmi`** (gemmi
-column-preserving join, no `cad` binary — the slim-server guard forbids it) and
-repoint `aimless_pipe` / `import_merged` `exportJobFile` at it (or run those in
-the job env). Keep the intensity-vs-amplitude + FreeR-base logic they encode.
+**2a. Reconstructors — IMPLEMENTED (2026-07-10).** Rather than a new util, the
+branch already had a gemmi join: `CCP4Utils.merge_mtz_files` (pure gemmi despite
+its "using CAD" docstring; distinct from the binary-shelling
+`merge_mtz_files_cad`). Added a thin wrapper `combine_mtz_files(sources,
+output_path)` in `lib/utils/jobs/export.py` that copies all data columns from
+each source (first wins on clash). Repointed `aimless_pipe` /`import_merged`
+`exportJobFile` from the dead `m.runCad(...)` to `combine_mtz_files(...)`
+(observed data first, FreeR second) and removed the `_RECONSTRUCTOR_TASKS` 501
+guard. No `cad` binary — satisfies the slim-server guard. Verified: a real
+gemmi merge of F/SIGF + FreeR mini-MTZs produces the combined file.
 
 **2b. Track the unsplit MTZ as a `CMtzDataFile` output.** *(recommended — makes
 export robust and purge-safe)*

--- a/server/ccp4i2/lib/utils/jobs/export.py
+++ b/server/ccp4i2/lib/utils/jobs/export.py
@@ -9,6 +9,7 @@ generic fallback. See docs/EXPORT_MTZ_PLAN.md for the design.
 import logging
 import os
 from pathlib import Path
+from typing import List, Union
 from django.http import FileResponse
 from ccp4i2.db import models
 from ccp4i2.lib.response import Result, api_error
@@ -20,10 +21,40 @@ logger = logging.getLogger(f"ccp4i2:{__name__}")
 # freerflag, phases, map). Used by the generic export fallback.
 MTZ_TYPE_PREFIX = "application/CCP4-mtz"
 
-# Tasks whose exportJobFile reconstructs via the (now-absent) runCad. Until a
-# gemmi join utility lands (EXPORT_MTZ_PLAN Phase 2) these would crash, so we
-# skip their plugin export and let the generic fallback handle them instead.
-_RECONSTRUCTOR_TASKS = {"aimless_pipe", "import_merged"}
+
+def combine_mtz_files(
+    sources: List[Union[str, Path]],
+    output_path: Union[str, Path],
+) -> Path:
+    """Combine reflection columns from several MTZ files into one (gemmi).
+
+    A CAD-free replacement for the old ``CMtzDataFile.runCad`` catenation used
+    by the reconstructor export tasks (aimless_pipe, import_merged): all data
+    columns from each source are copied into a single output, HKL-matched by
+    gemmi. On a column-label clash the earlier source wins (so pass the
+    observed-data MTZ first, the FreeR MTZ after).
+
+    Args:
+        sources: input MTZ paths, in priority order (first wins on conflict).
+        output_path: where to write the combined MTZ.
+
+    Returns:
+        Path to the written combined MTZ.
+    """
+    import gemmi
+    from ccp4i2.core.CCP4Utils import merge_mtz_files
+
+    input_specs = []
+    for src in sources:
+        src = Path(src)
+        mtz = gemmi.read_mtz_file(str(src))
+        # Copy every data column (everything except the H, K, L index columns).
+        mapping = {
+            c.label: c.label for c in mtz.columns if c.type not in ("H",)
+        }
+        input_specs.append({"path": str(src), "column_mapping": mapping})
+
+    return merge_mtz_files(input_specs, output_path, merge_strategy="first")
 
 
 def export_job(job: models.Job, output_path: Path) -> Result[Path]:
@@ -126,7 +157,6 @@ def export_job_file_menu(job: models.Job):
     module = get_plugin_module(task_name)
     if (
         module is not None
-        and task_name not in _RECONSTRUCTOR_TASKS
         and hasattr(module, "exportJobFileMenu")
         and hasattr(module, "exportJobFile")
     ):
@@ -139,9 +169,10 @@ def export_job_file_menu(job: models.Job):
             )
             declared = []
         # The plugin menu is optimistic — it advertises a mode regardless of
-        # whether the file exists. For these (non-reconstructor) tasks
-        # exportJobFile is a cheap path resolve, so validate each mode by
-        # confirming it yields a file on disk before offering it.
+        # whether the file can be produced. Validate each mode by resolving it
+        # to a file on disk before offering it. For locator tasks this is a
+        # cheap lookup; for reconstructor tasks it builds (and caches) the
+        # combined MTZ, which is fast and idempotent.
         menu = []
         for item in declared:
             mode = item[0] if item else None
@@ -195,12 +226,6 @@ def export_job_file(pk, mode):
         export_path = f.path
     else:
         # Plugin mode: call the module-level exportJobFile contract.
-        if job.task_name in _RECONSTRUCTOR_TASKS:
-            return None, api_error(
-                "MTZ reconstruction for this task is not yet available "
-                "(pending a gemmi CAD replacement).",
-                status=501,
-            )
         from ccp4i2.core.tasks import get_plugin_module
 
         module = get_plugin_module(job.task_name)

--- a/server/ccp4i2/pipelines/aimless_pipe/script/aimless_pipe.py
+++ b/server/ccp4i2/pipelines/aimless_pipe/script/aimless_pipe.py
@@ -1074,7 +1074,7 @@ class aimless_pipe(CPluginScript):
 # ----------------------------------------------------------------------
 # Function to return list of names of exportable MTZ(s)
 def exportJobFile(jobId=None,mode=None):
-    from ccp4i2.core import CCP4Modules, CCP4XtalData
+    from ccp4i2.core import CCP4Modules
 
     jobDir = CCP4Modules.PROJECTSMANAGER().jobDirectory(jobId=jobId,create=False)
     exportFile = os.path.join(jobDir,'exportMtz.mtz')
@@ -1094,13 +1094,14 @@ def exportJobFile(jobId=None,mode=None):
     if truncateOut is None: return None
     if freerflagOut is None: return truncateOut
 
-    # print('aimless_pipe.exportJobFile  runCad:',exportFile,[ freerflagOut ])
-    
-    m = CCP4XtalData.CMtzDataFile(truncateOut)
-    #print m.runCad.__doc__   #Print out docs for the function
-    outfile,err = m.runCad(exportFile,[ freerflagOut ] )
-    print('aimless_pipe.exportJobFile',outfile,err.report())
-    return   outfile                                                   
+    # Combine the ctruncate observed data with the FreeR column into one MTZ.
+    # gemmi-based (no cad binary); observed data first so it wins on conflict.
+    from ccp4i2.lib.utils.jobs.export import combine_mtz_files
+    try:
+        return str(combine_mtz_files([truncateOut, freerflagOut], exportFile))
+    except Exception as e:
+        print('ERROR: aimless_pipe.exportJobFile combine failed:', e)
+        return None
  
 def exportJobFileMenu(jobId=None):
     # Return a list of items to appear on the 'Export' menu - each has three subitems:

--- a/server/ccp4i2/pipelines/import_merged/script/import_merged.py
+++ b/server/ccp4i2/pipelines/import_merged/script/import_merged.py
@@ -643,9 +643,8 @@ def exportJobFile(jobId=None,mode=None):
     #     which would mean truncate applied twice
     import os
 
-    from ccp4i2.core import CCP4Modules, CCP4XtalData
+    from ccp4i2.core import CCP4Modules
 
-    print("\nexportJobFile")
     jobDir = CCP4Modules.PROJECTSMANAGER().jobDirectory(jobId=jobId,create=False)
     exportFile = os.path.join(jobDir,'exportMtz.mtz')
     if os.path.exists(exportFile): return exportFile
@@ -679,26 +678,26 @@ def exportJobFile(jobId=None,mode=None):
         obsOut = os.path.join( CCP4Modules.PROJECTSMANAGER().jobDirectory(jobId=jobId,create=False), obsfilename)
 
 
-    #print("now FreeR")
+    # No observed-data MTZ located (e.g. intensity input but ctruncate output
+    # missing) -> nothing to reconstruct.
+    if not obsOut or not os.path.exists(str(obsOut)):
+        return None
+
     info = db.getJobFilesInfo(jobId=jobId,jobParamName='FREEOUT')
     freerfilename = info[0]['fileName']
-    freerflagOut = None
     freerflagOut = os.path.join( CCP4Modules.PROJECTSMANAGER().jobDirectory(jobId=jobId,create=False),freerfilename)
-    if not os.path.exists(freerflagOut): freerflagOut = None
-    #if truncateOut is None: return None
-    #if freerflagOut is None: return truncateOut
-    if freerflagOut is None: return None
+    if not os.path.exists(freerflagOut):
+        # No FreeR to add: the observed-data file is the best we can offer.
+        return str(obsOut)
 
-    #print('import_merge.exportJobFile  runCad:',exportFile,[ freerflagOut ])
-    
-    m = CCP4XtalData.CMtzDataFile(obsOut)   # observed data
-    #print(m.runCad.__doc__)   #Print out docs for the function
-    #  Make sure that FreeR is flagged as base dataset
-    comLines = ["XNAME FILE_NUMBER 2 ALL=HKL_base",
-                "DNAME FILE_NUMBER 2 ALL=HKL_base"]
-    outfile,err = m.runCad(exportFile,[ freerflagOut ], comLines)
-    print('aimless_pipe.exportJobFile',outfile,err.report())
-    return   outfile                                                   
+    # Combine observed data with the FreeR column into one MTZ. gemmi-based
+    # (no cad binary); observed data first so it wins on any column clash.
+    from ccp4i2.lib.utils.jobs.export import combine_mtz_files
+    try:
+        return str(combine_mtz_files([obsOut, freerflagOut], exportFile))
+    except Exception as e:
+        print('ERROR: import_merged.exportJobFile combine failed:', e)
+        return None
  
 def exportJobFileMenu(jobId=None):
     print("exportJobFileMenu")

--- a/server/ccp4i2/wrappers/EXPORT_TASK_GUIDE.md
+++ b/server/ccp4i2/wrappers/EXPORT_TASK_GUIDE.md
@@ -1,0 +1,145 @@
+# Making a task's data files exportable (the "Export MTZ" button)
+
+The job panel's **Export MTZ** button lets a user download a task's principal
+reflection file. This guide is for task (wrapper/pipeline) authors who want their
+task to offer a meaningful export. See `docs/EXPORT_MTZ_PLAN.md` for the wider
+design.
+
+## How the button decides what to offer
+
+For the current job the frontend calls
+`GET /api/jobs/{id}/export_job_file_menu/`. The server
+(`lib/utils/jobs/export.py`) builds the menu in this order:
+
+1. **Plugin contract** — if your plugin *module* defines `exportJobFileMenu`
+   **and** `exportJobFile`, they are used.
+2. **Generic fallback** — otherwise (or if the plugin offers nothing usable),
+   the job's **tracked output MTZ `File`s** are offered directly.
+
+Every declared mode is **validated**: the server calls `exportJobFile` for it and
+only keeps the mode if it resolves to a file that exists on disk. So an empty or
+unusable result simply means the button is hidden — never a broken download.
+
+You therefore have two ways to make a task exportable. Prefer the first.
+
+## Option A (recommended): declare a tracked output MTZ
+
+If your task produces a principal reflection file, declare it as an `outputData`
+`CMtzDataFile` so it is gleaned into the database as a `File`. The generic
+fallback then offers it automatically — **no `exportJobFile` code needed** — and,
+being a tracked output, it survives project export and is protected from purge.
+
+1. **def.xml** — add to `<container id="outputData">`:
+
+   ```xml
+   <content id="COMPLETE_MTZ">
+       <className>CMtzDataFile</className>
+       <qualifiers>
+           <saveToDb>True</saveToDb>
+           <label>Complete reflection file</label>
+       </qualifiers>
+   </content>
+   ```
+
+2. **wrapper `processOutputFiles`** — point it at the unsplit file and set an
+   annotation, *before* you split it into mini-MTZs:
+
+   ```python
+   self.container.outputData.COMPLETE_MTZ.setFullPath(
+       os.path.join(self.getWorkDirectory(), "hklout.mtz"))
+   self.container.outputData.COMPLETE_MTZ.annotation.set(
+       "Complete unsplit reflection file")
+   ```
+
+   The gleaner persists any `outputData` `CDataFile` that is set and exists on
+   disk (`db/async_db_handler.py: glean_job_files`).
+
+3. **Keep it away from the purge scratch list.** `core/CPurgeProject.py`
+   `SEARCHLIST` marks **`hklout.mtz` and `hklin.mtz` as category 1**
+   ("scratch — always safe to delete", purged in *every* context). If your
+   tracked file is literally `hklout.mtz`, it will be gleaned and then deleted
+   by the next purge. Two ways to avoid that:
+
+   - **Rename** the tracked copy to a non-scratch name (e.g. write/point at
+     `complete.mtz`), which no default glob matches; **or**
+   - **Protect it** by giving your plugin class a `PURGESEARCHLIST` entry with
+     **category 0** (override/keep), which removes the matching default rule:
+
+     ```python
+     class my_task(CPluginScript):
+         PURGESEARCHLIST = [["hklout.mtz", 0]]   # 0 = keep, overrides the default
+     ```
+
+   Category 0 only affects *your* task, so this does not change scratch handling
+   for tasks that don't export their `hklout.mtz`.
+
+## Option B: the imperative `exportJobFile` contract
+
+Use this for **pipelines** where the exportable file lives in a subjob, or must
+be **reconstructed** from several subjob outputs. Define two *module-level*
+functions (not methods) in your plugin script:
+
+```python
+def exportJobFileMenu(jobId=None):
+    # One row per exportable file: [mode, menu label, mime type].
+    return [["complete_mtz", "MTZ file", "application/CCP4-mtz"]]
+
+def exportJobFile(jobId=None, mode=None, fileInfo={}):
+    # Return an absolute path to the file to serve (or None if unavailable).
+    ...
+```
+
+`jobId` is the job's UUID. Inside these functions you may use the legacy DB
+facade, which is backed by the Django ORM
+(`PROJECTSMANAGER().db()` → `CCP4i2DjangoDbApi`):
+
+- `getChildJobs(jobId, details=True)` → `[(number, uuid, task_name), ...]`
+- `jobDirectory(jobId=uuid)` → the job's directory
+- `getJobFilesInfo(jobId=uuid, jobParamName=...)`
+
+### Locator pattern — return an existing unsplit file
+
+Find the subjob that produced the file and return its path. Be robust: search
+**all** matching subjobs rather than assuming a fixed position, and cover every
+variant filename. Example (servalcat_pipe):
+
+```python
+def exportJobFile(jobId=None, mode=None, fileInfo={}):
+    from ccp4i2.core import CCP4Modules
+    db = CCP4Modules.PROJECTSMANAGER().db()
+    if mode != "complete_mtz":
+        return None
+    servalcat_jobs = [cj for cj in db.getChildJobs(jobId=jobId, details=True)
+                      if cj[2] == "servalcat"]
+    for cj in reversed(servalcat_jobs):
+        jobDir = CCP4Modules.PROJECTSMANAGER().jobDirectory(jobId=cj[1], create=False)
+        for name in ("refined.mtz", "refined_diffmap.mtz"):   # xtal / spa
+            p = os.path.join(jobDir, name)
+            if os.path.exists(p):
+                return p
+    return None
+```
+
+### Reconstruct pattern — combine subjob outputs
+
+When there is no single unsplit file (import/scaling pipelines), combine the
+relevant subjob outputs. **Do not shell out to `cad`** — the server is CCP4-free.
+Use the gemmi helper:
+
+```python
+from ccp4i2.lib.utils.jobs.export import combine_mtz_files
+# observed-data MTZ first so it wins on any column-label clash; FreeR after.
+return str(combine_mtz_files([obsOut, freerflagOut], exportFile))
+```
+
+`combine_mtz_files` copies all data columns from each source into one
+HKL-matched MTZ using gemmi (see `lib/utils/jobs/export.py`).
+
+## Checklist
+
+- [ ] If your task has a natural unsplit output → **Option A** (tracked output),
+      and keep it off the category-1 purge list.
+- [ ] If it's a pipeline needing subjob lookup / reconstruction → **Option B**.
+- [ ] `exportJobFile` returns `None` (not raise) when the file is unavailable —
+      the server validates and simply hides the button.
+- [ ] Never call the `cad` binary; use `combine_mtz_files` for joins.


### PR DESCRIPTION
Builds on #242 (Phase 1).

## 2a — reconstructor export (aimless_pipe, import_merged)

Their "Export MTZ" reconstruction was dead: `exportJobFile` called `CMtzDataFile.runCad`, which no longer exists on this branch. (The nearest sibling `merge_mtz_files_cad` still shells out to the `cad` binary — forbidden by the slim-server guard.)

- **`lib/utils/jobs/export.py`** — add `combine_mtz_files(sources, output_path)`, a thin wrapper over the existing **gemmi** `CCP4Utils.merge_mtz_files` (pure gemmi, despite its "using CAD" docstring). Copies all data columns from each source into one HKL-matched MTZ; first source wins on a column clash.
- **`aimless_pipe` / `import_merged` `exportJobFile`** — repoint from `runCad` to `combine_mtz_files` (observed data first, FreeR second); add guards for absent observed/FreeR files; drop the now-unused `CCP4XtalData` import.
- Remove the `_RECONSTRUCTOR_TASKS` 501 guard — both now work. The menu still validates each mode by resolving it to a real on-disk file, so an unavailable reconstruction just hides the button.

## Developer documentation (requested)

- **`wrappers/EXPORT_TASK_GUIDE.md`** (new) — how task authors make their data files exportable:
  - **Option A (recommended)** — declare a tracked `outputData` `CMtzDataFile`; the generic fallback then offers it automatically. Includes the purge caveat: `hklout.mtz`/`hklin.mtz` are `CPurgeProject` **category-1 scratch**, so a tracked file with that name gets purged — rename it or add a `PURGESEARCHLIST` category-0 keep.
  - **Option B** — the module-level `exportJobFileMenu`/`exportJobFile` contract, with locator and gemmi-reconstruct patterns, and the DB facade methods available.
- Referenced from `CLAUDE.md`; `EXPORT_MTZ_PLAN.md` marks 2a done.

## Verification

gemmi merge of F/SIGF + FreeR mini-MTZs produces the combined file; aimless with no subjobs degrades to an empty menu / 404 (not 501, not a crash).

## Still to do (Phase 2b, documented not built)

Track the unsplit MTZ as a purge-safe `CMtzDataFile` output for refmac/servalcat/aimless/dimple — needs a live job run to verify gleaning + purge, so it's a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)