### PR TITLE
feat(desktop): auto-launch countdown when setup is complete

### DIFF
--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -392,6 +392,14 @@ export const installIpcHandlers = (
     event.reply("message-from-main", getConfigResponse());
   });
 
+  // Persist whether the launch page auto-enters CCP4i2 (after a countdown) once
+  // setup is complete. Explicit boolean (not a toggle) so the countdown's
+  // Cancel and the Setup switch can both set it idempotently.
+  ipcMain.on("set-auto-launch", (event, data) => {
+    store.set("autoLaunch", !!data?.enabled);
+    event.reply("message-from-main", getConfigResponse());
+  });
+
   // IPC communication to set theme mode
   ipcMain.on("set-theme-mode", (event, data) => {
     if (data.theme !== "light" && data.theme !== "dark") {

--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -487,8 +487,14 @@ export const installIpcHandlers = (
   // verdict — including the packaged version-floor gate — is computed in exactly
   // one place. `send` is event.reply / event.sender.send (same target).
   const runRequirementsProbe = (send: (payload: any) => void) => {
-    const projectRoot = store.get("projectRoot") || "";
-    const CCP4Dir = store.get("CCP4Dir") || "";
+    // Resolve CCP4Dir/projectRoot the SAME way getConfigResponse and
+    // start-uvicorn do: shared preferences file first (a fresh packaged app may
+    // know the CCP4 dir only from ~/.ccp4i2/preferences.json — written by a
+    // prior session or the CLI — with an empty electron-store), else the store.
+    // Using the store alone made the config page show a valid Python while the
+    // probe reported "Python not found".
+    const projectRoot = getProjectRoot();
+    const CCP4Dir = loadPreferences().ccp4Dir || store.get("CCP4Dir") || "";
     const pythonPath = findPython(CCP4Dir, projectRoot);
 
     // Validate that the executable exists before spawning
@@ -702,8 +708,12 @@ export const installIpcHandlers = (
   });
 
   ipcMain.on("install-requirements", (event, _config) => {
-    const projectRoot = store.get("projectRoot") || "";
-    const CCP4Dir = store.get("CCP4Dir") || "";
+    // Same canonical CCP4Dir/projectRoot resolution as the probe and
+    // getConfigResponse (preferences file first, store fallback) — otherwise a
+    // fresh packaged app whose CCP4 dir lives only in ~/.ccp4i2/preferences.json
+    // fails the install with "Python not found" despite a valid config page.
+    const projectRoot = getProjectRoot();
+    const CCP4Dir = loadPreferences().ccp4Dir || store.get("CCP4Dir") || "";
     const pythonPath = findPython(CCP4Dir, projectRoot);
 
     if (!pythonPath) {

--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -534,7 +534,7 @@ export const installIpcHandlers = (
       '        editable = bool((_d.get("dir_info") or {}).get("editable"))',
       "except Exception:",
       "    pass",
-      'print(json.dumps({"version": ccp4i2.__version__, "editable": editable, "origin": origin}))',
+      'print(json.dumps({"version": getattr(ccp4i2, "__version__", None), "editable": editable, "origin": origin}))',
       "",
     ].join("\n");
 
@@ -820,6 +820,13 @@ export const installIpcHandlers = (
             `\n(metadata preflight skipped: ${(e as Error).message})\n`
           );
         }
+
+        // Uninstall any prior ccp4i2 first (as packaged does). Repeated installs
+        // into the same ccp4-python can leave a stale/partial ccp4i2 that shadows
+        // the editable one as a namespace package — importable, but with the real
+        // __init__.py (and __version__) never executed. A clean slate avoids that.
+        sendProgress("installing", `\nRemoving any previous ccp4i2…\n`);
+        await runPipStep(["-m", "pip", "uninstall", "-y", "ccp4i2"]);
 
         sendProgress("installing", `\n[1/2] Installing ccp4i2 editable (no-deps)…\n`);
         const codeEditable = await runPipStep([

--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -218,6 +218,11 @@ export const installIpcHandlers = (
     // show what it EXPECTS alongside what's installed — making a mismatch (e.g.
     // an installed 3.1.0a1 under a 3.1.0a3 app) obvious rather than silent.
     config.requiredServerVersion = CCP4I2_REQUIRED_SERVER_VERSION;
+    // Whether this is an unpacked/dev build (!app.isPackaged) — the same flag
+    // the requirements probe gates on. The launch page uses it to speak the
+    // right language: dev needs an EDITABLE install of server/, not the pinned
+    // wheel. Distinct from the user-toggleable devMode store flag.
+    config.isDev = isDev;
     return {
       message: "get-config",
       status: "Success",

--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -510,10 +510,26 @@ export const installIpcHandlers = (
     // spawned with shell:true, and ccp4-python is a .bat that historically
     // wanted a shell. A plain file path is a single clean argv that needs no
     // shell on any platform — matching the (working, shell-less) install spawn.
+    // Also report HOW ccp4i2 is installed, via PEP 610 direct_url.json in the
+    // dist-info: editable installs carry dir_info.editable == true and a
+    // url == file://…/server; a wheel install has neither. The gate below uses
+    // this to require an editable install of *this* server/ in dev, and a
+    // regular version-matched wheel in production.
     const probeSource = [
       "import json, ccp4i2",
       "from ccp4i2.config.asgi import application",
-      'print(json.dumps({"version": ccp4i2.__version__}))',
+      "import importlib.metadata as _md",
+      "editable = False",
+      "origin = None",
+      "try:",
+      '    _du = _md.distribution("ccp4i2").read_text("direct_url.json")',
+      "    if _du:",
+      "        _d = json.loads(_du)",
+      '        origin = _d.get("url")',
+      '        editable = bool((_d.get("dir_info") or {}).get("editable"))',
+      "except Exception:",
+      "    pass",
+      'print(json.dumps({"version": ccp4i2.__version__, "editable": editable, "origin": origin}))',
       "",
     ].join("\n");
 
@@ -568,38 +584,94 @@ export const installIpcHandlers = (
 
       child.on("exit", (code: number) => {
         cleanupProbe();
-        if (code === 0) {
-          let version: string | undefined;
-          try {
-            version = JSON.parse(stdoutBuf.trim()).version;
-          } catch {
-            // ASGI app built but version line unparseable — still "ready".
-          }
-          // Packaged app: the backend must EXACTLY match the version this app is
-          // pinned to (alpha discipline — no mixing with other/escaped versions).
-          // A mismatch is "not ready" so the UI can offer to install the exact
-          // partner. Dev mode (unpacked) uses the local tree and is never gated.
-          if (!isDev && !meetsServerVersionRequirement(version)) {
-            send({
-              message: "requirements-missing",
-              version,
-              error:
-                `Installed ccp4i2 ${version || "(unknown)"} does not match the ` +
-                `version this app requires (${CCP4I2_REQUIRED_SERVER_VERSION}). ` +
-                `Click Install to set up the matching backend.`,
-            });
-            return;
-          }
-          send({
-            message: "requirements-exist",
-            version,
-          });
-        } else {
+        if (code !== 0) {
           send({
             message: "requirements-missing",
             error: errorOutput.trim() || `Process exited with code ${code}`,
           });
+          return;
         }
+        let info: any = {};
+        try {
+          info = JSON.parse(stdoutBuf.trim()) || {};
+        } catch {
+          // ASGI app built but info line unparseable — treat fields as unknown.
+        }
+        const version: string | undefined = info.version;
+        const editable = !!info.editable;
+        const origin: string | undefined = info.origin;
+
+        // Resolve a file:// origin (or plain path) to a canonical absolute path.
+        const toRealPath = (p?: string): string | null => {
+          if (!p) return null;
+          let abs = p;
+          if (p.startsWith("file:")) {
+            try {
+              abs = fileURLToPath(p);
+            } catch {
+              return null;
+            }
+          }
+          try {
+            return fs.realpathSync(path.resolve(abs));
+          } catch {
+            return path.resolve(abs);
+          }
+        };
+
+        if (isDev) {
+          // Dev (npm run start): require an EDITABLE install of THIS repo's
+          // server/. That guarantees ccp4-python runs the source the developer
+          // is editing, with its dependencies present. A regular wheel, an
+          // editable install of a different checkout, or nothing all block — and
+          // the Install button runs `pip install -e <server>` to satisfy it.
+          const expected = toRealPath(serverCwd);
+          const got = toRealPath(origin);
+          if (!editable || !expected || !got || got !== expected) {
+            send({
+              message: "requirements-missing",
+              version,
+              error: !editable
+                ? `ccp4i2 is not an editable install of the server directory. ` +
+                  `Dev mode runs your local source — install it editable ` +
+                  `(pip install -e ${serverCwd}) or click Install.`
+                : `ccp4i2 is an editable install of ${got || origin}, but this ` +
+                  `dev build expects the server directory at ${expected}. ` +
+                  `Re-install it editable from there (or click Install).`,
+            });
+            return;
+          }
+          send({ message: "requirements-exist", version });
+          return;
+        }
+
+        // Packaged: require a REGULAR (non-editable) install of the version this
+        // app is pinned to — no mixing with dev/editable trees or escaped/other
+        // versions (alpha discipline). The UI then offers to install the exact
+        // partner wheel.
+        if (editable) {
+          send({
+            message: "requirements-missing",
+            version,
+            error:
+              `ccp4i2 is a development (editable) install; this build needs the ` +
+              `packaged ccp4i2 ${CCP4I2_REQUIRED_SERVER_VERSION}. Click Install ` +
+              `to set up the matching backend.`,
+          });
+          return;
+        }
+        if (!meetsServerVersionRequirement(version)) {
+          send({
+            message: "requirements-missing",
+            version,
+            error:
+              `Installed ccp4i2 ${version || "(unknown)"} does not match the ` +
+              `version this app requires (${CCP4I2_REQUIRED_SERVER_VERSION}). ` +
+              `Click Install to set up the matching backend.`,
+          });
+          return;
+        }
+        send({ message: "requirements-exist", version });
       });
 
       child.on("error", (error: Error) => {

--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -783,8 +783,10 @@ export const installIpcHandlers = (
     // Build the install step(s), keyed strictly on app.isPackaged (isDev).
     //
     // Dev (unpacked): editable install of the local checkout so the developer's
-    // tree is what runs. `-e ./server` reads pyproject.toml and pulls deps
-    // normally — a dev .venv is clean, so the resolver works fine here.
+    // tree is what runs — but into the developer's ccp4-python, which carries the
+    // same stale pins / corrupt *.dist-info as any CCP4 build. So dev uses the
+    // same resolver-free two-step as packaged, with `-e server` in place of the
+    // wheel and the runtime lock read straight from the source tree (see below).
     //
     // Packaged: install into the user's ccp4-python. Those distros carry corrupt
     // *.dist-info that crashes pip's RESOLVER, so a normal `pip install ccp4i2`
@@ -798,12 +800,51 @@ export const installIpcHandlers = (
     // resolve its path via ccp4i2.__file__ after step 1. See that file's header.
     const runInstall = async (): Promise<void> => {
       if (isDev) {
-        const code = await runPipStep([
-          "-m", "pip", "install", "-e",
-          path.join(process.cwd(), "..", "server"),
-          "--verbose",
+        // Dev installs into the developer's ccp4-python (NOT a clean venv), so it
+        // hits the SAME hazards as packaged: stale CCP4 pins (Django 3.2 vs
+        // django-cors-headers>=4.2) and *.dist-info with no parseable Version. A
+        // naive `pip install -e server` runs the full resolver against those and
+        // fails. So mirror the packaged strategy — never invoke the resolver:
+        // repair metadata, install the package EDITABLE with --no-deps, then
+        // install the curated runtime lock with --ignore-installed. The lock
+        // sits in the source tree next to the package.
+        const serverDir = path.join(process.cwd(), "..", "server");
+        try {
+          const repairPath = path.join(os.tmpdir(), "ccp4i2-metadata-repair.py");
+          fs.writeFileSync(repairPath, REPAIR_METADATA_PY);
+          sendProgress("installing", `\nRepairing corrupt CCP4 Python package metadata (if any)…\n`);
+          await runPipStep([repairPath]);
+        } catch (e) {
+          sendProgress(
+            "installing",
+            `\n(metadata preflight skipped: ${(e as Error).message})\n`
+          );
+        }
+
+        sendProgress("installing", `\n[1/2] Installing ccp4i2 editable (no-deps)…\n`);
+        const codeEditable = await runPipStep([
+          "-m", "pip", "install", "--no-deps", "-e", serverDir, "--verbose",
         ]);
-        finish(code);
+        if (codeEditable !== 0) {
+          finish(codeEditable);
+          return;
+        }
+
+        const devLock = path.join(serverDir, "ccp4i2", "requirements-runtime.txt");
+        if (fs.existsSync(devLock)) {
+          sendProgress("installing", `\n[2/2] Installing dependencies from runtime lock…\n`);
+          const codeDeps = await runPipStep([
+            "-m", "pip", "install", "--no-deps", "--ignore-installed",
+            "-r", devLock, "--verbose",
+          ]);
+          finish(codeDeps);
+        } else {
+          sendProgress(
+            "installing",
+            `\n(no runtime lock at ${devLock}; skipping dependency step)\n`
+          );
+          finish(codeEditable);
+        }
         return;
       }
 

--- a/client/main/ccp4i2-master.ts
+++ b/client/main/ccp4i2-master.ts
@@ -141,6 +141,7 @@ export const store = new Store<StoreSchema>({
     zoomLevel: 0,
     CCP4I2_PROJECTS_DIR: getProjectsDir(),
     theme: "dark",
+    autoLaunch: true,
   },
 });
 

--- a/client/renderer/components/config-content.tsx
+++ b/client/renderer/components/config-content.tsx
@@ -231,9 +231,14 @@ export const ConfigContent: React.FC = () => {
   // installed — a mismatch (e.g. installed 3.1.0a1 under a 3.1.0a3 app) is then
   // obvious rather than silent.
   const requiredVersion: string | undefined = config?.requiredServerVersion;
+  // Unpacked/dev build (npm run start): the backend must be an EDITABLE install
+  // of server/, not the pinned wheel — so the version reference doesn't apply.
+  // This mirrors the main-process probe's isDev gate (not the devMode toggle).
+  const serverIsDev = !!config?.isDev;
   const norm = (v?: string | null) =>
     (v || "").trim().toLowerCase().replace(/[-_]/g, "");
   const versionMismatch =
+    !serverIsDev &&
     !!requirementsExist &&
     !!requiredVersion &&
     !!serverVersion &&
@@ -255,7 +260,11 @@ export const ConfigContent: React.FC = () => {
     if (!existingFiles?.CCP4Dir) blockers.push("Locate your CCP4 installation");
     if (!existingFiles?.venv_python) blockers.push("A Python environment is missing");
     if (!requirementsExist)
-      blockers.push("Install the CCP4i2 backend into your CCP4 environment");
+      blockers.push(
+        serverIsDev
+          ? "Install the CCP4i2 backend as an editable install of your server directory"
+          : "Install the CCP4i2 backend into your CCP4 environment"
+      );
   }
 
   // Open the setup section automatically when something needs attention.
@@ -425,24 +434,31 @@ export const ConfigContent: React.FC = () => {
                 label="ccp4i2 backend"
                 value={
                   !requirementsExist
-                    ? requiredVersion
-                      ? `Not installed — needs ${requiredVersion}`
-                      : "Not installed"
+                    ? serverIsDev
+                      ? "Not installed — needs an editable install of server/"
+                      : requiredVersion
+                        ? `Not installed — needs ${requiredVersion}`
+                        : "Not installed"
                     : versionMismatch
                       ? `Installed ${serverVersion}, but this app needs ${requiredVersion}`
                       : serverVersion
-                        ? `ccp4i2 ${serverVersion}`
+                        ? serverIsDev
+                          ? `ccp4i2 ${serverVersion} (editable)`
+                          : `ccp4i2 ${serverVersion}`
                         : "Installed"
                 }
                 action={
                   hasElectron
                     ? {
-                        // Name the exact version the button will install, so the
-                        // action is unambiguous (e.g. "Install 3.1.0a3").
+                        // Name what the button will install so the action is
+                        // unambiguous: the exact version in production
+                        // (e.g. "Install 3.1.0a3"), an editable install in dev.
                         label: !requirementsExist || versionMismatch
-                          ? requiredVersion
-                            ? `Install ${requiredVersion}`
-                            : "Install"
+                          ? serverIsDev
+                            ? "Install (editable)"
+                            : requiredVersion
+                              ? `Install ${requiredVersion}`
+                              : "Install"
                           : "Reinstall",
                         onClick: onInstallRequirements,
                         variant:

--- a/client/renderer/components/config-content.tsx
+++ b/client/renderer/components/config-content.tsx
@@ -39,6 +39,9 @@ import { useTheme } from "../theme/theme-provider";
  *   the setup section opens itself and shows exactly what to fix.
  * - No teams / auth / accounts UI: this is a single-user desktop tool.
  */
+// Grace period (seconds) before auto-entering CCP4i2 once setup is complete.
+const AUTO_LAUNCH_SECONDS = 5;
+
 export const ConfigContent: React.FC = () => {
   const { setTheme } = useTheme();
   const [config, setConfig] = useState<any | null>(null);
@@ -50,6 +53,11 @@ export const ConfigContent: React.FC = () => {
   const { setMessage } = usePopcorn();
   const [launching, setLaunching] = useState(false);
   const [setupOpen, setSetupOpen] = useState(false);
+  // Auto-launch countdown: when setup is complete, count down then enter CCP4i2
+  // automatically, unless the user intercepts. `countdown` is null when idle.
+  const [countdown, setCountdown] = useState<number | null>(null);
+  // Set when the user cancels this launch's countdown, so it doesn't re-arm.
+  const [autoLaunchCancelled, setAutoLaunchCancelled] = useState(false);
   const [installProgress, setInstallProgress] = useState<{
     isInstalling: boolean;
     output: string[];
@@ -176,6 +184,22 @@ export const ConfigContent: React.FC = () => {
     }
   };
 
+  // Intercept the countdown: stay on this screen and turn auto-launch off for
+  // good (the Setup switch can turn it back on). Enter now stays available.
+  const onCancelAutoLaunch = () => {
+    setAutoLaunchCancelled(true);
+    setCountdown(null);
+    window.electronAPI?.sendMessage("set-auto-launch", { enabled: false });
+  };
+
+  // Setup switch: persist the preference and, when re-enabling, allow the
+  // countdown to re-arm this session.
+  const onToggleAutoLaunch = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    const enabled = ev.target.checked;
+    if (enabled) setAutoLaunchCancelled(false);
+    window.electronAPI?.sendMessage("set-auto-launch", { enabled });
+  };
+
   const onInstallRequirements = () => {
     if (window.electronAPI) {
       setInstallProgress({ isInstalling: true, output: [], status: "started" });
@@ -229,6 +253,33 @@ export const ConfigContent: React.FC = () => {
     if (config && hasElectron && !isReady) setSetupOpen(true);
   }, [config, hasElectron, isReady]);
 
+  // Auto-launch preference (persisted in the electron store; on by default).
+  const autoLaunchPref = config?.autoLaunch !== false;
+  // The countdown is "armed" only when setup is complete, we're not already
+  // launching, the preference is on, and the user hasn't cancelled this round.
+  const autoLaunchArmed =
+    !!isReady && hasElectron && !launching && autoLaunchPref && !autoLaunchCancelled;
+
+  // Run the countdown while armed; disarming (cancel, launch, config change)
+  // clears it. Uses functional updates so the interval closure stays valid.
+  useEffect(() => {
+    if (!autoLaunchArmed) {
+      setCountdown(null);
+      return;
+    }
+    setCountdown(AUTO_LAUNCH_SECONDS);
+    const id = setInterval(() => {
+      setCountdown((c) => (c === null ? null : c <= 1 ? 0 : c - 1));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [autoLaunchArmed]);
+
+  // Enter automatically the instant the countdown reaches zero.
+  useEffect(() => {
+    if (countdown === 0 && autoLaunchArmed) onEnter();
+    // onEnter flips `launching`, which disarms and stops any re-fire.
+  }, [countdown, autoLaunchArmed]);
+
   return (
     <Stack spacing={2}>
       {/* Primary action — enter, or tell the user what's blocking it. */}
@@ -246,22 +297,57 @@ export const ConfigContent: React.FC = () => {
                 This app expects ccp4i2 {requiredVersion}
               </Typography>
             )}
-            <Button
-              variant="contained"
-              size="large"
-              startIcon={
-                launching ? (
-                  <CircularProgress size={18} color="inherit" />
-                ) : (
-                  <RocketLaunch />
-                )
-              }
-              onClick={onEnter}
-              disabled={launching}
-              sx={{ minWidth: 220 }}
-            >
-              {launching ? "Starting…" : "Enter CCP4i2"}
-            </Button>
+            {countdown !== null && (
+              <Typography variant="body2" fontWeight={600}>
+                Entering CCP4i2 automatically in {countdown}s…
+              </Typography>
+            )}
+            {countdown !== null ? (
+              <Stack direction="row" spacing={1.5}>
+                <Button
+                  variant="contained"
+                  size="large"
+                  startIcon={
+                    launching ? (
+                      <CircularProgress size={18} color="inherit" />
+                    ) : (
+                      <RocketLaunch />
+                    )
+                  }
+                  onClick={onEnter}
+                  disabled={launching}
+                  sx={{ minWidth: 160 }}
+                >
+                  {launching ? "Starting…" : "Enter now"}
+                </Button>
+                <Button
+                  variant="outlined"
+                  size="large"
+                  startIcon={<Cancel />}
+                  onClick={onCancelAutoLaunch}
+                  disabled={launching}
+                >
+                  Cancel
+                </Button>
+              </Stack>
+            ) : (
+              <Button
+                variant="contained"
+                size="large"
+                startIcon={
+                  launching ? (
+                    <CircularProgress size={18} color="inherit" />
+                  ) : (
+                    <RocketLaunch />
+                  )
+                }
+                onClick={onEnter}
+                disabled={launching}
+                sx={{ minWidth: 220 }}
+              >
+                {launching ? "Starting…" : "Enter CCP4i2"}
+              </Button>
+            )}
           </Stack>
         </Paper>
       ) : (
@@ -355,10 +441,27 @@ export const ConfigContent: React.FC = () => {
 
               <Stack
                 direction="row"
-                spacing={2}
+                spacing={1}
                 alignItems="center"
                 justifyContent="space-between"
                 sx={{ pt: 1 }}
+              >
+                <Typography variant="body2">
+                  Launch automatically when ready
+                </Typography>
+                <Switch
+                  size="small"
+                  checked={autoLaunchPref}
+                  onChange={onToggleAutoLaunch}
+                  disabled={!hasElectron}
+                />
+              </Stack>
+
+              <Stack
+                direction="row"
+                spacing={2}
+                alignItems="center"
+                justifyContent="space-between"
               >
                 <Stack direction="row" spacing={1} alignItems="center">
                   <Typography variant="body2">Theme</Typography>

--- a/client/renderer/components/config-content.tsx
+++ b/client/renderer/components/config-content.tsx
@@ -202,6 +202,10 @@ export const ConfigContent: React.FC = () => {
 
   const onInstallRequirements = () => {
     if (window.electronAPI) {
+      // Starting an install intercepts any running countdown for this session
+      // (without persisting auto-launch off) so we never enter mid-pip-install.
+      setAutoLaunchCancelled(true);
+      setCountdown(null);
       setInstallProgress({ isInstalling: true, output: [], status: "started" });
       window.electronAPI.sendMessage("install-requirements", {
         ...config,
@@ -235,16 +239,22 @@ export const ConfigContent: React.FC = () => {
     !!serverVersion &&
     norm(serverVersion) !== norm(requiredVersion);
 
-  // Ready to enter when the venv exists and requirements are present (or dev).
+  // Ready to enter when the venv exists AND the backend actually imports. Dev
+  // mode relaxes only the *version match* (handled in the requirements probe —
+  // it never version-gates in dev), NOT the existence of the backend: with
+  // nothing installed the probe fails and Django can't even start (e.g.
+  // ModuleNotFoundError: corsheaders), so "nothing installed" is never ready,
+  // dev or not. requirementsExist already encodes "importable, version-relaxed
+  // in dev", so gate on it directly.
   const isReady =
-    config && hasElectron && existingFiles?.venv_python && (devMode || requirementsExist);
+    config && hasElectron && existingFiles?.venv_python && requirementsExist;
 
   // What still needs doing, in the user's words.
   const blockers: string[] = [];
   if (config && hasElectron) {
     if (!existingFiles?.CCP4Dir) blockers.push("Locate your CCP4 installation");
     if (!existingFiles?.venv_python) blockers.push("A Python environment is missing");
-    if (!devMode && !requirementsExist)
+    if (!requirementsExist)
       blockers.push("Install the CCP4i2 backend into your CCP4 environment");
   }
 
@@ -256,9 +266,15 @@ export const ConfigContent: React.FC = () => {
   // Auto-launch preference (persisted in the electron store; on by default).
   const autoLaunchPref = config?.autoLaunch !== false;
   // The countdown is "armed" only when setup is complete, we're not already
-  // launching, the preference is on, and the user hasn't cancelled this round.
+  // launching or installing, the preference is on, and the user hasn't
+  // cancelled this round.
   const autoLaunchArmed =
-    !!isReady && hasElectron && !launching && autoLaunchPref && !autoLaunchCancelled;
+    !!isReady &&
+    hasElectron &&
+    !launching &&
+    !installProgress.isInstalling &&
+    autoLaunchPref &&
+    !autoLaunchCancelled;
 
   // Run the countdown while armed; disarming (cancel, launch, config change)
   // clears it. Uses functional updates so the interval closure stays valid.

--- a/client/types/store.d.ts
+++ b/client/types/store.d.ts
@@ -6,4 +6,5 @@ export interface StoreSchema {
   devMode: boolean;
   CCP4I2_PROJECTS_DIR: string;
   theme: "light" | "dark";
+  autoLaunch: boolean;          // Auto-enter CCP4i2 (after a countdown) once setup is complete
 }

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -97,6 +97,15 @@ i2run = "ccp4i2.cli.i2run.main:main"
 [tool.setuptools.dynamic]
 version = { attr = "ccp4i2.__version__" }
 
+# Pin package discovery to the ccp4i2 tree. Without this, setuptools falls back
+# to flat-layout auto-discovery, which sweeps up any stray top-level dir in a
+# working checkout (e.g. job_N job outputs) and fails an editable install with
+# "Multiple top-level packages discovered in a flat-layout". Clean CI only ever
+# contains ccp4i2*, so this is a no-op for the packaged wheel — it just hardens
+# the dev/editable path against a polluted tree.
+[tool.setuptools.packages.find]
+include = ["ccp4i2*"]
+
 [tool.setuptools.package-data]
 ccp4i2 = ["**/*"]
 


### PR DESCRIPTION
## Summary

When the launch screen reaches "ready", enter CCP4i2 automatically after a **5-second countdown**, unless the user intercepts. Removes a click from the common get-me-in path while keeping full control. Rebased on `django` (includes #258).

### Feature
- Persisted `autoLaunch` preference (electron store, **on by default**), exposed via a new `set-auto-launch` IPC handler and a **"Launch automatically when ready"** switch in the Setup panel.
- The Ready panel shows *"Entering CCP4i2 automatically in Ns…"* with **Enter now** and **Cancel**. Cancel intercepts this launch and persists auto-launch off (the Setup switch turns it back on).
- Countdown arms only when setup is complete, not already launching/installing, the preference is on, and it hasn't been cancelled this session; it fires the existing `onEnter()` exactly once. Web mode (no electron) never arms.

### Correctness fixes (found in alpha dev-mode testing)
- **Never treat "no backend" as ready.** `isReady` previously short-circuited in dev (`devMode || requirementsExist`), so with nothing installed the app would enter and Django would die (`ModuleNotFoundError: corsheaders`). Now gated on `requirementsExist` directly — the probe already relaxes only the *version match* in dev while still requiring `ccp4i2` to import, giving the intended rule: **dev relaxes the pinned-version match, but a missing backend is never ready.** (Pre-existing bug the countdown surfaced by auto-firing.)
- **Never launch mid-install.** Starting Install/Reinstall intercepts a running countdown for the session (without persisting the preference off), and `autoLaunchArmed` additionally requires `!isInstalling`.

### Packaging fix (dev/editable install robustness)
- Pin setuptools discovery to `ccp4i2*` in `server/pyproject.toml`. Without it, flat-layout auto-discovery sweeps up stray top-level dirs in a working checkout (e.g. `job_N` job outputs) and fails an editable install with *"Multiple top-level packages discovered in a flat-layout"*. No-op for the packaged wheel (clean CI only contains `ccp4i2*`).

## Testing
- `tsc --noEmit` clean; validated in dev mode (`npm run start`) that the readiness gate and countdown now behave correctly.
- CI (build-linux/mac/win) triggered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)