### PR TITLE
fix(server): launch uvicorn with --ws none (backend is HTTP-only)

### DIFF
--- a/client/main/ccp4i2-django-server.ts
+++ b/client/main/ccp4i2-django-server.ts
@@ -192,8 +192,18 @@ export async function startDjangoServer(
 
   // Start Python process — ccp4i2 is pip-installed so uvicorn uses module path
   // Use 2 workers for concurrent requests (no --reload, requires manual restart)
+  //
+  // --ws none: the ccp4i2 backend is a plain HTTP Django ASGI app
+  // (get_asgi_application; no channels / websocket routing). uvicorn's default
+  // "--ws auto" eagerly imports its websockets protocol impl at startup, which
+  // on newer uvicorn (>=0.30) is the sansio impl that needs websockets>=13.
+  // If the environment ships an older websockets (e.g. the CCP4 bundle's 10.4),
+  // that import raises "cannot import name 'ServerProtocol'" and every worker
+  // crashes on boot. Since we never serve websockets, disable the protocol
+  // entirely rather than depend on a specific websockets version.
   const uvicornArgs = [
     "-m", "uvicorn", "ccp4i2.config.asgi:application", "--workers", "2",
+    "--ws", "none",
     "--log-level", "warning",  // Suppress per-request INFO access logs
   ];
 


### PR DESCRIPTION
## Symptom

The Django backend failed to start — every uvicorn worker crashed on boot with:

```
ImportError: cannot import name 'ServerProtocol' from 'websockets.server'
```

## Cause

The ccp4i2 backend is a **plain HTTP Django ASGI app** (`config/asgi.py` = `get_asgi_application()`; no channels, no websocket routing). But uvicorn's default `--ws auto` **eagerly imports its websockets protocol impl at startup even when unused**. On uvicorn ≥0.30 that's the new *sansio* impl, which imports `websockets.server.ServerProtocol` — a symbol that only exists in `websockets >= 13`.

When the environment ships an older `websockets` (the CCP4 bundle here has **websockets 10.4** with **uvicorn 0.51**), that import raises and all workers die.

## Fix

Pass **`--ws none`** so uvicorn skips the websockets protocol import entirely. Correct because the app genuinely never serves websockets — and it removes the dependency on a specific `websockets` version rather than pinning/upgrading a shared CCP4 bundle.

## Verification

- Default `--ws auto` → reproduces the `ServerProtocol` ImportError.
- `--ws none` → boots cleanly (`Application startup complete`, `Uvicorn running`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)