### PR TITLE
fix(purge): category-0 keep suppresses same-task higher-category rules

### DIFF
--- a/server/ccp4i2/core/CPurgeProject.py
+++ b/server/ccp4i2/core/CPurgeProject.py
@@ -301,16 +301,24 @@ class CPurgeProject:
 
         # Add task-specific entries
         if task_purge_list:
-            # Check for overrides (category 0)
+            # Category 0 means "keep": it must suppress EVERY purge rule for that
+            # pattern — both the defaults AND any same-task entry that lists the
+            # pattern at another category. Otherwise a task that writes e.g.
+            #   ['refmac%*/hklout.mtz', 0], ['refmac%*/hklout.mtz', 7]
+            # would still purge the file under category 7, silently defeating its
+            # own keep. So drop overridden patterns from both lists.
             overridden_patterns = {entry[0] for entry in task_purge_list if entry[1] == 0}
 
-            # Remove overridden patterns from default list
             if overridden_patterns:
                 search_list = [entry for entry in search_list
                              if entry[0] not in overridden_patterns]
 
-            # Add non-override task entries
-            search_list.extend([entry for entry in task_purge_list if entry[1] != 0])
+            # Add task entries, excluding both the keep markers (cat 0) and any
+            # non-zero entry for a pattern that a keep marker overrode.
+            search_list.extend([
+                entry for entry in task_purge_list
+                if entry[1] != 0 and entry[0] not in overridden_patterns
+            ])
 
         return search_list
 


### PR DESCRIPTION
Follow-up to #247, and likely the fix for the observed "prosmart_refmac deleted its refmac hklout.mtz" symptom.

## Bug

`_buildSearchList` treated a category-0 ("keep") `PURGESEARCHLIST` entry as overriding only the **default** SEARCHLIST. It then re-added *every* non-zero task entry — **including one for the same pattern at another category**. So prosmart_refmac's list:

```python
['refmac%*/hklout.mtz', 0],   # keep
['refmac%*/hklout.mtz', 7],   # "large file, deletable"
```

still purged the file under **category 7** in any context that includes 7 (`extended_intermediate = [1,2,5,7]`) — silently defeating its own keep. That's why the refmac subjob's `hklout.mtz` disappeared despite being "protected".

## Fix

Make category 0 mean **keep, unconditionally**: drop the overridden pattern from the default list *and* from the task's own non-zero entries.

## Verification

With prosmart_refmac's real `PURGESEARCHLIST`, no purge entry survives for `refmac%*/hklout.mtz`; unrelated task entries (e.g. `['foo.log', 2]`) are preserved.

## Relation to Export MTZ

This is one of three layers making Export MTZ reliable: (a) pipelines will copy a `COMPLETE_MTZ` to their top-level job dir as a tracked output [pending], (b) #247 makes tracked outputs unpurgeable, (c) this PR makes `PURGESEARCHLIST` keep-rules actually hold. Together they ensure the export target survives cleanup regardless of the `REFMAC_CLEANUP` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)