### PR TITLE
feat(export): COMPLETE_MTZ on refmac + prosmart_refmac (Phase 2b a1/a2)

### DIFF
--- a/server/ccp4i2/pipelines/prosmart_refmac/script/prosmart_refmac.py
+++ b/server/ccp4i2/pipelines/prosmart_refmac/script/prosmart_refmac.py
@@ -522,6 +522,12 @@ class prosmart_refmac(CPluginScript):
         self.container.outputData.COOTSCRIPTOUT.annotation = 'Coot script written from refinement'
         self.container.outputData.ANOMFPHIOUT.annotation = 'Weighted anomalous difference map from refinement'
         self.container.outputData.DIFANOMFPHIOUT.annotation = 'Weighted differences of anomalous difference map'
+        # COMPLETE_MTZ (the unsplit reflection file) was copied up from the terminal
+        # refmac child by the generic dataOrder() loop above; annotate it so the
+        # Export MTZ button can serve this tracked, purge-protected pipeline output.
+        if self.container.outputData.COMPLETE_MTZ.exists():
+            self.container.outputData.COMPLETE_MTZ.annotation.set(
+                'Complete unsplit reflection file from refinement')
 
         # Set ligand dictionary annotations
         if self.container.outputData.DICT.exists():

--- a/server/ccp4i2/tests/i2run/test_refmac.py
+++ b/server/ccp4i2/tests/i2run/test_refmac.py
@@ -277,3 +277,22 @@ def test_gamma_basic():
     args += ["--VALIDATE_MOLPROBITY", "False"]  # Explicitly disable MolProbity (requires rotarama_data)
     with i2run(args) as job:
         _check_output(job, anom=True, expected_cycles=5, expected_rwork=0.27, require_molprobity=False)
+
+
+def test_complete_mtz_survives_cleanup():
+    """The tracked COMPLETE_MTZ (unsplit reflection file) must be produced by the
+    pipeline AND survive REFMAC_CLEANUP=True, proving both a1 (wrapper output) and
+    a2 (copy-up into the pipeline dir) plus purge protection (#247)."""
+    args = ["prosmart_refmac"]
+    args += ["--F_SIGF", demoData("gamma", "merged_intensities_Xe.mtz")]
+    args += ["--XYZIN", demoData("gamma", "gamma_model.pdb")]
+    args += ["--NCYCLES", "2"]
+    args += ["--VALIDATE_MOLPROBITY", "False"]
+    args += ["--REFMAC_CLEANUP", "True"]  # Purge intermediate files after refinement
+    with i2run(args) as job:
+        complete = job / "COMPLETE_MTZ.mtz"
+        assert complete.is_file(), (
+            f"COMPLETE_MTZ.mtz missing from pipeline dir {job} after REFMAC_CLEANUP"
+        )
+        # Sanity: it is a readable MTZ with reflection data
+        read_mtz_file(str(complete))

--- a/server/ccp4i2/wrappers/refmac/script/refmac.def.xml
+++ b/server/ccp4i2/wrappers/refmac/script/refmac.def.xml
@@ -142,6 +142,13 @@ See the "Generate a Free R set" task in the "Data reduction" section.</toolTip>
             </content>
         </container>
         <container id="outputData">
+            <content id="COMPLETE_MTZ">
+                <className>CMtzDataFile</className>
+                <qualifiers>
+                    <saveToDb>True</saveToDb>
+                    <label>Complete reflection file</label>
+                </qualifiers>
+            </content>
             <content id="XYZOUT">
                 <className>CPdbDataFile</className>
                 <qualifiers>

--- a/server/ccp4i2/wrappers/refmac/script/refmac.py
+++ b/server/ccp4i2/wrappers/refmac/script/refmac.py
@@ -235,8 +235,17 @@ class refmac(CPluginScript):
         import os
 
         from ccp4i2.core import CCP4XtalData
-        hkloutFile=CCP4XtalData.CMtzDataFile(os.path.join(self.getWorkDirectory(), "hklout.mtz"))
+        hkloutPath = os.path.join(self.getWorkDirectory(), "hklout.mtz")
+        hkloutFile=CCP4XtalData.CMtzDataFile(hkloutPath)
         hkloutFile.loadFile()
+
+        # Track the complete, unsplit reflection file as a first-class output so
+        # the Export MTZ button can serve it and #247 protects it from purge.
+        # No copy needed - it already lives in this wrapper's work directory.
+        self.container.outputData.COMPLETE_MTZ.setFullPath(hkloutPath)
+        self.container.outputData.COMPLETE_MTZ.annotation.set(
+            "Complete unsplit reflection file from refinement")
+
         columnLabelsInFile = [column.columnLabel.__str__() for column in hkloutFile.fileContent.listOfColumns]
         print('columnLabelsInFile',columnLabelsInFile)
         


### PR DESCRIPTION
Phase 2b layer a for the **refmac reference pair** of the Export MTZ feature. Models the unsplit reflection file (`COMPLETE_MTZ`) as a tracked output at both the wrapper and pipeline level so the job-panel **Export MTZ** button reliably serves it and it survives cleanup.

## What & why

The naive "keep the child's `hklout.mtz`" approach is a dead end (proven by a real `REFMAC_CLEANUP=True` run — refmac declares no HKLOUT, and the child-dir purge deletes it). The fix is to model the file as a real output.

**a1 — wrapper (`refmac`)**
- `refmac.def.xml`: add `COMPLETE_MTZ` (`CMtzDataFile`, `saveToDb=True`) to `outputData`.
- `refmac.py processOutputFiles`: `setFullPath` + annotate `COMPLETE_MTZ` to the wrapper's own `hklout.mtz`, right where it is already loaded before the mini-MTZ split (no copy). Gleaned as a child output → #247 protects it in the child purge.

**a2 — pipeline (`prosmart_refmac`)**
- `prosmart_refmac.def.xml` inherits refmac's `outputData` via its `<file>` include, so `COMPLETE_MTZ` appears automatically.
- The existing `dataOrder()` copy-up loop in `finishUp()` copies the terminal refmac child's `COMPLETE_MTZ` into the pipeline dir **before** the child `purgeJob`; we add only the annotation.

The tracked pipeline output is then found by the generic Export MTZ fallback (`lib/utils/jobs/export.py`); the legacy `exportJobFile` locator stays as a fallback for pre-tracking jobs.

## Test

`test_complete_mtz_survives_cleanup` runs `prosmart_refmac` with `--REFMAC_CLEANUP True` and asserts `(job / "COMPLETE_MTZ.mtz").is_file()` — proving both production **and** survival past purge. Verified end-to-end; full `test_refmac.py` green (3 passed, 2 pre-existing clipper skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)