### PR TITLE
fix: Export MTZ button now actually downloads (use existing ExportJobMenu)

### DIFF
--- a/client/renderer/components/export-job-file-menu.tsx
+++ b/client/renderer/components/export-job-file-menu.tsx
@@ -80,7 +80,7 @@ interface ExportJobFileMenuResponse {
  * @param url - The URL to download from
  * @param filename - Suggested filename for the download
  */
-const doDownload = async (url: string, filename: string): Promise<void> => {
+export const doDownload = async (url: string, filename: string): Promise<void> => {
   try {
     // Fetch the response to get headers
     const response = await apiFetch(url);

--- a/client/renderer/components/tool-bar.tsx
+++ b/client/renderer/components/tool-bar.tsx
@@ -27,6 +27,7 @@ import { usePopcorn } from "../providers/popcorn-provider";
 import { useRunCheck } from "../providers/run-check-provider";
 import { useJobTab } from "../providers/job-tab-provider";
 import { I2RunDialog } from "./i2run-dialog";
+import { ExportJobMenu, doDownload } from "./export-job-file-menu";
 import { useRecentlyStartedJobs } from "../providers/recently-started-jobs-context";
 import { useProjectJobs } from "../utils";
 import { mutate } from "swr";
@@ -152,24 +153,27 @@ export default function ToolBar() {
 
   const handleLog = () => setJobTabValue(10);
 
-  const [exportMenuAnchor, setExportMenuAnchor] =
-    useState<null | HTMLElement>(null);
+  // Export MTZ: job id fed to the ExportJobMenu dialog (null = closed).
+  const [exportDialogJobId, setExportDialogJobId] = useState<number | null>(
+    null
+  );
 
-  // Trigger a browser download of a given export mode via the proxy endpoint.
-  const downloadExportMode = (mode: string) => {
+  const handleExportMtz = () => {
     if (!job) return;
-    const url = `/api/proxy/ccp4i2/jobs/${job.id}/export_job_file/?mode=${encodeURIComponent(
-      mode
-    )}`;
-    window.open(url, "_blank");
-  };
-
-  const handleExportMtz = (e: React.MouseEvent<HTMLElement>) => {
     if (exportItems.length === 1) {
-      downloadExportMode(exportItems[0][0]);
+      // Single exportable file: download it directly (proper blob/anchor
+      // download — Electron-safe, unlike window.open).
+      const mode = encodeURIComponent(exportItems[0][0]);
+      const url = `/api/proxy/ccp4i2/jobs/${job.id}/export_job_file?mode=${mode}`;
+      doDownload(url, exportItems[0][1]).catch((err) =>
+        setMessage(
+          `Export failed: ${err instanceof Error ? err.message : String(err)}`,
+          "error"
+        )
+      );
     } else if (exportItems.length > 1) {
-      // Multiple exportable files: let the user pick.
-      setExportMenuAnchor(e.currentTarget);
+      // Multiple exportable files: open the picker dialog.
+      setExportDialogJobId(job.id);
     }
   };
 
@@ -291,24 +295,11 @@ export default function ToolBar() {
               </MuiMenu>
             </>
           )}
-          {/* Export MTZ: picker shown only when >1 exportable file */}
-          <MuiMenu
-            anchorEl={exportMenuAnchor}
-            open={Boolean(exportMenuAnchor)}
-            onClose={() => setExportMenuAnchor(null)}
-          >
-            {exportItems.map(([mode, label]) => (
-              <MenuItem
-                key={mode}
-                onClick={() => {
-                  downloadExportMode(mode);
-                  setExportMenuAnchor(null);
-                }}
-              >
-                {label}
-              </MenuItem>
-            ))}
-          </MuiMenu>
+          {/* Export MTZ picker (shown only when >1 exportable file) */}
+          <ExportJobMenu
+            jobId={exportDialogJobId}
+            setJobId={setExportDialogJobId}
+          />
           <HelpIframe
             url={`/help/html/tasks/${job?.task_name}/index.html`}
             open={showHelpPanel}

--- a/server/ccp4i2/lib/utils/jobs/export.py
+++ b/server/ccp4i2/lib/utils/jobs/export.py
@@ -246,4 +246,8 @@ def export_job_file(pk, mode):
         filename=download_name,
         content_type="application/octet-stream",
     )
+    # The frontend download helper prefers a filename from this header.
+    import json as _json
+
+    response["X-Export-Info"] = _json.dumps({"original_filename": download_name})
     return response, None


### PR DESCRIPTION
Follow-up to #242 / #243. The **Export MTZ** button no-op'd.

## Cause

Two things:
1. The click handler downloaded via `window.open(url)` — which does **not** trigger a download in the Electron renderer (opens a blank window).
2. A complete, correct **`ExportJobMenu`** dialog already existed (`components/export-job-file-menu.tsx`) but was **never mounted**. It downloads properly (`apiFetch` → blob → anchor `link.download`), handles multiple files, loading/error states, and an `X-Export-Info` filename header.

## Fix

- **`tool-bar.tsx`** — drop `window.open` and the ad-hoc picker menu. Per the chosen UX: **single** exportable file → download directly via the shared `doDownload` helper; **multiple** → open the mounted `ExportJobMenu` dialog. Button visibility is still driven by the `export_job_file_menu` result (hidden when nothing to export).
- **`export-job-file-menu.tsx`** — export `doDownload` for reuse.
- **`lib/utils/jobs/export.py`** — set the `X-Export-Info` response header (`original_filename`) that the download helper prefers.

## Verification

End-to-end against a real Django DB for the screenshot case: a `prosmart_refmac` (REFMAC5) job → menu resolves the `refmac` subjob's `hklout.mtz`; `FileResponse` 200 with `Content-Disposition: attachment; filename="GammaDemo1_job_7_hklout.mtz"` and matching `X-Export-Info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)