### PR TITLE
fix(desktop): Windows ccp4-python.bat spawn (install/probe) + silent file-import errors

### DIFF
--- a/client/main/ccp4i2-django-server.ts
+++ b/client/main/ccp4i2-django-server.ts
@@ -207,7 +207,14 @@ export async function startDjangoServer(
     "--log-level", "warning",  // Suppress per-request INFO access logs
   ];
 
-  const pythonProcess = spawn(PYTHON_PATH, uvicornArgs, {
+  // shell:true is REQUIRED on Windows to launch ccp4-python.bat (a .bat cannot be
+  // spawned without a shell on modern Node — see spawnPython in ccp4i2-ipc.ts).
+  // With a shell the executable is NOT auto-escaped, so quote it when the CCP4
+  // install path contains whitespace — matching the quoted `migrate` execSync
+  // above, which would otherwise succeed while this launch broke. uvicornArgs are
+  // all space-free literals and need no quoting.
+  const launcher = /\s/.test(PYTHON_PATH) ? `"${PYTHON_PATH}"` : PYTHON_PATH;
+  const pythonProcess = spawn(launcher, uvicornArgs, {
     env: pythonEnv,
     shell: true,
     ...(serverCwd && { cwd: serverCwd }),

--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -128,6 +128,42 @@ function findPython(CCP4Dir: string, projectRoot: string): string | null {
 }
 
 /**
+ * Spawn ccp4-python cross-platform.
+ *
+ * On Windows the interpreter is `ccp4-python.bat`. Since the CVE-2024-27980 fix
+ * (Node >= 18.20.2 / 20.12.2, i.e. every Electron >= v30 — this app ships 33),
+ * `child_process.spawn` REFUSES to launch a .bat/.cmd file unless `shell: true`,
+ * throwing EINVAL *synchronously*. That throw is what silently broke the two
+ * remaining direct-spawn call sites on modern Windows:
+ *   - the requirements probe: the throw was caught and reported as
+ *     "requirements-missing", so a perfectly-good pip-installed backend showed as
+ *     NOT installed (Launch still worked because it uses shell:true — see
+ *     startDjangoServer);
+ *   - the pip install: the throw rejected the un-awaited install promise, so
+ *     `finish()` never ran and the progress modal spun forever.
+ *
+ * With a shell, cmd.exe does NOT auto-escape arguments, so quote the executable
+ * and any arg containing whitespace (Windows filenames cannot contain `"`, so
+ * wrapping in double quotes is sufficient — e.g. a temp path under
+ * `C:\Users\Given Name\...`). On mac/linux we spawn directly with no shell,
+ * exactly as before.
+ */
+function spawnPython(
+  pythonPath: string,
+  args: string[],
+  options: Parameters<typeof spawn>[2] = {}
+): ChildProcessWithoutNullStreams {
+  if (platform() === "win32") {
+    const q = (s: string) => (/\s/.test(s) ? `"${s}"` : s);
+    return spawn(q(pythonPath), args.map(q), {
+      ...options,
+      shell: true,
+    }) as ChildProcessWithoutNullStreams;
+  }
+  return spawn(pythonPath, args, options) as ChildProcessWithoutNullStreams;
+}
+
+/**
  * Installs IPC handlers for communication between the Electron main process and renderer processes.
  *
  * @param ipcMain - The Electron IpcMain instance used to listen for IPC events.
@@ -504,7 +540,7 @@ export const installIpcHandlers = (
 
     // Add error handling for spawn
     try {
-      const child = spawn(pythonPath, [probePath], {
+      const child = spawnPython(pythonPath, [probePath], {
         stdio: ["ignore", "pipe", "pipe"],
         env: {
           ...process.env,
@@ -610,8 +646,22 @@ export const installIpcHandlers = (
     // genuinely successful install. The probe is the authority.
     const runPipStep = (args: string[]): Promise<number> =>
       new Promise((resolve) => {
-        const proc = spawn(pythonPath, args);
         let settled = false;
+        // `spawn` can throw *synchronously* (e.g. a .bat launched without a shell
+        // on modern Node — see spawnPython). Guard it so a throw resolves the step
+        // (which the probe then adjudicates) instead of rejecting an un-awaited
+        // promise and leaving the progress modal spinning forever. (#237)
+        let proc: ChildProcessWithoutNullStreams;
+        try {
+          proc = spawnPython(pythonPath, args);
+        } catch (err) {
+          sendProgress(
+            "installing",
+            `Error launching pip: ${(err as Error).message}\n`
+          );
+          resolve(-1);
+          return;
+        }
         const done = (code: number) => {
           if (settled) return;
           settled = true;
@@ -787,6 +837,13 @@ export const installIpcHandlers = (
       });
     };
 
-    void runInstall();
+    // A rejection here must never leave the modal spinning: report it and let the
+    // probe (via finish) render the real backend state.
+    runInstall().catch((err) => {
+      sendProgress(
+        "failed",
+        `Installation aborted: ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
   });
 };

--- a/client/renderer/components/task/task-elements/csimpledatafile.tsx
+++ b/client/renderer/components/task/task-elements/csimpledatafile.tsx
@@ -57,10 +57,25 @@ export const CSimpleDataFileElement: React.FC<CSimpleDataFileElementProps> = (
     mutateDigest,
   ]);
 
-  // Auto-process files when selected
+  // Auto-process files when selected.
+  //
+  // processFirstFile is async; previously it was fired here un-awaited and with
+  // no error handler, so ANY failure (file read, upload POST, digest fetch) was
+  // silently swallowed — the file picker appeared to do nothing at all, with no
+  // console message. Attach a catch so the failure is at least visible/diagnosable
+  // and the component is left in a clean state to retry.
   useEffect(() => {
-    if (selectedFiles && processFirstFile) processFirstFile();
-  }, [selectedFiles, processFirstFile]);
+    if (selectedFiles && processFirstFile) {
+      processFirstFile().catch((err) => {
+        console.error(
+          `File upload failed for ${itemName} ` +
+            `(${selectedFiles?.[0]?.name ?? "unknown file"}):`,
+          err
+        );
+        setSelectedFiles(null);
+      });
+    }
+  }, [selectedFiles, processFirstFile, itemName]);
 
   const isVisible = useMemo(
     () =>


### PR DESCRIPTION
## Two Windows alpha-tester failures, both silent-error bugs

### 1. Install button hangs; a correctly-installed backend reads as "not installed"
Electron 33 bundles **Node 20.18**, where the CVE-2024-27980 fix makes `child_process.spawn` throw **synchronously** when launching a `.bat`/`.cmd` without `shell: true`. On Windows `findPython()` returns `ccp4-python.bat`, so:

- **Requirements probe** threw → caught → reported `requirements-missing`. A correctly `pip install`-ed `3.1.0a13` therefore showed as **NOT installed**. (Launch worked anyway because `startDjangoServer` already spawns with `shell: true`.)
- **Each pip step** threw → rejected the un-awaited `runInstall()` promise → `finish()` never ran → **progress modal spun forever**.

This affects **any** Windows on this Electron-33 build, not a specific Windows version.

**Fix:** new `spawnPython()` helper sets `shell: true` + quotes whitespace args on Windows (spawns directly, unchanged, on mac/linux). The probe and all pip steps route through it. `runPipStep`'s spawn is wrapped in try/catch and `runInstall()` gets a `.catch`, so a spawn failure can never hang the modal again.

### 2. Browsing to a local file (unmerged MTZ) then clicking Open was a silent no-op
`CSimpleDataFileElement` fired its async upload **un-awaited with no `.catch`**, so any read/upload/digest failure vanished with **no console message** — matching the tester's "null op". Added a catch that logs the real error (item + filename) and resets state, making the underlying cause diagnosable on the next repro.

## Packaging
Opened to produce an **unsigned** Windows installer artifact (`windows-installers`) for the alpha tester — Azure Trusted Signing identity is not yet in place, so per-PR builds are unsigned (SmartScreen → *More info → Run anyway*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)