### PR TITLE
feat(export): COMPLETE_MTZ on servalcat + servalcat_pipe (Phase 2b a1/a2)

### DIFF
--- a/server/ccp4i2/pipelines/servalcat_pipe/script/servalcat_pipe.py
+++ b/server/ccp4i2/pipelines/servalcat_pipe/script/servalcat_pipe.py
@@ -1077,6 +1077,13 @@ class servalcat_pipe(CPluginScript):
                     servalcatJob.container.outputData.MAP_FOFC.annotation)
                 self.container.outputData.MAP_FOFC.subType = \
                     servalcatJob.container.outputData.MAP_FOFC.subType
+
+            # COMPLETE_MTZ (the unsplit reflection file) was copied up from the
+            # final servalcat child by the generic dataOrder() loop; annotate it
+            # so the Export MTZ button can serve this tracked pipeline output.
+            if self.container.outputData.COMPLETE_MTZ.exists():
+                self.container.outputData.COMPLETE_MTZ.annotation.set(
+                    'Complete unsplit reflection file from refinement')
         except Exception as e:
             self.appendErrorReport(101,
                 f'Failed to apply annotations: {e}')

--- a/server/ccp4i2/tests/i2run/test_servalcat.py
+++ b/server/ccp4i2/tests/i2run/test_servalcat.py
@@ -224,3 +224,32 @@ def check_r_and_cc(
     assert maxRfree is None or rfrees[-1] <= maxRfree
     assert minCCwork is None or ccworks[-1] >= minCCwork
     assert minCCfree is None or ccfrees[-1] >= minCCfree
+
+
+def test_complete_mtz_survives_cleanup(cif8xfm, mtz8xfm):
+    """The tracked COMPLETE_MTZ (unsplit reflection file) must be produced by the
+    pipeline AND survive REFMAC_CLEANUP=True, proving both a1 (wrapper output) and
+    a2 (copy-up into the pipeline dir) plus purge protection (#247)."""
+    from gemmi import read_mtz_file
+
+    args = ["servalcat_pipe"]
+    args += ["--XYZIN", cif8xfm]
+    args += ["--DATA_METHOD", "xtal"]
+    args += ["--HKLIN", f"fullPath={mtz8xfm}", "columnLabels=/*/*/[FP,SIGFP]"]
+    args += ["--FREERFLAG", f"fullPath={mtz8xfm}", "columnLabels=/*/*/[FREE]"]
+    args += ["--NCYCLES", "2"]
+    args += ["--ADD_WATERS", "False"]
+    args += ["--F_SIGF_OR_I_SIGI", "F_SIGF"]
+    args += ["--VALIDATE_IRIS", "False"]
+    args += ["--VALIDATE_BAVERAGE", "False"]
+    args += ["--VALIDATE_RAMACHANDRAN", "False"]
+    args += ["--VALIDATE_MOLPROBITY", "False"]
+    args += ["--RUN_ADP_ANALYSIS", "False"]
+    args += ["--RUN_COORDADPDEV_ANALYSIS", "False"]
+    args += ["--REFMAC_CLEANUP", "True"]  # Purge intermediate files after refinement
+    with i2run(args) as job:
+        complete = job / "COMPLETE_MTZ.mtz"
+        assert complete.is_file(), (
+            f"COMPLETE_MTZ.mtz missing from pipeline dir {job} after REFMAC_CLEANUP"
+        )
+        read_mtz_file(str(complete))

--- a/server/ccp4i2/wrappers/servalcat/script/servalcat.def.xml
+++ b/server/ccp4i2/wrappers/servalcat/script/servalcat.def.xml
@@ -138,6 +138,13 @@ See the "Generate a Free R set" task in the "Data reduction" section.</toolTip>
             </content>
         </container>
         <container id="outputData">
+            <content id="COMPLETE_MTZ">
+                <className>CMtzDataFile</className>
+                <qualifiers>
+                    <saveToDb>True</saveToDb>
+                    <label>Complete reflection file</label>
+                </qualifiers>
+            </content>
             <content id="CIFFILE">
                 <className>CPdbDataFile</className>
                 <qualifiers>

--- a/server/ccp4i2/wrappers/servalcat/script/servalcat.py
+++ b/server/ccp4i2/wrappers/servalcat/script/servalcat.py
@@ -203,6 +203,13 @@ class servalcat(CPluginScript):
                 f'Failed to read output MTZ: {e}\n{traceback.format_exc()}')
             return CPluginScript.FAILED
 
+        # Track the complete, unsplit reflection file as a first-class output so
+        # the Export MTZ button can serve it and #247 protects it from purge.
+        # No copy needed - it already lives in this wrapper's work directory.
+        self.container.outputData.COMPLETE_MTZ.setFullPath(hkloutFilePath)
+        self.container.outputData.COMPLETE_MTZ.annotation.set(
+            "Complete unsplit reflection file from refinement")
+
         if str(self.container.controlParameters.DATA_METHOD) == "xtal":
             if 'FAN' in columnLabelsInFile and 'PHAN' in columnLabelsInFile:
                 self.container.outputData.ANOMFPHIOUT.annotation.set(


### PR DESCRIPTION
Phase 2b layer a for the **servalcat pair** of the Export MTZ feature, mirroring #251 (refmac). Models the unsplit reflection file (`COMPLETE_MTZ`) as a tracked output at wrapper and pipeline level.

**a1 — wrapper (`servalcat`)**
- `servalcat.def.xml`: add `COMPLETE_MTZ` (`CMtzDataFile`, `saveToDb=True`) to `outputData`.
- `servalcat.py processOutputFiles`: `setFullPath` + annotate `COMPLETE_MTZ` to the wrapper's own unsplit reflection file — `refined.mtz` (xtal) / `refined_diffmap.mtz` (spa) — where it is already loaded before the mini-MTZ split (no copy). Gleaned as a child output → #247 protects it.

**a2 — pipeline (`servalcat_pipe`)**
- `servalcat_pipe.def.xml` inherits servalcat's `outputData` via its `<file>` include, so `COMPLETE_MTZ` appears automatically (its own `outputData` container only augments with `METALCOORD_*`).
- The existing `dataOrder()` copy-up loop copies the final servalcat child's `COMPLETE_MTZ` into the pipeline dir **before** the child `purgeJob`; we add the annotation in `_applyAnnotations`.

## Test

`test_complete_mtz_survives_cleanup` runs `servalcat_pipe` (xtal) with `--REFMAC_CLEANUP True` and asserts `(job / "COMPLETE_MTZ.mtz").is_file()`. Verified end-to-end; existing `test_8xfm_basic` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)