### PR TITLE
feat(export): COMPLETE_MTZ on aimless_pipe + i2Dimple (Phase 2b a)

### DIFF
--- a/docs/EXPORT_MTZ_PLAN.md
+++ b/docs/EXPORT_MTZ_PLAN.md
@@ -1,6 +1,9 @@
 # Export MTZ — design & wiring plan
 
-Status: **design, not yet implemented** (2026-07-10, `django` branch).
+Status: **Phase 1, 2a, and 2b (a1/a2) IMPLEMENTED** (2026-07-10, `django` branch).
+COMPLETE_MTZ is a tracked output on refmac, servalcat, prosmart_refmac,
+servalcat_pipe, aimless_pipe and i2Dimple; the toolbar Export MTZ button
+surfaces and downloads it. See the Phase 2b section for the per-pipeline table.
 
 The job-panel toolbar (`client/renderer/components/tool-bar.tsx`) has an **Export
 MTZ** button that is currently a no-op (`onClick: () => {}`), gated by a
@@ -179,6 +182,26 @@ refmac `hklout.mtz` was still deleted. Why:
 
 So the child file is fundamentally fragile. The fix is to **model it as a real
 output — at BOTH the wrapper and the pipeline** (each serves a different role):
+
+**Layer a1/a2 — IMPLEMENTED (2026-07-10).**
+
+| Pipeline | PR | How COMPLETE_MTZ is produced |
+|----------|-----|------------------------------|
+| refmac + prosmart_refmac | #251 (merged) | a1 wrapper: setFullPath to `hklout.mtz`. a2 pipeline: inherits def.xml via `<file>` include; existing `dataOrder()` copy-up in `finishUp` copies it up + annotate. |
+| servalcat + servalcat_pipe | #252 (merged) | a1 wrapper: setFullPath to `refined.mtz`/`refined_diffmap.mtz`. a2 pipeline: inherits def.xml; `dataOrder()` copy-up + annotate in `_applyAnnotations`. |
+| aimless_pipe | #254 | Reconstructor (pipeline-only): `process_finish` recombines `HKLOUT[0]` + FreeR via `combine_mtz_files`; tracked outputData `CMtzDataFile`. |
+| i2Dimple | #254 | **Locator, single wrapper** (plan correction — dimple is NOT a reconstructor): it splits mini-MTZs from `final.mtz` in its own work dir, so `final.mtz` IS the unsplit file. `processOutputFiles` setFullPath to `final.mtz` (no copy). Tracked under its native name in the job's own dir. |
+
+Also fixed the frontend bug that hid the button (#253): `tool-bar.tsx` fetched
+`export_job_file_menu` via `get_endpoint`, whose fetcher does not unwrap the
+`{success, data}` envelope `api_success()` adds — so `exportMenuData.result` was
+`undefined` and the button was filtered out. Now reads `.data?.result ?? .result`.
+
+Verification: TDD i2run tests for all four pipelines pass end-to-end; refmac &
+servalcat assert survival past `REFMAC_CLEANUP=True`. The full refmac+servalcat
+i2run files are green (8 passed, 2 pre-existing clipper skips).
+
+Design notes below retained for context.
 
 **Layer a1 — model COMPLETE_MTZ on the WRAPPER (refmac, servalcat).** This is the
 primary, correct fix: declare the unsplit file as an output where it is

--- a/server/ccp4i2/pipelines/aimless_pipe/script/aimless_pipe.def.xml
+++ b/server/ccp4i2/pipelines/aimless_pipe/script/aimless_pipe.def.xml
@@ -213,6 +213,13 @@
           </subType>
         </qualifiers>
       </content>
+      <content id="COMPLETE_MTZ">
+        <className>CMtzDataFile</className>
+        <qualifiers>
+          <saveToDb>True</saveToDb>
+          <label>Complete reflection file</label>
+        </qualifiers>
+      </content>
       <content id="XMLOUT">
         <className>CXmlDataFile</className>
         <qualifiers>

--- a/server/ccp4i2/pipelines/aimless_pipe/script/aimless_pipe.py
+++ b/server/ccp4i2/pipelines/aimless_pipe/script/aimless_pipe.py
@@ -624,6 +624,20 @@ class aimless_pipe(CPluginScript):
                 e.append(freerxml)
         xmlroot.append(e)
 
+      # Build a tracked, unsplit COMPLETE_MTZ so the Export MTZ button can serve
+      # the reconstructed reflection file directly (found by the generic
+      # fallback) and it survives cleanup/project export. There is no single
+      # unsplit file here - aimless splits observed data across datasets and
+      # FreeR is generated separately - so recombine the primary observed
+      # dataset with the FreeR column (gemmi, no cad binary). Observed data
+      # first so it wins on any column-label clash.
+      if self.container.outputData.XMLOUT.isSet():  # i.e. not import_merged
+        try:
+            self.buildCompleteMtz()
+        except Exception as ex:
+            # Non-fatal: export just falls back to the legacy reconstruct path.
+            print('WARNING: aimless_pipe failed to build COMPLETE_MTZ:', ex)
+
       newXml = lxml_etree.tostring(xmlroot,pretty_print=True,encoding='unicode')
       xmlfile = open( xmlout, "w" )
       xmlfile.write(newXml)
@@ -677,6 +691,36 @@ class aimless_pipe(CPluginScript):
           self.reportStatus(CPluginScript.UNSATISFACTORY)
       else:
           self.reportStatus(status)
+
+    # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+    def buildCompleteMtz(self):
+        """Recombine the primary observed dataset + FreeR into a tracked
+        COMPLETE_MTZ in the pipeline job directory.
+
+        Mirrors the reconstruction the legacy exportJobFile does, but produces
+        a real tracked output (gleaned + purge-protected) rather than an
+        on-demand file. Observed data first so it wins on any label clash.
+        """
+        obsPath = None
+        if len(self.container.outputData.HKLOUT) > 0:
+            candidate = str(self.container.outputData.HKLOUT[0].fullPath)
+            if candidate and os.path.exists(candidate):
+                obsPath = candidate
+        if obsPath is None:
+            return  # nothing observed to export
+
+        sources = [obsPath]
+        if self.container.outputData.FREEROUT.isSet():
+            freerPath = str(self.container.outputData.FREEROUT.fullPath)
+            if freerPath and os.path.exists(freerPath):
+                sources.append(freerPath)
+
+        completePath = os.path.join(self.workDirectory, 'COMPLETE_MTZ.mtz')
+        from ccp4i2.lib.utils.jobs.export import combine_mtz_files
+        combine_mtz_files(sources, completePath)
+        self.container.outputData.COMPLETE_MTZ.setFullPath(completePath)
+        self.container.outputData.COMPLETE_MTZ.annotation.set(
+            'Complete reflection file (observed data + FreeR)')
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     def makeMmcifXML(self, containerXML):

--- a/server/ccp4i2/tests/i2run/test_aimless.py
+++ b/server/ccp4i2/tests/i2run/test_aimless.py
@@ -18,6 +18,17 @@ def check_result(job: Path, spacegroup, resolution, rmeas):
     assert float(tree.find(".//ResolutionHigh/Overall").text) == approx(resolution)
     assert float(tree.find(".//Rmeas/Overall").text) == approx(rmeas)
 
+    # COMPLETE_MTZ: reconstructed observed data + FreeR, tracked as a top-level
+    # output so the Export MTZ button can serve it (found by the generic
+    # fallback) and it survives cleanup / project export (#247).
+    complete = job / "COMPLETE_MTZ.mtz"
+    assert complete.is_file(), f"COMPLETE_MTZ.mtz missing from {job}"
+    mtz = read_mtz_file(str(complete))
+    labels = {c.label for c in mtz.columns}
+    assert "FREER" in labels, (
+        f"COMPLETE_MTZ should carry the FreeR column; got {sorted(labels)}"
+    )
+
 
 def test_gamma():
     mtz = demoData("gamma", "gamma_native.mtz")

--- a/server/ccp4i2/tests/i2run/test_dimple.py
+++ b/server/ccp4i2/tests/i2run/test_dimple.py
@@ -1,9 +1,12 @@
 import xml.etree.ElementTree as ET
+from pathlib import Path
 import gemmi
 from .utils import demoData, i2run
 
 
 def test_dimple():
+    from ccp4i2.db import models
+
     args = ["i2Dimple"]  # Plugin is named i2Dimple in registry
     args += ["--F_SIGF", demoData("gamma", "merged_intensities_native.mtz")]
     args += ["--XYZIN", demoData("gamma", "gamma_model.pdb")]
@@ -11,3 +14,25 @@ def test_dimple():
         for name in ["FPHIOUT", "FPHIOUT"]:
             gemmi.read_mtz_file(str(job / f"{name}.mtz"))
         xml = ET.parse(job / "program.xml")
+
+        # COMPLETE_MTZ: dimple's unsplit reflection file (final.mtz), tracked as
+        # a top-level output so the Export MTZ button can serve it (via the
+        # generic fallback over tracked output-MTZ Files). A standalone wrapper
+        # keeps the file's native name (final.mtz) rather than renaming to
+        # COMPLETE_MTZ.mtz - the invariant is that it lives in the job's own
+        # top-level dir, which it does. Assert on the gleaned File the export
+        # path actually resolves, not a fixed filename.
+        job_number = job.name.replace("job_", "")
+        job_record = models.Job.objects.filter(number=job_number).first()
+        complete = models.File.objects.filter(
+            job=job_record, job_param_name="COMPLETE_MTZ"
+        ).first()
+        assert complete is not None, "COMPLETE_MTZ not gleaned as a tracked output"
+        complete_path = Path(complete.path)
+        assert complete_path.is_file(), (
+            f"tracked COMPLETE_MTZ {complete_path} missing on disk"
+        )
+        assert complete_path.parent == job, (
+            f"COMPLETE_MTZ must live in the job's own dir; got {complete_path}"
+        )
+        gemmi.read_mtz_file(str(complete_path))

--- a/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.def.xml
+++ b/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.def.xml
@@ -40,6 +40,13 @@
             </content>
         </container>
         <container id="outputData">
+            <content id="COMPLETE_MTZ">
+                <className>CMtzDataFile</className>
+                <qualifiers>
+                    <saveToDb>True</saveToDb>
+                    <label>Complete reflection file</label>
+                </qualifiers>
+            </content>
             <content id="XYZOUT">
                 <className>CPdbDataFile</className>
                 <qualifiers>

--- a/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.py
+++ b/server/ccp4i2/wrappers/i2Dimple/script/i2Dimple.py
@@ -66,6 +66,15 @@ class i2Dimple(CPluginScript):
         outputFiles = ['FPHIOUT','DIFFPHIOUT']
         outputColumns = ['FWT,PHWT','DELFWT,PHDELWT']
         infile = os.path.join(self.workDirectory,'final.mtz')
+
+        # Track dimple's complete, unsplit reflection file (final.mtz) as a
+        # first-class output so the Export MTZ button can serve it and #247
+        # protects it from purge. No copy - it is already in the work dir.
+        if os.path.exists(infile):
+            self.container.outputData.COMPLETE_MTZ.setFullPath(infile)
+            self.container.outputData.COMPLETE_MTZ.annotation.set(
+                'Complete unsplit reflection file from dimple')
+
         error = self.splitHklout(outputFiles,outputColumns,infile=infile)
         if error.maxSeverity()>CCP4ErrorHandling.SEVERITY_WARNING:
             return CPluginScript.FAILED


### PR DESCRIPTION
Completes **Phase 2b layer a** for the two remaining Export-MTZ pipelines, after #251 (refmac) and #252 (servalcat). Neither uses the refmac/servalcat wrapper pair, so each is handled on its own terms.

## aimless_pipe — reconstructor (pipeline-only)

There is no single unsplit file: observed data is split across datasets and FreeR is generated separately. `process_finish()` now recombines the primary observed dataset (`HKLOUT[0]`) with the FreeR column via `combine_mtz_files` (gemmi, **no cad binary**; observed first so it wins on any label clash) into a tracked `COMPLETE_MTZ`, built before `reportStatus`. `def.xml` gains the `outputData CMtzDataFile`. Guarded to the non-`import_merged` path and non-fatal (falls back to the legacy `exportJobFile` reconstruct if it can't build).

## i2Dimple — locator (single wrapper)

**Correction to the plan:** dimple is not a reconstructor. It already splits its mini-MTZs from `final.mtz` in its own work dir, so `final.mtz` **is** the natural unsplit file — no reconstruction needed. `processOutputFiles` `setFullPath` + annotates `COMPLETE_MTZ` to `final.mtz` (no copy) before the split; `def.xml` gains the entry. Being a standalone top-level wrapper, the gleaner tracks it under its **native name** (`final.mtz`) in the job's own dir — the generic Export fallback and #247 key on the tracked `File`, not a fixed filename, so this is correct.

## Tests

- `test_aimless.check_result` asserts `COMPLETE_MTZ.mtz` exists and carries the `FREER` column (both `test_gamma` and `test_mdm2`).
- `test_dimple` asserts `COMPLETE_MTZ` is gleaned as a tracked output living in the job's own dir (name-agnostic — matches how export resolves it).

Both verified end-to-end. Also confirmed no regression: the full refmac+servalcat i2run files pass (8 passed, 2 pre-existing clipper skips) on the merged a1/a2 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)