### PR TITLE
feat(preferences): binary/program discovery + Tips of the Day

### DIFF
--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -163,6 +163,28 @@ export const installIpcHandlers = (
       });
   });
 
+  // Generic native path picker for the preferences UI (Program locations).
+  // Promise-returning (ipcMain.handle): opens a directory or file chooser and
+  // returns the selected absolute path, or null if cancelled. No side effects.
+  ipcMain.handle(
+    "browse-path",
+    async (
+      _event,
+      opts: { mode?: "directory" | "file"; title?: string } = {}
+    ): Promise<string | null> => {
+      const mainWindow: BrowserWindow | null = getMainWindow();
+      if (!mainWindow) return null;
+      const properties: Array<"openDirectory" | "openFile"> =
+        opts.mode === "file" ? ["openFile"] : ["openDirectory"];
+      const result = await dialog.showOpenDialog(mainWindow, {
+        properties,
+        title: opts.title,
+      });
+      if (result.canceled || result.filePaths.length === 0) return null;
+      return result.filePaths[0];
+    }
+  );
+
   // IPC communication to trigger file dialog to locate the ccp4i2 project root
   ipcMain.on("locate-project-root", (event, _data) => {
     const mainWindow: BrowserWindow | null = getMainWindow();

--- a/client/preload/index.cjs
+++ b/client/preload/index.cjs
@@ -7,6 +7,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   removeMessageListener: (channel, callback) => {
     ipcRenderer.removeListener(channel, callback);
   },
+  // Promise-returning IPC (ipcMain.handle). Used e.g. by the Program locations
+  // preferences panel to open a native file/folder picker and get the path back.
+  invoke: (channel, data) => ipcRenderer.invoke(channel, data),
 });
 
 // LocalSession surface — exposes the per-launch token and the

--- a/client/renderer/app/ccp4i2/(authed)/preferences/page.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/preferences/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { ProgramLocations } from "@/components/program-locations";
+import { Paper } from "@mui/material";
+import { NavigationShortcutsProvider } from "@/providers/navigation-shortcuts-provider";
+import CCP4i2TopBar from "@/components/ccp4i2-topbar";
+
+/**
+ * Preferences — running-app settings (distinct from the launch/get-ready
+ * screen at /ccp4i2/config). First section is Program locations (binary
+ * discovery); more preference sections can be added here over time.
+ */
+export default function PreferencesPage() {
+  return (
+    <NavigationShortcutsProvider>
+      <CCP4i2TopBar title="Preferences" showBackButton backPath="/ccp4i2" />
+      <Paper
+        sx={{
+          minHeight: "calc(100vh - 80px)",
+          overflowY: "auto",
+          py: 3,
+        }}
+      >
+        <ProgramLocations />
+      </Paper>
+    </NavigationShortcutsProvider>
+  );
+}

--- a/client/renderer/components/edit-menu.tsx
+++ b/client/renderer/components/edit-menu.tsx
@@ -31,7 +31,7 @@ export default function EditMenu() {
 
   const handlePreferences = () => {
     handleClose();
-    router.push("/ccp4i2/config");
+    router.push("/ccp4i2/preferences");
   };
 
   return (

--- a/client/renderer/components/help-menu.tsx
+++ b/client/renderer/components/help-menu.tsx
@@ -14,7 +14,8 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { Help, Info, MenuBook } from "@mui/icons-material";
+import { Help, Info, MenuBook, EmojiObjects } from "@mui/icons-material";
+import { TipOfTheDayDialog } from "./tip-of-the-day-dialog";
 
 const CCP4I2_HELP_URL = "https://www.ccp4.ac.uk/html/ccp4i2.html";
 
@@ -26,6 +27,7 @@ export default function HelpMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const [aboutOpen, setAboutOpen] = useState(false);
+  const [tipOpen, setTipOpen] = useState(false);
   const [version, setVersion] = useState<VersionInfo | null>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -57,6 +59,11 @@ export default function HelpMenu() {
     window.open(CCP4I2_HELP_URL, "_blank", "noopener,noreferrer");
   };
 
+  const handleTip = () => {
+    handleClose();
+    setTipOpen(true);
+  };
+
   return (
     <>
       <Button color="inherit" onClick={handleClick}>
@@ -72,6 +79,12 @@ export default function HelpMenu() {
             (F1)
           </Typography>
         </MenuItem>
+        <MenuItem onClick={handleTip}>
+          <ListItemIcon>
+            <EmojiObjects fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Tip of the day</ListItemText>
+        </MenuItem>
         <MenuItem onClick={handleAbout}>
           <ListItemIcon>
             <Info fontSize="small" />
@@ -79,6 +92,8 @@ export default function HelpMenu() {
           <ListItemText>About CCP4i2</ListItemText>
         </MenuItem>
       </Menu>
+
+      <TipOfTheDayDialog open={tipOpen} onClose={() => setTipOpen(false)} />
 
       <Dialog
         open={aboutOpen}

--- a/client/renderer/components/program-locations.tsx
+++ b/client/renderer/components/program-locations.tsx
@@ -26,6 +26,7 @@ interface ProgramStatus {
   name: string;
   path: string | null;
   source: string;
+  tasks?: string[];
 }
 
 // Explicit path fields shown as their own inputs (the rest go via exePaths).
@@ -273,7 +274,12 @@ export function ProgramLocations() {
       {/* Live discovery status */}
       <Box>
         <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
-          <Typography variant="subtitle2">Discovered programs</Typography>
+          <Typography variant="subtitle2">Task programs</Typography>
+          {statuses.length > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              {statuses.filter((s) => s.path != null).length}/{statuses.length} found
+            </Typography>
+          )}
           <Tooltip title="Re-probe">
             <IconButton size="small" onClick={loadStatuses} disabled={saving}>
               <Refresh fontSize="small" />
@@ -281,31 +287,49 @@ export function ProgramLocations() {
           </Tooltip>
           {saving && <CircularProgress size={16} />}
         </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+          The external programs each task runs (from the task registry). Hover for
+          the resolved path and which tasks use it.
+        </Typography>
         <Paper variant="outlined" sx={{ p: 1.5 }}>
           <Box
             sx={{
               display: "grid",
-              gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+              gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
               gap: 1,
             }}
           >
-            {statuses.map((s) => {
-              const found = s.path != null;
-              return (
-                <Tooltip
-                  key={s.name}
-                  title={found ? `${s.path} (${SOURCE_LABEL[s.source] ?? s.source})` : "not found"}
-                >
-                  <Chip
-                    icon={found ? <CheckCircle /> : <ErrorOutline />}
-                    color={found ? "success" : "default"}
-                    variant={found ? "filled" : "outlined"}
-                    label={s.name}
-                    size="small"
-                  />
-                </Tooltip>
-              );
-            })}
+            {[...statuses]
+              .sort((a, b) => {
+                // Missing first (they're what the user needs to act on), then name.
+                const am = a.path == null ? 0 : 1;
+                const bm = b.path == null ? 0 : 1;
+                return am - bm || a.name.localeCompare(b.name);
+              })
+              .map((s) => {
+                const found = s.path != null;
+                const usedBy = s.tasks && s.tasks.length
+                  ? `\nused by: ${s.tasks.join(", ")}`
+                  : "";
+                return (
+                  <Tooltip
+                    key={s.name}
+                    title={
+                      (found
+                        ? `${s.path} (${SOURCE_LABEL[s.source] ?? s.source})`
+                        : "not found on PATH or in your program locations") + usedBy
+                    }
+                  >
+                    <Chip
+                      icon={found ? <CheckCircle /> : <ErrorOutline />}
+                      color={found ? "success" : "warning"}
+                      variant={found ? "filled" : "outlined"}
+                      label={s.name}
+                      size="small"
+                    />
+                  </Tooltip>
+                );
+              })}
           </Box>
         </Paper>
       </Box>

--- a/client/renderer/components/program-locations.tsx
+++ b/client/renderer/components/program-locations.tsx
@@ -17,6 +17,7 @@ import {
   Add,
   Delete,
   Refresh,
+  FolderOpen,
 } from "@mui/icons-material";
 import React, { useCallback, useEffect, useState } from "react";
 import { apiGet, apiPatch } from "../api-fetch";
@@ -28,13 +29,41 @@ interface ProgramStatus {
 }
 
 // Explicit path fields shown as their own inputs (the rest go via exePaths).
-const EXPLICIT_FIELDS: { key: string; label: string; help: string }[] = [
-  { key: "COOT_EXECUTABLE", label: "Coot executable", help: "Full path to the coot binary" },
-  { key: "CCP4MG_EXECUTABLE", label: "CCP4mg executable", help: "Full path to the ccp4mg binary" },
-  { key: "SHELXDIR", label: "SHELX directory", help: "Directory containing shelxc/d/e/l" },
-  { key: "DIALSDIR", label: "DIALS directory", help: "Directory containing dials binaries" },
-  { key: "BUSTERDIR", label: "BUSTER directory", help: "Directory containing the BUSTER refine binary" },
+// `browse` picks the native-picker mode: "file" for a single executable,
+// "directory" for a suite install dir.
+const EXPLICIT_FIELDS: {
+  key: string;
+  label: string;
+  help: string;
+  browse: "file" | "directory";
+}[] = [
+  { key: "COOT_EXECUTABLE", label: "Coot executable", help: "Full path to the coot binary", browse: "file" },
+  { key: "CCP4MG_EXECUTABLE", label: "CCP4mg executable", help: "Full path to the ccp4mg binary", browse: "file" },
+  { key: "SHELXDIR", label: "SHELX directory", help: "Directory containing shelxc/d/e/l", browse: "directory" },
+  { key: "DIALSDIR", label: "DIALS directory", help: "Directory containing dials binaries", browse: "directory" },
+  { key: "BUSTERDIR", label: "BUSTER directory", help: "Directory containing the BUSTER refine binary", browse: "directory" },
 ];
+
+/** Open the native picker via Electron IPC; returns null in the web build. */
+async function browsePath(
+  mode: "file" | "directory",
+  title?: string
+): Promise<string | null> {
+  const api = typeof window !== "undefined" ? window.electronAPI : undefined;
+  if (!api?.invoke) return null;
+  try {
+    return (await api.invoke("browse-path", { mode, title })) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True in the Electron desktop build (native picker available). */
+function canBrowse(): boolean {
+  return (
+    typeof window !== "undefined" && Boolean(window.electronAPI?.invoke)
+  );
+}
 
 const SOURCE_LABEL: Record<string, string> = {
   executable_pref: "explicit path",
@@ -102,13 +131,29 @@ export function ProgramLocations() {
   const handleExplicitBlur = (key: string, value: string) => {
     if ((prefs[key] ?? "") !== value) persist({ [key]: value });
   };
-  const handleAddPath = () => {
-    const p = newPath.trim();
-    if (!p || exePaths.includes(p)) return;
-    const next = [...exePaths, p];
+  const handleBrowseExplicit = async (
+    key: string,
+    mode: "file" | "directory",
+    label: string
+  ) => {
+    const picked = await browsePath(mode, `Select ${label}`);
+    if (picked && picked !== (prefs[key] ?? "")) {
+      setPrefs((p) => ({ ...p, [key]: picked }));
+      persist({ [key]: picked });
+    }
+  };
+  const addPath = (p: string) => {
+    const trimmed = p.trim();
+    if (!trimmed || exePaths.includes(trimmed)) return;
+    const next = [...exePaths, trimmed];
     setExePaths(next);
     setNewPath("");
     persist({ exePaths: next });
+  };
+  const handleAddPath = () => addPath(newPath);
+  const handleBrowseAddPath = async () => {
+    const picked = await browsePath("directory", "Add executable search directory");
+    if (picked) addPath(picked);
   };
   const handleRemovePath = (p: string) => {
     const next = exePaths.filter((x) => x !== p);
@@ -143,16 +188,30 @@ export function ProgramLocations() {
       {/* Explicit per-program fields */}
       <Stack spacing={2}>
         {EXPLICIT_FIELDS.map((f) => (
-          <TextField
-            key={f.key}
-            label={f.label}
-            helperText={f.help}
-            defaultValue={prefs[f.key] ?? ""}
-            disabled={!editable || saving}
-            size="small"
-            fullWidth
-            onBlur={(e) => handleExplicitBlur(f.key, e.target.value.trim())}
-          />
+          <Stack key={f.key} direction="row" spacing={1} alignItems="flex-start">
+            <TextField
+              label={f.label}
+              helperText={f.help}
+              value={prefs[f.key] ?? ""}
+              disabled={!editable || saving}
+              size="small"
+              fullWidth
+              onChange={(e) =>
+                setPrefs((p) => ({ ...p, [f.key]: e.target.value }))
+              }
+              onBlur={(e) => handleExplicitBlur(f.key, e.target.value.trim())}
+            />
+            {editable && canBrowse() && (
+              <Button
+                startIcon={<FolderOpen />}
+                onClick={() => handleBrowseExplicit(f.key, f.browse, f.label)}
+                disabled={saving}
+                sx={{ mt: 0.25, whiteSpace: "nowrap" }}
+              >
+                Browse
+              </Button>
+            )}
+          </Stack>
         ))}
       </Stack>
 
@@ -190,6 +249,16 @@ export function ProgramLocations() {
               onKeyDown={(e) => e.key === "Enter" && handleAddPath()}
               fullWidth
             />
+            {canBrowse() && (
+              <Button
+                startIcon={<FolderOpen />}
+                onClick={handleBrowseAddPath}
+                disabled={saving}
+                sx={{ whiteSpace: "nowrap" }}
+              >
+                Browse
+              </Button>
+            )}
             <Button
               startIcon={<Add />}
               onClick={handleAddPath}

--- a/client/renderer/components/program-locations.tsx
+++ b/client/renderer/components/program-locations.tsx
@@ -1,0 +1,245 @@
+"use client";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  CheckCircle,
+  ErrorOutline,
+  Add,
+  Delete,
+  Refresh,
+} from "@mui/icons-material";
+import React, { useCallback, useEffect, useState } from "react";
+import { apiGet, apiPatch } from "../api-fetch";
+
+interface ProgramStatus {
+  name: string;
+  path: string | null;
+  source: string;
+}
+
+// Explicit path fields shown as their own inputs (the rest go via exePaths).
+const EXPLICIT_FIELDS: { key: string; label: string; help: string }[] = [
+  { key: "COOT_EXECUTABLE", label: "Coot executable", help: "Full path to the coot binary" },
+  { key: "CCP4MG_EXECUTABLE", label: "CCP4mg executable", help: "Full path to the ccp4mg binary" },
+  { key: "SHELXDIR", label: "SHELX directory", help: "Directory containing shelxc/d/e/l" },
+  { key: "DIALSDIR", label: "DIALS directory", help: "Directory containing dials binaries" },
+  { key: "BUSTERDIR", label: "BUSTER directory", help: "Directory containing the BUSTER refine binary" },
+];
+
+const SOURCE_LABEL: Record<string, string> = {
+  executable_pref: "explicit path",
+  suite_dir: "suite directory",
+  exe_paths: "extra search path",
+  path: "PATH",
+  missing: "not found",
+};
+
+/**
+ * Program locations preferences: let a user point CCP4i2 at programs installed
+ * off PATH. Reads/writes the desktop preferences.json via the config API; in a
+ * cloud deployment the API reports editable=false and the panel is read-only
+ * (values come from environment variables there).
+ */
+export function ProgramLocations() {
+  const [editable, setEditable] = useState<boolean>(false);
+  const [prefs, setPrefs] = useState<Record<string, any>>({});
+  const [exePaths, setExePaths] = useState<string[]>([]);
+  const [statuses, setStatuses] = useState<ProgramStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [newPath, setNewPath] = useState("");
+
+  const loadPrefs = useCallback(async () => {
+    const resp = await apiGet<any>("config/program-preferences/");
+    const data = resp?.data ?? resp;
+    setEditable(Boolean(data?.editable));
+    const p = data?.preferences ?? {};
+    setPrefs(p);
+    setExePaths(Array.isArray(p.exePaths) ? p.exePaths : []);
+  }, []);
+
+  const loadStatuses = useCallback(async () => {
+    const resp = await apiGet<any>("config/discover-programs/");
+    const data = resp?.data ?? resp;
+    setStatuses(data?.programs ?? []);
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        await Promise.all([loadPrefs(), loadStatuses()]);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [loadPrefs, loadStatuses]);
+
+  const persist = useCallback(
+    async (updates: Record<string, any>) => {
+      setSaving(true);
+      try {
+        await apiPatch("config/program-preferences/set/", updates);
+        // Re-probe after a change so the status chips reflect it.
+        await Promise.all([loadPrefs(), loadStatuses()]);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [loadPrefs, loadStatuses]
+  );
+
+  const handleExplicitBlur = (key: string, value: string) => {
+    if ((prefs[key] ?? "") !== value) persist({ [key]: value });
+  };
+  const handleAddPath = () => {
+    const p = newPath.trim();
+    if (!p || exePaths.includes(p)) return;
+    const next = [...exePaths, p];
+    setExePaths(next);
+    setNewPath("");
+    persist({ exePaths: next });
+  };
+  const handleRemovePath = (p: string) => {
+    const next = exePaths.filter((x) => x !== p);
+    setExePaths(next);
+    persist({ exePaths: next });
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={3} sx={{ maxWidth: 720, mx: "auto", p: 2 }}>
+      <Box>
+        <Typography variant="h6">Program locations</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Point CCP4i2 at programs installed outside your PATH. Resolution order:
+          explicit path → suite directory → extra search paths → PATH.
+        </Typography>
+        {!editable && (
+          <Typography variant="body2" color="warning.main" sx={{ mt: 1 }}>
+            Read-only: in a server deployment these are set via environment
+            variables.
+          </Typography>
+        )}
+      </Box>
+
+      {/* Explicit per-program fields */}
+      <Stack spacing={2}>
+        {EXPLICIT_FIELDS.map((f) => (
+          <TextField
+            key={f.key}
+            label={f.label}
+            helperText={f.help}
+            defaultValue={prefs[f.key] ?? ""}
+            disabled={!editable || saving}
+            size="small"
+            fullWidth
+            onBlur={(e) => handleExplicitBlur(f.key, e.target.value.trim())}
+          />
+        ))}
+      </Stack>
+
+      {/* Extra search paths (exePaths / legacy EXEPATHLIST) */}
+      <Box>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Extra executable search directories
+        </Typography>
+        <Stack spacing={1}>
+          {exePaths.map((p) => (
+            <Stack key={p} direction="row" spacing={1} alignItems="center">
+              <Typography variant="body2" sx={{ flexGrow: 1, wordBreak: "break-all" }}>
+                {p}
+              </Typography>
+              {editable && (
+                <IconButton size="small" onClick={() => handleRemovePath(p)}>
+                  <Delete fontSize="small" />
+                </IconButton>
+              )}
+            </Stack>
+          ))}
+          {exePaths.length === 0 && (
+            <Typography variant="body2" color="text.secondary">
+              None.
+            </Typography>
+          )}
+        </Stack>
+        {editable && (
+          <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+            <TextField
+              size="small"
+              placeholder="/path/to/bin"
+              value={newPath}
+              onChange={(e) => setNewPath(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleAddPath()}
+              fullWidth
+            />
+            <Button
+              startIcon={<Add />}
+              onClick={handleAddPath}
+              disabled={!newPath.trim() || saving}
+            >
+              Add
+            </Button>
+          </Stack>
+        )}
+      </Box>
+
+      {/* Live discovery status */}
+      <Box>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+          <Typography variant="subtitle2">Discovered programs</Typography>
+          <Tooltip title="Re-probe">
+            <IconButton size="small" onClick={loadStatuses} disabled={saving}>
+              <Refresh fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          {saving && <CircularProgress size={16} />}
+        </Stack>
+        <Paper variant="outlined" sx={{ p: 1.5 }}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+              gap: 1,
+            }}
+          >
+            {statuses.map((s) => {
+              const found = s.path != null;
+              return (
+                <Tooltip
+                  key={s.name}
+                  title={found ? `${s.path} (${SOURCE_LABEL[s.source] ?? s.source})` : "not found"}
+                >
+                  <Chip
+                    icon={found ? <CheckCircle /> : <ErrorOutline />}
+                    color={found ? "success" : "default"}
+                    variant={found ? "filled" : "outlined"}
+                    label={s.name}
+                    size="small"
+                  />
+                </Tooltip>
+              );
+            })}
+          </Box>
+        </Paper>
+      </Box>
+    </Stack>
+  );
+}

--- a/client/renderer/components/tip-of-the-day-dialog.tsx
+++ b/client/renderer/components/tip-of-the-day-dialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  CircularProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { EmojiObjects, Refresh } from "@mui/icons-material";
+import React, { useCallback, useEffect, useState } from "react";
+import { apiGet } from "../api-fetch";
+
+interface TipData {
+  id: number;
+  html: string;
+  count: number;
+}
+
+/**
+ * Tip of the Day dialog. Fetches a random tip's body HTML from the tips API and
+ * renders it; "Next tip" fetches another. Content is bundled, first-party HTML
+ * (server/ccp4i2/tipsOfTheDay/*.html) with images served via the tips route.
+ */
+export function TipOfTheDayDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [tip, setTip] = useState<TipData | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchTip = useCallback(async () => {
+    setLoading(true);
+    try {
+      const resp = await apiGet<any>("tips/");
+      const data = resp?.data ?? resp;
+      if (data?.html != null) setTip(data as TipData);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open && !tip) fetchTip();
+  }, [open, tip, fetchTip]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <EmojiObjects fontSize="small" color="warning" />
+          <span>Tip of the day</span>
+        </Stack>
+      </DialogTitle>
+      <DialogContent dividers>
+        {loading || !tip ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              "& img": { maxWidth: "100%", height: "auto" },
+              "& div": { width: "auto !important" },
+            }}
+            // Bundled first-party tip HTML.
+            dangerouslySetInnerHTML={{ __html: tip.html }}
+          />
+        )}
+      </DialogContent>
+      <DialogActions sx={{ justifyContent: "space-between", px: 3 }}>
+        <Typography variant="caption" color="text.secondary">
+          {tip ? `Tip ${tip.id} of ${tip.count}` : ""}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button startIcon={<Refresh />} onClick={fetchTip} disabled={loading}>
+            Next tip
+          </Button>
+          <Button onClick={onClose}>Close</Button>
+        </Stack>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/renderer/types/global.d.ts
+++ b/client/renderer/types/global.d.ts
@@ -13,6 +13,7 @@ declare global {
       ) => typeof ipcRenderer.off;
       sendMessage: (channel: string, ...args: any[]) => typeof ipcRenderer.send;
       sendSync: (channel: string, ...args: any[]) => any;
+      invoke?: (channel: string, data?: any) => Promise<any>;
     };
   }
 }

--- a/docs/PREFERENCES_BINARY_DISCOVERY_PLAN.md
+++ b/docs/PREFERENCES_BINARY_DISCOVERY_PLAN.md
@@ -1,0 +1,134 @@
+# Preferences & binary discovery — design & wiring plan
+
+Status: **IMPLEMENTED** (2026-07-11, `django` branch, branch
+`feat/preferences-binary-discovery`).
+
+## What shipped
+
+- **`config/program_discovery.py`** — resolution: explicit `{PROG}_EXECUTABLE`
+  → `{SUITE}DIR`+exe → `exePaths` list → `PATH` → missing. Reports the source.
+  Pure stdlib (slim-server safe; imported by both the server probe and the
+  ccp4-python job env).
+- **`CCP4PluginScript`** — exec site now resolves via `resolve_program` (was a
+  bare `shutil.which`), with an actionable not-found log. Plus a
+  `_checkProgramAvailable` **advisory warning** in `runTimeValidity` so a
+  missing program surfaces at **job-config time** (in the run dialog), not just
+  at execution. Pipelines with no single `TASKCOMMAND` (crank2) are skipped —
+  and crank2's internal shelx already reads the same `SHELXDIR` via
+  `PREFERENCES().SHELXDIR` → `user_preference`, so no change was needed there.
+- **`config/preferences_migration.py`** — one-time, **desktop-only**,
+  non-destructive, idempotent import of the legacy Qt GUI's program-location
+  prefs (`~/.CCP4I2/configs/guipreferences.params.xml`: COOT_EXECUTABLE,
+  SHELXDIR, …, and the EXEPATHLIST `CExePath` dirs → `exePaths`). Runs lazily on
+  the first `program-preferences` GET. Guarded by `preferences.is_desktop()`
+  (`CCP4I2_LOCAL_SESSION_TOKEN`).
+- **API** — `GET /config/discover-programs/` (universal probe),
+  `GET /config/program-preferences/` (values + `editable`),
+  `PATCH /config/program-preferences/set/` (desktop-only; 409 in cloud). Plus
+  `GET /tips/` (random tip HTML, image srcs rewritten) and
+  `GET /tips/image/<name>` (traversal-guarded).
+- **Frontend** — new `/ccp4i2/preferences` route (Edit→Preferences now points
+  here, not the launch screen) with a **Program locations** panel: explicit
+  fields + editable `exePaths` list + live found/not-found status chips. New
+  Help → **Tip of the day** dialog.
+- **Cloud posture** — discovery reads work in cloud via env vars
+  (`user_preference` env>file>default); migration + file writes are desktop-only
+  (409 write in cloud, `editable:false`). Tips ship in the wheel/image
+  (`tipsOfTheDay/` is not MANIFEST-pruned) and serve through the authed API.
+- **Tests** — `tests/unit/config/test_program_discovery.py` (11: resolution
+  order, precedence, env-override, migration desktop/cloud/idempotent/
+  non-destructive) + `tests/api/unit/test_config_and_tips_api.py` (6: discover,
+  desktop roundtrip, cloud read-only 409, tips random/specific/traversal).
+
+Original design notes retained below.
+
+---
+
+The Edit → Preferences menu item routes to the config page
+(`/ccp4i2/config`, `components/config-content.tsx`), which currently exposes
+only CCP4 dir, Projects dir, Python, backend, Theme, Developer mode. The legacy
+`main` branch had a much richer preferences set — and, crucially, **program /
+binary discovery controls that django lacks entirely**.
+
+## The gap (verified)
+
+**Django task-binary resolution is a bare PATH lookup with no override.**
+`core/CCP4PluginScript.py:1697`:
+
+```python
+exe_path = shutil.which(self.TASKCOMMAND)   # PATH only; no preference override
+```
+
+If a program (coot, ccp4mg, shelx, dials, buster) is not on `PATH`, the task
+fails and the user has **no supported way to point CCP4i2 at it**.
+
+**`main` solved this** in `CPluginScript.getCommand` (core/CCP4PluginScript.py
+~230-255), resolving per-program against preferences:
+
+| Pref (`main`) | Type | Meaning |
+|---------------|------|---------|
+| `COOT_EXECUTABLE` | path | explicit coot executable |
+| `CCP4MG_EXECUTABLE` | path | explicit ccp4mg executable |
+| `SHELXDIR` | dir | dir holding shelx* binaries (`join(dir, exeName)`) |
+| `DIALSDIR` / `BUSTERDIR` | dir | external-suite install dirs |
+| `EXEPATHLIST` | `CExePathList` | general extra search dirs; `getExecutable(exeName)` |
+
+Django `config/preferences.py` resolves only `ccp4Dir`, `ccp4i2Root`,
+`database`, `projectsDir`, `version`, `userPreferences` — none of the above.
+`COOT_EXECUTABLE` appears once, in a **docstring example only** (line 141), not
+consumed anywhere.
+
+## Plan
+
+### 1. Backend — a resolution layer
+
+- **`config/preferences.py`**: recognise new keys — `exePaths` (list, the
+  django name for `EXEPATHLIST`), and optional explicit `COOT_EXECUTABLE`,
+  `CCP4MG_EXECUTABLE`, `SHELXDIR`, `DIALSDIR`, `BUSTERDIR`. Same
+  env > preferences.json > default precedence as every other pref.
+- **`CCP4PluginScript`**: a `resolve_task_command(taskcommand)` helper used at
+  line 1697 in place of the bare `shutil.which`. Resolution order:
+  1. an explicit `{PROG}_EXECUTABLE` pref for known programs (coot, ccp4mg);
+  2. a `{SUITE}DIR` pref joined with the exe name (shelx*, dials, buster);
+  3. each dir in `exePaths` (the general `EXEPATHLIST` equivalent);
+  4. `shutil.which(taskcommand)` (PATH) — unchanged default;
+  5. fail with an **actionable** message naming the program and pointing at the
+     Preferences → Program locations UI.
+- Keep it slim-server-safe: pure path resolution, no CCP4 import; the jobs run
+  in ccp4-python where this executes.
+
+### 2. Backend — a discovery/probe endpoint
+
+- `GET /api/config/discover_programs/` (or a config action): for a known list of
+  programs, report `{name, resolved_path | null, source: pref|dir|PATH|missing}`.
+  Powers the live "found at /…" indicator in the UI. Read-only; no execution.
+
+### 3. Frontend — "Program locations" in the config page
+
+- Extend `components/config-content.tsx` with a section:
+  - editable `exePaths` list (add/remove dirs);
+  - optional explicit fields for coot / ccp4mg / shelx / dials / buster;
+  - per-program live status from the discover endpoint (green "found at …" /
+    red "not found"), so users see immediately whether a path fixed discovery.
+- Persist through the same config write path the page already uses.
+
+### 4. Migration note
+
+Legacy `main` stored these in `configs/guipreferences.params.xml`. Django uses
+`~/.ccp4i2/preferences.json`. A one-time importer (read the old XML → seed the
+JSON keys) is a nice-to-have, not required for the first cut.
+
+## Out of scope / decided
+
+- Pure external-link menu items (Tutorials, Quickstart, YouTube, Send error
+  report, Task documentation/info) stay **dropped** — no bundled content, just
+  outbound URLs; per-job Help already links task docs.
+- The full `main` preferences set (toolbar-button visibility toggles, font/zoom,
+  invalid-frame styling, etc.) is a **later** pass; this plan is scoped to the
+  binary-discovery gap the owner flagged, which is the one with runtime impact.
+
+## Companion quick win (separate, parallel): Tips of the Day
+
+`server/ccp4i2/tipsOfTheDay/*.html` (35 files) already exist. Add a tiny
+`GET /api/tips/random/` (or serve one at random) + a small Help → "Tip of the
+day" dialog. Independent of the preferences work; low effort, real content.

--- a/server/ccp4i2/api/urls.py
+++ b/server/ccp4i2/api/urls.py
@@ -45,6 +45,23 @@ _api_patterns = [
     path("task_lookup/", views.task_lookup, name="task_lookup"),
     path("active_jobs/", views.active_jobs, name="active_jobs"),
     path("monomer-info/<str:code>/", views.monomer_info, name="monomer_info"),
+    path(
+        "config/discover-programs/",
+        views.discover_programs_view,
+        name="discover_programs",
+    ),
+    path(
+        "config/program-preferences/",
+        views.get_program_preferences,
+        name="get_program_preferences",
+    ),
+    path(
+        "config/program-preferences/set/",
+        views.set_program_preferences,
+        name="set_program_preferences",
+    ),
+    path("tips/", views.tip_of_the_day, name="tip_of_the_day"),
+    path("tips/image/<str:name>", views.tip_image, name="tip_image"),
 ]
 
 # Legacy-migration admin endpoints. These are core desktop functionality (a

--- a/server/ccp4i2/api/views.py
+++ b/server/ccp4i2/api/views.py
@@ -182,3 +182,195 @@ def monomer_info(request, code):
             {"success": False, "error": f"Error parsing monomer: {str(e)}"},
             status=500,
         )
+
+
+# ---------------------------------------------------------------------------
+# Program locations (binary discovery) preferences
+# ---------------------------------------------------------------------------
+
+# The userPreferences keys the Program-locations UI reads/writes. Kept explicit
+# so the write endpoint can reject anything else (it must not become a general
+# preferences-write backdoor).
+_PROGRAM_PREF_KEYS = (
+    "exePaths",
+    "COOT_EXECUTABLE",
+    "CCP4MG_EXECUTABLE",
+    "SHELXDIR",
+    "DIALSDIR",
+    "BUSTERDIR",
+)
+
+
+@api_view(["GET"])
+def discover_programs_view(request):
+    """Report where each known program resolves (read-only probe).
+
+    GET /api/ccp4i2/config/discover-programs/[?names=coot,shelxd]
+
+    Response: {"success": true, "data": {"programs": [
+        {"name", "path"|null, "source": executable_pref|suite_dir|exe_paths|path|missing}
+    ]}}
+    Never runs a program; just resolves paths against preferences + PATH.
+    """
+    from ..config.program_discovery import discover_programs
+
+    names_param = request.query_params.get("names")
+    names = (
+        [n.strip() for n in names_param.split(",") if n.strip()]
+        if names_param
+        else None
+    )
+    return JsonResponse(
+        {"success": True, "data": {"programs": discover_programs(names)}}
+    )
+
+
+@api_view(["GET"])
+def get_program_preferences(request):
+    """Return the current program-location preferences + desktop-writability.
+
+    GET /api/ccp4i2/config/program-preferences/
+
+    Response: {"success": true, "data": {"editable": <bool>, "preferences": {...}}}
+    In cloud (`editable=false`) these come from env vars and are not file-editable.
+    """
+    from ..config.preferences import is_desktop, load_preferences
+
+    # First-load lazy migration: import program locations from the legacy Qt GUI
+    # (~/.CCP4I2). Desktop-only and idempotent (self-guarded), so calling it here
+    # is safe and cheap — it no-ops in cloud and after the first successful run.
+    try:
+        from ..config.preferences_migration import migrate_legacy_program_prefs
+
+        migrate_legacy_program_prefs()
+    except Exception:
+        logger.debug("legacy program-preference migration skipped", exc_info=True)
+
+    bag = load_preferences().get("userPreferences", {})
+    bag = bag if isinstance(bag, dict) else {}
+    prefs = {k: bag[k] for k in _PROGRAM_PREF_KEYS if k in bag}
+    return JsonResponse(
+        {"success": True, "data": {"editable": is_desktop(), "preferences": prefs}}
+    )
+
+
+@api_view(["PATCH", "POST"])
+def set_program_preferences(request):
+    """Update program-location preferences (desktop only).
+
+    PATCH /api/ccp4i2/config/program-preferences/  {"SHELXDIR": "...", "exePaths": [...]}
+
+    Only the _PROGRAM_PREF_KEYS are accepted; any other key is ignored. In a
+    cloud deployment this is rejected (409) — preferences arrive as env vars and
+    preferences.json is per-replica/ephemeral.
+    """
+    from ..config.preferences import is_desktop, load_preferences, save_preferences
+
+    if not is_desktop():
+        return JsonResponse(
+            {
+                "success": False,
+                "error": "Program-location preferences are editable only on the "
+                "desktop app; in a server deployment set them via environment "
+                "variables.",
+            },
+            status=409,
+        )
+
+    payload = request.data if isinstance(request.data, dict) else {}
+    updates = {k: v for k, v in payload.items() if k in _PROGRAM_PREF_KEYS}
+
+    prefs = load_preferences()
+    bag = prefs.get("userPreferences")
+    bag = bag if isinstance(bag, dict) else {}
+    for key, value in updates.items():
+        if value in (None, "", []):
+            bag.pop(key, None)  # clearing a field removes it
+        else:
+            bag[key] = value
+    prefs["userPreferences"] = bag
+    save_preferences(prefs)
+
+    saved = {k: bag[k] for k in _PROGRAM_PREF_KEYS if k in bag}
+    return JsonResponse({"success": True, "data": {"preferences": saved}})
+
+
+# ---------------------------------------------------------------------------
+# Tips of the Day
+# ---------------------------------------------------------------------------
+
+# Deterministic-free randomness for tip selection; tips live beside the package.
+_TIPS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "tipsOfTheDay")
+
+
+def _tip_ids():
+    try:
+        return sorted(
+            int(f[:-5])
+            for f in os.listdir(_TIPS_DIR)
+            if f.endswith(".html") and f[:-5].isdigit()
+        )
+    except OSError:
+        return []
+
+
+@api_view(["GET"])
+def tip_of_the_day(request):
+    """Return a random (or specific) tip's body HTML.
+
+    GET /api/ccp4i2/tips/?id=<n>   (id optional; omitted -> random)
+
+    Response: {"success": true, "data": {"id": <n>, "html": "<...>", "count": <N>}}
+    Image ``src="./foo.png"`` references are rewritten to the tip-image route so
+    they render in the app.
+    """
+    import random
+    import re
+
+    ids = _tip_ids()
+    if not ids:
+        return JsonResponse(
+            {"success": False, "error": "No tips available"}, status=404
+        )
+
+    requested = request.query_params.get("id")
+    if requested is not None and requested.isdigit() and int(requested) in ids:
+        tip_id = int(requested)
+    else:
+        tip_id = random.choice(ids)
+
+    path = os.path.join(_TIPS_DIR, f"{tip_id}.html")
+    try:
+        with open(path, encoding="windows-1252") as handle:
+            raw = handle.read()
+    except OSError:
+        return JsonResponse(
+            {"success": False, "error": f"Tip {tip_id} not found"}, status=404
+        )
+
+    # Extract the <body> inner HTML (the tips are full HTML documents).
+    body_match = re.search(r"<body[^>]*>(.*)</body>", raw, re.DOTALL | re.IGNORECASE)
+    html = body_match.group(1).strip() if body_match else raw
+    # Rewrite relative image srcs to the tip-image API route.
+    html = re.sub(
+        r'src\s*=\s*["\']\.?/?([^"\']+\.(?:png|jpg|jpeg|gif))["\']',
+        lambda m: f'src="/api/proxy/ccp4i2/tips/image/{m.group(1)}"',
+        html,
+        flags=re.IGNORECASE,
+    )
+    return JsonResponse(
+        {"success": True, "data": {"id": tip_id, "html": html, "count": len(ids)}}
+    )
+
+
+@api_view(["GET"])
+def tip_image(request, name):
+    """Serve a tip image by filename (from the tipsOfTheDay dir only)."""
+    from django.http import FileResponse, Http404
+
+    # Guard against path traversal: basename only, must live in the tips dir.
+    safe = os.path.basename(name)
+    path = os.path.join(_TIPS_DIR, safe)
+    if not os.path.isfile(path):
+        raise Http404("Tip image not found")
+    return FileResponse(open(path, "rb"))

--- a/server/ccp4i2/api/views.py
+++ b/server/ccp4i2/api/views.py
@@ -201,28 +201,56 @@ _PROGRAM_PREF_KEYS = (
 )
 
 
+# Executables that are core CCP4/Python interpreters or ubiquitous utilities:
+# always present, not user-relocatable, and noise in a "point me at your
+# programs" panel. Excluded from the default discovery list (still probeable
+# explicitly via ?names=).
+_DISCOVERY_EXCLUDE = frozenset({
+    "ccp4-python", "python", "python3", "cad", "gemmi", "pdbset", "mtzutils",
+    "cif2mtz", "convert2mtz", "chltofom", "cmapcoeff",
+})
+
+
 @api_view(["GET"])
 def discover_programs_view(request):
-    """Report where each known program resolves (read-only probe).
+    """Report where each task program resolves (read-only probe).
 
-    GET /api/ccp4i2/config/discover-programs/[?names=coot,shelxd]
+    GET /api/ccp4i2/config/discover-programs/[?names=cbuccaneer,shelxd]
+
+    The default program set is the registry-derived list of distinct plugin
+    TASKCOMMANDs — the real executables the task suite runs (correct names, e.g.
+    ``cbuccaneer`` not ``buccaneer``), each annotated with the tasks that need
+    it. Pass ``names`` to probe a specific set instead. Core interpreters /
+    ubiquitous utilities are omitted from the default list.
 
     Response: {"success": true, "data": {"programs": [
-        {"name", "path"|null, "source": executable_pref|suite_dir|exe_paths|path|missing}
+        {"name", "path"|null, "source": ..., "tasks": [task_name, ...]}
     ]}}
     Never runs a program; just resolves paths against preferences + PATH.
     """
-    from ..config.program_discovery import discover_programs
+    from ..config.program_discovery import discover_program
+    from ..core.tasks import task_commands
 
     names_param = request.query_params.get("names")
-    names = (
-        [n.strip() for n in names_param.split(",") if n.strip()]
-        if names_param
-        else None
-    )
-    return JsonResponse(
-        {"success": True, "data": {"programs": discover_programs(names)}}
-    )
+    cmd_map = task_commands()
+    if names_param:
+        names = [n.strip() for n in names_param.split(",") if n.strip()]
+    else:
+        # Registry-derived defaults: real executable names, minus core/noise and
+        # anything that is an absolute path or a dotted sub-tool wrapper we can't
+        # meaningfully "relocate" (kept if a plain command name).
+        names = [
+            cmd
+            for cmd in cmd_map
+            if cmd not in _DISCOVERY_EXCLUDE and "/" not in cmd
+        ]
+
+    programs = []
+    for name in names:
+        entry = discover_program(name)
+        entry["tasks"] = cmd_map.get(name, [])
+        programs.append(entry)
+    return JsonResponse({"success": True, "data": {"programs": programs}})
 
 
 @api_view(["GET"])

--- a/server/ccp4i2/config/preferences.py
+++ b/server/ccp4i2/config/preferences.py
@@ -74,6 +74,19 @@ def preferences_path() -> Path:
     return ccp4i2_home() / "preferences.json"
 
 
+def is_desktop() -> bool:
+    """True on a desktop (Electron) launch, False in a cloud/server deployment.
+
+    ``preferences.json`` and legacy-preference migration are a *desktop* concept:
+    in cloud, settings arrive as env vars (see the module docstring) and the
+    per-user file/home is meaningless (ephemeral, per-replica). The desktop
+    launcher sets ``CCP4I2_LOCAL_SESSION_TOKEN`` (the same signal
+    ``settings.py`` uses to pick the local-session auth middleware), so use it
+    here to gate file writes and legacy migration.
+    """
+    return bool(os.environ.get("CCP4I2_LOCAL_SESSION_TOKEN"))
+
+
 def load_preferences() -> dict:
     """Load ``preferences.json``; return ``{}`` if absent or unreadable.
 

--- a/server/ccp4i2/config/preferences_migration.py
+++ b/server/ccp4i2/config/preferences_migration.py
@@ -1,0 +1,152 @@
+"""
+One-time import of program-location preferences from the legacy Qt CCP4i2.
+
+Established users have their program locations in the classic GUI's
+``~/.CCP4I2/configs/guipreferences.params.xml`` (COOT_EXECUTABLE, SHELXDIR,
+EXEPATHLIST …). The Django app keeps its own ``preferences.json`` and does not
+share the legacy home (deliberately — see ``preferences.ccp4i2_home``). Without
+migration those users would have to re-enter every program path.
+
+This module reads the legacy XML and seeds the *program-location* keys of
+``preferences.json`` (only the ones relevant to binary discovery — not the whole
+legacy pref set). It is:
+
+- **non-destructive**: never overwrites a key already present in
+  ``preferences.json`` (the Django value wins);
+- **idempotent**: a ``userPreferences._legacyProgramImport`` marker records that
+  the import ran, so it does not re-import on every launch;
+- **best-effort**: any parse error is swallowed — migration must never block
+  startup.
+
+Legacy serialisation handled:
+- scalar ``<KEY>value</KEY>`` for COOT_EXECUTABLE / CCP4MG_EXECUTABLE /
+  SHELXDIR / DIALSDIR / BUSTERDIR;
+- ``<EXEPATHLIST><CExePath><exeName>…</exeName><exePath><baseName>…</baseName>
+  <relPath>…</relPath></exePath></CExePath>…</EXEPATHLIST>`` — each entry's
+  directory (relPath, or relPath/baseName) is collected into ``exePaths``.
+"""
+
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ccp4i2.config.preferences import (
+    is_desktop,
+    load_preferences,
+    save_preferences,
+)
+
+# Scalar legacy keys copied verbatim into the userPreferences bag.
+_SCALAR_KEYS = (
+    "COOT_EXECUTABLE",
+    "CCP4MG_EXECUTABLE",
+    "SHELXDIR",
+    "DIALSDIR",
+    "BUSTERDIR",
+)
+
+_IMPORT_MARKER = "_legacyProgramImport"
+
+
+def legacy_preferences_path() -> Path:
+    """Classic Qt CCP4i2 GUI preferences file (``~/.CCP4I2/configs/…``)."""
+    override = os.environ.get("CCP4I2_LEGACY_PREFS")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".CCP4I2" / "configs" / "guipreferences.params.xml"
+
+
+def _text(elem: Optional[ET.Element]) -> Optional[str]:
+    if elem is None or elem.text is None:
+        return None
+    value = elem.text.strip()
+    return value or None
+
+
+def parse_legacy_program_prefs(path: Path) -> Dict[str, object]:
+    """Extract the program-location keys from a legacy prefs XML file.
+
+    Returns a dict with any of the scalar keys plus an ``exePaths`` list
+    (directories derived from EXEPATHLIST). Missing/empty values are omitted.
+    Returns ``{}`` on any parse failure.
+    """
+    try:
+        tree = ET.parse(str(path))
+    except (ET.ParseError, OSError):
+        return {}
+    root = tree.getroot()
+    body = root.find("ccp4i2_body")
+    if body is None:
+        # Some legacy files namespace or omit the wrapper; fall back to root.
+        body = root
+
+    out: Dict[str, object] = {}
+    for key in _SCALAR_KEYS:
+        val = _text(body.find(key))
+        if val:
+            out[key] = val
+
+    exe_paths: List[str] = []
+    exepathlist = body.find("EXEPATHLIST")
+    if exepathlist is not None:
+        for cexe in exepathlist.findall("CExePath"):
+            exepath = cexe.find("exePath")
+            if exepath is None:
+                continue
+            rel = _text(exepath.find("relPath"))
+            base = _text(exepath.find("baseName"))
+            if not rel:
+                continue
+            # relPath is the directory; baseName (when present) is the app/exe
+            # inside it. The directory is what feeds exePaths.
+            directory = rel
+            if directory and directory not in exe_paths:
+                exe_paths.append(directory)
+    if exe_paths:
+        out["exePaths"] = exe_paths
+
+    return out
+
+
+def migrate_legacy_program_prefs(force: bool = False) -> Dict[str, object]:
+    """Seed ``preferences.json`` program-location keys from the legacy GUI.
+
+    Non-destructive (existing keys win), idempotent (records a marker). Returns
+    the dict of keys actually imported (empty if nothing to do).
+
+    Args:
+        force: re-run even if the import marker is present.
+    """
+    # Desktop-only: in cloud there is no legacy home, preferences arrive as env
+    # vars, and preferences.json is per-replica/ephemeral. Never migrate there.
+    if not is_desktop() and not force:
+        return {}
+
+    prefs = load_preferences()
+    bag = prefs.get("userPreferences")
+    bag = bag if isinstance(bag, dict) else {}
+
+    if bag.get(_IMPORT_MARKER) and not force:
+        return {}
+
+    legacy = parse_legacy_program_prefs(legacy_preferences_path())
+
+    imported: Dict[str, object] = {}
+    for key, value in legacy.items():
+        if key == "exePaths":
+            existing = bag.get("exePaths")
+            existing = list(existing) if isinstance(existing, list) else []
+            merged = existing + [p for p in value if p not in existing]
+            if merged != existing:
+                bag["exePaths"] = merged
+                imported["exePaths"] = value
+        elif key not in bag:  # scalar: Django value wins if already set
+            bag[key] = value
+            imported[key] = value
+
+    # Always stamp the marker so we don't re-scan the legacy file each launch.
+    bag[_IMPORT_MARKER] = True
+    prefs["userPreferences"] = bag
+    save_preferences(prefs)
+    return imported

--- a/server/ccp4i2/config/program_discovery.py
+++ b/server/ccp4i2/config/program_discovery.py
@@ -1,0 +1,154 @@
+"""
+Program (binary) discovery — resolve a task's executable against user
+preferences before falling back to ``PATH``.
+
+Django's task execution was a bare ``shutil.which(TASKCOMMAND)``: if a program
+(coot, ccp4mg, shelx*, dials, buster, …) was not on ``PATH``, the job failed
+with no supported way to point CCP4i2 at it. The legacy Qt GUI let users set
+program locations (``COOT_EXECUTABLE``, ``SHELXDIR``, ``EXEPATHLIST`` …); this
+module is the Django equivalent.
+
+Resolution order for a program ``name``:
+
+1. an explicit ``{PROG}_EXECUTABLE`` preference (exact executable path) for the
+   programs that have one (coot, ccp4mg);
+2. a ``{SUITE}DIR`` preference joined with ``name`` (shelx* -> SHELXDIR,
+   dials -> DIALSDIR, buster/refine -> BUSTERDIR);
+3. each directory in the general ``exePaths`` list (the django name for the
+   legacy ``EXEPATHLIST``);
+4. ``shutil.which(name)`` — the ``PATH`` default (unchanged behaviour);
+5. ``None`` — caller raises an actionable error.
+
+Preferences are read via ``config.preferences.user_preference`` (env var >
+``preferences.json`` ``userPreferences`` bag > default), so cloud deployments
+can supply them as plain env vars. Pure stdlib — no Django, no CCP4 import — so
+it is safe to call from the CCP4-free server (the probe endpoint) and from the
+ccp4-python job environment (``CCP4PluginScript``) alike.
+"""
+
+import os
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ccp4i2.config.preferences import user_preference
+
+# Programs with an explicit single-executable preference.
+_EXECUTABLE_PREF: Dict[str, str] = {
+    "coot": "COOT_EXECUTABLE",
+    "ccp4mg": "CCP4MG_EXECUTABLE",
+}
+
+# Programs whose executable lives in a preference-specified suite directory.
+# Maps program name -> the {SUITE}DIR preference key that holds its directory.
+_SUITE_DIR_PREF: Dict[str, str] = {
+    "shelxc": "SHELXDIR",
+    "shelxd": "SHELXDIR",
+    "shelxe": "SHELXDIR",
+    "shelxl": "SHELXDIR",
+    "shelx": "SHELXDIR",
+    "dials": "DIALSDIR",
+    "dials.import": "DIALSDIR",
+    "dials.integrate": "DIALSDIR",
+    "buster": "BUSTERDIR",
+    "refine": "BUSTERDIR",
+}
+
+# The general extra-search-path list preference (legacy EXEPATHLIST).
+_EXE_PATHS_KEY = "exePaths"
+
+# Discovery source labels (also surfaced by the probe endpoint).
+SOURCE_EXECUTABLE_PREF = "executable_pref"
+SOURCE_SUITE_DIR = "suite_dir"
+SOURCE_EXE_PATHS = "exe_paths"
+SOURCE_PATH = "path"
+SOURCE_MISSING = "missing"
+
+# Programs the discovery UI probes by default. Extendable via preferences later.
+KNOWN_PROGRAMS: List[str] = [
+    "coot", "ccp4mg", "shelxc", "shelxd", "shelxe", "dials", "buster",
+    "refmac5", "refmacat", "servalcat", "aimless", "pointless", "ctruncate",
+    "freerflag", "phaser", "molrep", "modelcraft", "nautilus", "buccaneer",
+]
+
+
+def _exe_paths() -> List[str]:
+    """The user's extra executable search directories (``exePaths`` pref)."""
+    value = user_preference(_EXE_PATHS_KEY, default=None)
+    if not value:
+        return []
+    if isinstance(value, str):
+        # tolerate an os.pathsep-joined string as well as a JSON list
+        return [p for p in value.split(os.pathsep) if p]
+    if isinstance(value, (list, tuple)):
+        return [str(p) for p in value if p]
+    return []
+
+
+def _is_executable_file(path: Path) -> bool:
+    try:
+        return path.is_file() and os.access(str(path), os.X_OK)
+    except OSError:
+        return False
+
+
+def _candidate_names(name: str) -> List[str]:
+    """Executable filenames to try for ``name`` (adds ``.exe`` on Windows)."""
+    if os.name == "nt" and not name.lower().endswith(".exe"):
+        return [name, f"{name}.exe"]
+    return [name]
+
+
+def resolve_program(name: str) -> Optional[str]:
+    """Resolve ``name`` to an absolute executable path, or ``None``.
+
+    Convenience wrapper around :func:`discover_program` returning just the path.
+    """
+    return discover_program(name)["path"]
+
+
+def discover_program(name: str) -> Dict[str, Optional[str]]:
+    """Resolve ``name`` and report *how* it was found.
+
+    Returns ``{"name", "path", "source"}`` where ``source`` is one of the
+    ``SOURCE_*`` constants (``missing`` when unresolved). Read-only: never runs
+    the program.
+    """
+    # 1. explicit {PROG}_EXECUTABLE
+    pref_key = _EXECUTABLE_PREF.get(name)
+    if pref_key:
+        explicit = user_preference(pref_key, default=None)
+        if explicit:
+            p = Path(explicit)
+            if _is_executable_file(p):
+                return {"name": name, "path": str(p), "source": SOURCE_EXECUTABLE_PREF}
+
+    # 2. {SUITE}DIR joined with the program name
+    dir_key = _SUITE_DIR_PREF.get(name)
+    if dir_key:
+        suite_dir = user_preference(dir_key, default=None)
+        if suite_dir:
+            for cand in _candidate_names(name):
+                p = Path(suite_dir) / cand
+                if _is_executable_file(p):
+                    return {"name": name, "path": str(p), "source": SOURCE_SUITE_DIR}
+
+    # 3. general exePaths list
+    for d in _exe_paths():
+        for cand in _candidate_names(name):
+            p = Path(d) / cand
+            if _is_executable_file(p):
+                return {"name": name, "path": str(p), "source": SOURCE_EXE_PATHS}
+
+    # 4. PATH (unchanged default)
+    which = shutil.which(name)
+    if which:
+        return {"name": name, "path": which, "source": SOURCE_PATH}
+
+    # 5. not found
+    return {"name": name, "path": None, "source": SOURCE_MISSING}
+
+
+def discover_programs(names: Optional[List[str]] = None) -> List[Dict[str, Optional[str]]]:
+    """Discover a list of programs (default :data:`KNOWN_PROGRAMS`)."""
+    return [discover_program(n) for n in (names if names is not None else KNOWN_PROGRAMS)]

--- a/server/ccp4i2/config/program_discovery.py
+++ b/server/ccp4i2/config/program_discovery.py
@@ -64,12 +64,10 @@ SOURCE_EXE_PATHS = "exe_paths"
 SOURCE_PATH = "path"
 SOURCE_MISSING = "missing"
 
-# Programs the discovery UI probes by default. Extendable via preferences later.
-KNOWN_PROGRAMS: List[str] = [
-    "coot", "ccp4mg", "shelxc", "shelxd", "shelxe", "dials", "buster",
-    "refmac5", "refmacat", "servalcat", "aimless", "pointless", "ctruncate",
-    "freerflag", "phaser", "molrep", "modelcraft", "nautilus", "buccaneer",
-]
+# NB: the set of programs the UI probes is NOT hardcoded here — it is derived
+# from the plugin registry's real TASKCOMMANDs (see api.views.discover_programs_view
+# / core.tasks.task_commands), so the names are always correct (e.g. cbuccaneer,
+# not buccaneer). This module only *resolves* a name; it does not decide the list.
 
 
 def _exe_paths() -> List[str]:
@@ -149,6 +147,6 @@ def discover_program(name: str) -> Dict[str, Optional[str]]:
     return {"name": name, "path": None, "source": SOURCE_MISSING}
 
 
-def discover_programs(names: Optional[List[str]] = None) -> List[Dict[str, Optional[str]]]:
-    """Discover a list of programs (default :data:`KNOWN_PROGRAMS`)."""
-    return [discover_program(n) for n in (names if names is not None else KNOWN_PROGRAMS)]
+def discover_programs(names: List[str]) -> List[Dict[str, Optional[str]]]:
+    """Discover an explicit list of programs (the caller supplies the names)."""
+    return [discover_program(n) for n in names]

--- a/server/ccp4i2/core/CCP4PluginScript.py
+++ b/server/ccp4i2/core/CCP4PluginScript.py
@@ -1072,7 +1072,44 @@ class CPluginScript(CData):
         """
         error = self.validity()
         self._checkSameCrystalAs(error)
+        self._checkProgramAvailable(error)
         return error
+
+    def _checkProgramAvailable(self, error: CErrorReport) -> None:
+        """Advisory pre-flight check that the task's program can be found.
+
+        Resolves TASKCOMMAND against program-location preferences + PATH (the
+        same resolution used at execution). If it cannot be found, append a
+        WARNING (not a blocking error): the run environment (worker) may differ
+        from where validation runs, so a false negative must not block Confirm —
+        but a heads-up at job-config time, pointing at Preferences, is far
+        friendlier than a cryptic runtime failure.
+
+        Only checks the leaf program a plain wrapper declares. Pipelines that
+        drive several programs internally (e.g. crank2) don't set a single
+        TASKCOMMAND and are skipped here.
+        """
+        taskcommand = getattr(self, 'TASKCOMMAND', None)
+        if not taskcommand:
+            return
+        try:
+            from ccp4i2.config.program_discovery import resolve_program
+            if resolve_program(taskcommand) is not None:
+                return
+        except Exception:
+            return  # never let the check itself break validation
+        error.append(
+            self.__class__,
+            299,
+            details=(
+                f"Program '{taskcommand}' was not found on PATH or in your "
+                f"program-location preferences. If it is installed in a "
+                f"non-standard location, set it in Preferences -> Program "
+                f"locations before running."
+            ),
+            name=f'{getattr(self, "TASKNAME", self.__class__.__name__)}',
+            severity=SEVERITY_WARNING,
+        )
 
     def _checkSameCrystalAs(self, error: CErrorReport) -> None:
         """Enforce sameCrystalAs constraints declared in def.xml.
@@ -1693,13 +1730,32 @@ class CPluginScript(CData):
         stdout_path = self.makeFileName('LOG')
         stderr_path = self.makeFileName('STDERR')
 
-        # Find full path to executable to ensure subprocess can find it
-        exe_path = shutil.which(self.TASKCOMMAND)
+        # Find full path to executable to ensure subprocess can find it.
+        # Resolve against user program-location preferences (explicit
+        # {PROG}_EXECUTABLE, {SUITE}DIR, exePaths) before PATH, so users can
+        # point CCP4i2 at programs not on PATH via Preferences -> Program
+        # locations. Falls back to bare PATH (shutil.which) unchanged.
+        try:
+            from ccp4i2.config.program_discovery import resolve_program
+            exe_path = resolve_program(self.TASKCOMMAND)
+        except Exception:
+            # Never let discovery break execution; fall back to PATH.
+            exe_path = shutil.which(self.TASKCOMMAND)
         if exe_path:
             # Use full path if found
             command = [exe_path] + self.commandLine
         else:
-            # Fall back to command name
+            # Not found via preferences or PATH. Emit an actionable message
+            # (the program name is the plugin's declared TASKCOMMAND) so the
+            # job log tells the user how to fix it, then fall back to the bare
+            # command name and let the subprocess launch surface the failure.
+            print(
+                f"WARNING: program '{self.TASKCOMMAND}' not found on PATH or in "
+                f"your program-location preferences. If it is installed in a "
+                f"non-standard location, set it in Preferences -> Program "
+                f"locations (or the {self.TASKCOMMAND.upper()} / exePaths "
+                f"preference)."
+            )
             command = [self.TASKCOMMAND] + self.commandLine
 
         # Copy environment to ensure subprocess inherits all variables

--- a/server/ccp4i2/core/tasks.py
+++ b/server/ccp4i2/core/tasks.py
@@ -1547,3 +1547,29 @@ def locate_def_xml(task_name: str):
 def supports_running_report(task_name: str):
     task = TASKS.get(task_name)
     return task.runningReport if task else False
+
+
+@cache
+def task_commands() -> dict[str, list[str]]:
+    """Map each distinct plugin ``TASKCOMMAND`` to the tasks that invoke it.
+
+    This is the honest, registry-derived list of the external executables the
+    task suite actually runs — the correct basis for program discovery (the
+    executable name is whatever the plugin declares, e.g. ``cbuccaneer``, not
+    the task name ``buccaneer``). Tasks whose plugin fails to import, or that
+    declare no ``TASKCOMMAND`` (pure-Python pipelines, importers), are skipped.
+
+    Returns ``{taskcommand: [task_name, ...]}`` sorted for stable output.
+    Cached — the registry is static for a process.
+    """
+    commands: dict[str, list[str]] = {}
+    for task_name in TASKS:
+        try:
+            cls = get_plugin_class(task_name)
+        except Exception:
+            continue
+        taskcommand = getattr(cls, "TASKCOMMAND", None)
+        if not taskcommand:
+            continue
+        commands.setdefault(str(taskcommand), []).append(task_name)
+    return {cmd: sorted(tasks) for cmd, tasks in sorted(commands.items())}

--- a/server/ccp4i2/tests/api/unit/test_config_and_tips_api.py
+++ b/server/ccp4i2/tests/api/unit/test_config_and_tips_api.py
@@ -1,0 +1,80 @@
+"""API tests for program-location config + Tips-of-the-Day endpoints."""
+
+import json
+
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def client(bypass_api_permissions):
+    return APIClient()
+
+
+def test_discover_programs(client):
+    resp = client.get("/api/ccp4i2/config/discover-programs/?names=ls,zzz_nope")
+    assert resp.status_code == 200
+    programs = {p["name"]: p for p in resp.json()["data"]["programs"]}
+    assert programs["ls"]["path"] is not None
+    assert programs["ls"]["source"] == "path"
+    assert programs["zzz_nope"]["path"] is None
+    assert programs["zzz_nope"]["source"] == "missing"
+
+
+def test_program_preferences_desktop_roundtrip(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    monkeypatch.setenv("CCP4I2_LOCAL_SESSION_TOKEN", "desktop")
+
+    # set
+    resp = client.patch(
+        "/api/ccp4i2/config/program-preferences/set/",
+        data=json.dumps({"SHELXDIR": "/opt/shelx", "bogus": "x"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["preferences"] == {"SHELXDIR": "/opt/shelx"}
+
+    # get reflects it, editable True on desktop
+    resp = client.get("/api/ccp4i2/config/program-preferences/")
+    body = resp.json()["data"]
+    assert body["editable"] is True
+    assert body["preferences"]["SHELXDIR"] == "/opt/shelx"
+
+
+def test_program_preferences_cloud_readonly(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    monkeypatch.delenv("CCP4I2_LOCAL_SESSION_TOKEN", raising=False)  # cloud
+
+    resp = client.patch(
+        "/api/ccp4i2/config/program-preferences/set/",
+        data=json.dumps({"SHELXDIR": "/opt/shelx"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 409
+    assert resp.json()["success"] is False
+
+    resp = client.get("/api/ccp4i2/config/program-preferences/")
+    assert resp.json()["data"]["editable"] is False
+
+
+def test_tip_of_the_day(client):
+    resp = client.get("/api/ccp4i2/tips/")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["count"] > 0
+    assert isinstance(data["id"], int)
+    assert "<" in data["html"]  # some HTML body
+    # image srcs rewritten to the tips-image route
+    if "img" in data["html"]:
+        assert "/api/proxy/ccp4i2/tips/image/" in data["html"]
+
+
+def test_tip_specific_id(client):
+    resp = client.get("/api/ccp4i2/tips/?id=1")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["id"] == 1
+
+
+def test_tip_image_traversal_blocked(client):
+    resp = client.get("/api/ccp4i2/tips/image/..%2fviews.py")
+    assert resp.status_code == 404

--- a/server/ccp4i2/tests/api/unit/test_config_and_tips_api.py
+++ b/server/ccp4i2/tests/api/unit/test_config_and_tips_api.py
@@ -11,7 +11,7 @@ def client(bypass_api_permissions):
     return APIClient()
 
 
-def test_discover_programs(client):
+def test_discover_programs_explicit_names(client):
     resp = client.get("/api/ccp4i2/config/discover-programs/?names=ls,zzz_nope")
     assert resp.status_code == 200
     programs = {p["name"]: p for p in resp.json()["data"]["programs"]}
@@ -19,6 +19,22 @@ def test_discover_programs(client):
     assert programs["ls"]["source"] == "path"
     assert programs["zzz_nope"]["path"] is None
     assert programs["zzz_nope"]["source"] == "missing"
+
+
+def test_discover_programs_default_is_registry_derived(client):
+    """With no ?names, the list comes from real plugin TASKCOMMANDs, each
+    annotated with the tasks that use it — not a hardcoded guess."""
+    resp = client.get("/api/ccp4i2/config/discover-programs/")
+    assert resp.status_code == 200
+    programs = resp.json()["data"]["programs"]
+    assert len(programs) > 20
+    by_name = {p["name"]: p for p in programs}
+    # A real executable name (ctruncate) is present and task-annotated...
+    assert "ctruncate" in by_name
+    assert "ctruncate" in by_name["ctruncate"]["tasks"]
+    # ...and core interpreters / abs-path commands are excluded from the default.
+    assert "ccp4-python" not in by_name
+    assert all("/" not in name for name in by_name)
 
 
 def test_program_preferences_desktop_roundtrip(client, monkeypatch, tmp_path):

--- a/server/ccp4i2/tests/unit/config/test_program_discovery.py
+++ b/server/ccp4i2/tests/unit/config/test_program_discovery.py
@@ -1,0 +1,185 @@
+"""
+Tests for program (binary) discovery and legacy-preference migration
+(``ccp4i2/config/program_discovery.py`` + ``preferences_migration.py``).
+
+Slim, CCP4-free: resolution is pure path logic; migration parses an XML file we
+construct in a temp dir. Each test isolates CCP4I2_HOME via monkeypatch.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from ccp4i2.config import preferences, program_discovery
+from ccp4i2.config import preferences_migration
+
+
+def _write_prefs(home: Path, user_prefs: dict):
+    (home / "preferences.json").write_text(
+        json.dumps({"version": 1, "userPreferences": user_prefs})
+    )
+
+
+def _make_exe(path: Path):
+    path.write_text("#!/bin/sh\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_resolve_via_suite_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    sdir = tmp_path / "shelxbin"
+    sdir.mkdir()
+    _make_exe(sdir / "shelxd")
+    _write_prefs(tmp_path, {"SHELXDIR": str(sdir)})
+
+    result = program_discovery.discover_program("shelxd")
+    assert result["path"] == str(sdir / "shelxd")
+    assert result["source"] == program_discovery.SOURCE_SUITE_DIR
+
+
+def test_resolve_via_explicit_executable(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    coot = tmp_path / "mycoot"
+    _make_exe(coot)
+    _write_prefs(tmp_path, {"COOT_EXECUTABLE": str(coot)})
+
+    result = program_discovery.discover_program("coot")
+    assert result["path"] == str(coot)
+    assert result["source"] == program_discovery.SOURCE_EXECUTABLE_PREF
+
+
+def test_resolve_via_exe_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    d = tmp_path / "extra"
+    d.mkdir()
+    _make_exe(d / "someprog")
+    _write_prefs(tmp_path, {"exePaths": [str(d)]})
+
+    result = program_discovery.discover_program("someprog")
+    assert result["path"] == str(d / "someprog")
+    assert result["source"] == program_discovery.SOURCE_EXE_PATHS
+
+
+def test_resolve_via_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    # ls is on PATH on any POSIX CI host.
+    result = program_discovery.discover_program("ls")
+    assert result["path"] is not None
+    assert result["source"] == program_discovery.SOURCE_PATH
+
+
+def test_resolve_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    result = program_discovery.discover_program("zzz_definitely_not_a_program")
+    assert result["path"] is None
+    assert result["source"] == program_discovery.SOURCE_MISSING
+
+
+def test_precedence_explicit_beats_path(monkeypatch, tmp_path):
+    # An explicit COOT_EXECUTABLE must win over a PATH coot.
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    explicit = tmp_path / "explicit_coot"
+    _make_exe(explicit)
+    _write_prefs(tmp_path, {"COOT_EXECUTABLE": str(explicit)})
+    # Even if a 'coot' were on PATH, the explicit pref is checked first.
+    result = program_discovery.discover_program("coot")
+    assert result["source"] == program_discovery.SOURCE_EXECUTABLE_PREF
+
+
+def test_env_var_overrides_file(monkeypatch, tmp_path):
+    # user_preference precedence is env > file; a SHELXDIR env var must win.
+    monkeypatch.setenv("CCP4I2_HOME", str(tmp_path))
+    filedir = tmp_path / "filedir"
+    filedir.mkdir()
+    _make_exe(filedir / "shelxd")
+    envdir = tmp_path / "envdir"
+    envdir.mkdir()
+    _make_exe(envdir / "shelxd")
+    _write_prefs(tmp_path, {"SHELXDIR": str(filedir)})
+    monkeypatch.setenv("SHELXDIR", str(envdir))
+
+    result = program_discovery.discover_program("shelxd")
+    assert result["path"] == str(envdir / "shelxd")
+
+
+# --- migration ---------------------------------------------------------------
+
+
+LEGACY_XML = """<?xml version='1.0' encoding='ASCII'?>
+<ccp4:ccp4i2 xmlns:ccp4="http://www.ccp4.ac.uk/ccp4ns">
+  <ccp4i2_header><pluginName>guipreferences</pluginName></ccp4i2_header>
+  <ccp4i2_body>
+    <SHELXDIR>/opt/shelx</SHELXDIR>
+    <COOT_EXECUTABLE>/opt/coot/bin/coot</COOT_EXECUTABLE>
+    <EXEPATHLIST>
+      <CExePath>
+        <exeName>moorhen</exeName>
+        <exePath>
+          <baseName>Moorhen.app</baseName>
+          <relPath>/opt/moorhen</relPath>
+        </exePath>
+      </CExePath>
+    </EXEPATHLIST>
+  </ccp4i2_body>
+</ccp4:ccp4i2>
+"""
+
+
+def test_parse_legacy_program_prefs(tmp_path):
+    legacy = tmp_path / "guipreferences.params.xml"
+    legacy.write_text(LEGACY_XML)
+    parsed = preferences_migration.parse_legacy_program_prefs(legacy)
+    assert parsed["SHELXDIR"] == "/opt/shelx"
+    assert parsed["COOT_EXECUTABLE"] == "/opt/coot/bin/coot"
+    assert parsed["exePaths"] == ["/opt/moorhen"]
+
+
+def test_migration_desktop_imports_and_is_idempotent(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    legacy = tmp_path / "guipreferences.params.xml"
+    legacy.write_text(LEGACY_XML)
+    monkeypatch.setenv("CCP4I2_HOME", str(home))
+    monkeypatch.setenv("CCP4I2_LEGACY_PREFS", str(legacy))
+    monkeypatch.setenv("CCP4I2_LOCAL_SESSION_TOKEN", "desktop")  # desktop
+
+    imported = preferences_migration.migrate_legacy_program_prefs()
+    assert imported.get("SHELXDIR") == "/opt/shelx"
+    bag = preferences.load_preferences()["userPreferences"]
+    assert bag["SHELXDIR"] == "/opt/shelx"
+    assert bag["exePaths"] == ["/opt/moorhen"]
+
+    # Second run is a no-op (marker set).
+    assert preferences_migration.migrate_legacy_program_prefs() == {}
+
+
+def test_migration_cloud_noop(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    legacy = tmp_path / "guipreferences.params.xml"
+    legacy.write_text(LEGACY_XML)
+    monkeypatch.setenv("CCP4I2_HOME", str(home))
+    monkeypatch.setenv("CCP4I2_LEGACY_PREFS", str(legacy))
+    monkeypatch.delenv("CCP4I2_LOCAL_SESSION_TOKEN", raising=False)  # cloud
+
+    assert preferences_migration.migrate_legacy_program_prefs() == {}
+    assert not (home / "preferences.json").exists()
+
+
+def test_migration_non_destructive(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    legacy = tmp_path / "guipreferences.params.xml"
+    legacy.write_text(LEGACY_XML)
+    monkeypatch.setenv("CCP4I2_HOME", str(home))
+    monkeypatch.setenv("CCP4I2_LEGACY_PREFS", str(legacy))
+    monkeypatch.setenv("CCP4I2_LOCAL_SESSION_TOKEN", "desktop")
+    # A Django-set SHELXDIR must not be clobbered by the legacy value.
+    _write_prefs(home, {"SHELXDIR": "/my/django/shelx"})
+
+    preferences_migration.migrate_legacy_program_prefs()
+    bag = preferences.load_preferences()["userPreferences"]
+    assert bag["SHELXDIR"] == "/my/django/shelx"  # existing value wins


### PR DESCRIPTION
Wires two capabilities the desktop app was missing versus the legacy Qt GUI, flagged during the toolbar-honesty review.

## Program (binary) discovery

Django task execution was a bare `shutil.which(TASKCOMMAND)`: a program not on `PATH` failed the job with no supported way to point CCP4i2 at it. The legacy GUI let users set `COOT_EXECUTABLE`, `SHELXDIR`, `EXEPATHLIST`… — this restores that, Django-native.

- **`config/program_discovery.py`** — resolution order: explicit `{PROG}_EXECUTABLE` → `{SUITE}DIR`+exe → `exePaths` list → `PATH` → missing (reports the source). Pure stdlib, slim-server safe.
- **`CCP4PluginScript`** — exec site resolves via `resolve_program` (+ actionable not-found log); a `_checkProgramAvailable` **advisory WARNING** in `runTimeValidity` surfaces a missing program at **job-config time** (the run dialog), not just at execution. crank2 (no single `TASKCOMMAND`) is skipped and its internal shelx already reads the same `SHELXDIR` via `PREFERENCES().SHELXDIR`, so no change needed there.
- **`config/preferences_migration.py`** — one-time, **desktop-only**, non-destructive, idempotent import of the legacy `~/.CCP4I2/configs/guipreferences.params.xml` program-location prefs (incl. `EXEPATHLIST` dirs → `exePaths`). Lazy on first `program-preferences` GET; guarded by `preferences.is_desktop()`.

## Cloud posture

Discovery reads work in cloud via env vars (`user_preference` env>file>default); migration and file writes are **desktop-only** (`PATCH set` → 409 in cloud, `GET` → `editable:false`). No behaviour change for deployed servers.

## API + UI

- `GET /config/discover-programs/`, `GET`/`PATCH /config/program-preferences/[set/]`.
- New **`/ccp4i2/preferences`** route with a Program locations panel (explicit fields + editable `exePaths` + live status chips). Edit→Preferences now points here rather than the Electron launch/get-ready screen (`/ccp4i2/config`), which is IPC-driven, not a settings surface.

## Tips of the Day

`GET /tips/` (random tip HTML, image srcs rewritten) + `/tips/image/<name>` (traversal-guarded). The 35 bundled tip HTMLs are not MANIFEST-pruned, so they ship in the cloud image and serve through the authed API. New Help → **Tip of the day** dialog.

## Tests

`tests/unit/config/test_program_discovery.py` (11) + `tests/api/unit/test_config_and_tips_api.py` (6) — all green (resolution order, precedence, env-override, migration desktop/cloud/idempotent/non-destructive; discover, desktop roundtrip, cloud read-only 409, tips random/specific/traversal).

Design doc: `docs/PREFERENCES_BINARY_DISCOVERY_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)