### PR TITLE
fix(toolbar): gate Export MTZ presence (not just inline/overflow) on having an exportable file

### DIFF
--- a/client/renderer/components/tool-bar.tsx
+++ b/client/renderer/components/tool-bar.tsx
@@ -38,6 +38,10 @@ interface ToolbarButton {
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
   disabled?: boolean;
   show: boolean;
+  // When false, the button is omitted entirely (not shown inline OR in the
+  // overflow menu). Defaults to true. Use for buttons that are conditionally
+  // meaningful (e.g. Export MTZ only when the job has an exportable file).
+  available?: boolean;
 }
 
 export default function ToolBar() {
@@ -221,9 +225,10 @@ export default function ToolBar() {
         label: "Export MTZ",
         icon: <SystemUpdateAlt />,
         onClick: handleExportMtz,
-        // Shown only when the server reports an exportable MTZ for this job
+        show: panelWidth > 950,
+        // Present only when the server reports an exportable MTZ for this job
         // (which already implies a finished job with a real output file).
-        show: panelWidth > 950 && exportItems.length > 0,
+        available: exportItems.length > 0,
       },
       {
         label: "Show log file",
@@ -242,8 +247,17 @@ export default function ToolBar() {
     [panelWidth, job, projectId, router, exportItems]
   );
 
-  const visibleButtons = toolbarButtons.filter((btn) => btn.show);
-  const hiddenButtons = toolbarButtons.filter((btn) => !btn.show);
+  // A button whose `show` is false is moved to the overflow menu, so the
+  // width breakpoint alone must NOT govern availability — otherwise a
+  // narrow panel surfaces buttons that have nothing behind them (e.g. an
+  // Export MTZ with no exportable file, which then silently no-ops).
+  // `available` (default true) gates presence entirely; `show` only decides
+  // inline-vs-overflow.
+  const availableButtons = toolbarButtons.filter(
+    (btn) => btn.available !== false
+  );
+  const visibleButtons = availableButtons.filter((btn) => btn.show);
+  const hiddenButtons = availableButtons.filter((btn) => !btn.show);
 
   return (
     <>


### PR DESCRIPTION
Follow-up to #244.

## Cause

The Export MTZ button folded availability into its `show` flag (`panelWidth > 950 && exportItems.length > 0`). But in this toolbar `show` only decides **inline vs. overflow** — a button with `show=false` is *moved to the overflow `⋮` menu*, not hidden. So on a narrow panel the button appeared in the overflow menu **even when the job had no exportable file**, and clicking it matched neither branch of the handler → silent no-op (no console, no network).

## Fix

Separate the two concerns:
- new `available` flag (default true) gates **presence** entirely (inline *and* overflow);
- `show` governs only inline-vs-overflow placement.

Export MTZ now sets `available: exportItems.length > 0` and `show: panelWidth > 950`.

Note: the visible no-op people hit was compounded by the app running a **stale production build** (`client/dist`) that predated #244's `window.open`→`doDownload` fix; a rebuild is needed to pick that up. This PR fixes the separate, real overflow-gating bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)