### PR TITLE
fix(desktop): smooth Linux AppImage first-launch

### DIFF
--- a/client/main/ccp4i2-master.ts
+++ b/client/main/ccp4i2-master.ts
@@ -22,6 +22,17 @@ import os from "os";
 
 const isDev = !app.isPackaged; // ✅ Works in compiled builds
 
+// On modern Linux (kernel 6.x + AppArmor), unprivileged user namespaces are
+// restricted by default, which the Chromium SUID sandbox needs. Inside an
+// AppImage this makes the very first launch hard-crash with
+// "The SUID sandbox helper binary was found, but is not configured correctly".
+// Disabling the sandbox here avoids forcing users to weaken kernel security
+// (sysctl kernel.apparmor_restrict_unprivileged_userns=0) just to start the app.
+// Only applied on Linux — macOS/Windows keep their working sandbox.
+if (process.platform === "linux") {
+  app.commandLine.appendSwitch("no-sandbox");
+}
+
 // Change the current working directory to the Resources folder
 if (!isDev) {
   const asarDir = app.getAppPath();
@@ -61,6 +72,22 @@ const getDefaultCCP4Dir = () => {
 
   // Check common CCP4 installation locations in order of preference
   const possiblePaths: string[] = [];
+
+  // Highest priority: an already-sourced CCP4 environment. When the app is
+  // launched from a shell that has sourced ccp4.setup-sh, $CCP4 points at the
+  // install root (which holds bin/ccp4-python) and ccp4-python is on PATH.
+  // Honour that so a user who already configured CCP4 isn't asked to re-select
+  // a directory by hand (the common Linux tarball-in-a-custom-location case).
+  const pythonBinName = isWindows ? "ccp4-python.bat" : "ccp4-python";
+  if (process.env.CCP4) {
+    possiblePaths.push(process.env.CCP4);
+  }
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    // A ccp4-python on PATH lives in <root>/bin, so the root is its parent.
+    if (dir && fs.existsSync(path.join(dir, pythonBinName))) {
+      possiblePaths.push(path.dirname(dir));
+    }
+  }
 
   if (isDev) {
     // In dev mode, check sibling directory (../ccp4-* patterns)

--- a/client/renderer/components/config-content.tsx
+++ b/client/renderer/components/config-content.tsx
@@ -221,7 +221,7 @@ export const ConfigContent: React.FC = () => {
     if (!existingFiles?.CCP4Dir) blockers.push("Locate your CCP4 installation");
     if (!existingFiles?.venv_python) blockers.push("A Python environment is missing");
     if (!devMode && !requirementsExist)
-      blockers.push("Install the CCP4i2 requirements");
+      blockers.push("Install the CCP4i2 backend into your CCP4 environment");
   }
 
   // Open the setup section automatically when something needs attention.


### PR DESCRIPTION
## Summary

Fixes prompted by an alpha-tester report on modern Linux (Ubuntu, kernel 6.x). Client-only; no server changes, no backend republish needed.

1. **Linux SUID sandbox crash (launch-blocker).** On kernel 6.x + AppArmor, unprivileged user namespaces are restricted by default, so the AppImage hard-crashes on first launch:
   > The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now.

   The only workaround was `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. We now append `--no-sandbox` at module load (before `whenReady`), **Linux only** — macOS/Windows keep their working sandbox.

2. **Auto-detect an already-sourced CCP4 environment.** `getDefaultCCP4Dir()` now honours `$CCP4` and scans `$PATH` for `ccp4-python` before the hardcoded `/opt/ccp4` locations. A user who launched the AppImage from a shell that sourced `ccp4.setup-sh` no longer has to re-select their CCP4 directory by hand.

3. **Setup wording.** Blocker text `Install the CCP4i2 requirements` → `Install the CCP4i2 backend into your CCP4 environment`, so the (working-as-designed) backend-install step reads as expected setup rather than a fault.

## Testing

- `tsc --noEmit` clean on the renderer edit; esbuild parse-check clean on the main-process edit.
- ⚠️ **The `--no-sandbox` fix is Linux-only and cannot be reproduced on the dev Mac.** It should be smoke-tested against a real modern-Linux AppImage build (CI artifact) before this rides into a tagged alpha.

## Out of scope

- The "Ready to go" panel appearing while the backend is still uninstalled (possible requirements-probe timing race) — left for a follow-up; cosmetic and unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)