### PR TITLE
fix(toolbar): unwrap api_success envelope so Export MTZ button surfaces

### DIFF
--- a/client/renderer/components/tool-bar.tsx
+++ b/client/renderer/components/tool-bar.tsx
@@ -57,11 +57,17 @@ export default function ToolBar() {
 
   // Exportable data-file (MTZ) menu for this job. `result` is a list of
   // [mode, label, mimeType] items; empty => nothing to export (hide button).
+  // NOTE: get_endpoint's fetcher does NOT unwrap the {success, data} envelope
+  // that api_success() adds, so the menu arrives as either
+  // {success, data: {result}} (wrapped) or {result} (already unwrapped) —
+  // accept both so the button surfaces whenever the server reports a file.
   const { data: exportMenuData } = api.get_endpoint<{
-    result: [string, string, string][];
+    success?: boolean;
+    data?: { result?: [string, string, string][] };
+    result?: [string, string, string][];
   }>(jobId ? { type: "jobs", id: jobId, endpoint: "export_job_file_menu" } : null);
   const exportItems = useMemo(
-    () => exportMenuData?.result ?? [],
+    () => exportMenuData?.data?.result ?? exportMenuData?.result ?? [],
     [exportMenuData]
   );
   const { mutateJobs } = useProjectJobs(projectId);


### PR DESCRIPTION
## The bug

The **Export MTZ** toolbar button never appeared, even for jobs the server reports as exportable (verified: `export_job_file_menu` for a real `prosmart_refmac` job returns `[['complete_mtz', 'MTZ file', 'application/CCP4-mtz']]`).

`tool-bar.tsx` fetched the menu via `api.get_endpoint`, whose fetcher (`endpointFetcher → jsonFetcher → apiJson`) **does not** unwrap the `{success, data}` envelope that `api_success()` adds. So the menu arrived as `{success, data:{result:[...]}}` and the toolbar read `exportMenuData.result` — `undefined` → `exportItems = []` → the button was filtered out by its `available` gate.

The `job` fetch on the same component works because DRF returns the serialized `Job` unwrapped; only `api_success`-wrapped endpoints are affected. The sibling `ExportJobMenu` **dialog** already reads `data.data.result`, which is why its picker worked (reachable via the job context menu) while the toolbar button stayed hidden.

## The fix

Read `exportMenuData.data?.result ?? exportMenuData.result` so both wrapped and unwrapped shapes surface the button (and feed the single-item direct-download path in `handleExportMtz`).

Confirmed live: button now appears for a `prosmart_refmac` job with a tracked/locatable MTZ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)