### PR TITLE
fix(desktop): only disable Linux sandbox when the kernel actually blocks it

### DIFF
--- a/client/main/ccp4i2-master.ts
+++ b/client/main/ccp4i2-master.ts
@@ -22,15 +22,41 @@ import os from "os";
 
 const isDev = !app.isPackaged; // ✅ Works in compiled builds
 
-// On modern Linux (kernel 6.x + AppArmor), unprivileged user namespaces are
-// restricted by default, which the Chromium SUID sandbox needs. Inside an
-// AppImage this makes the very first launch hard-crash with
-// "The SUID sandbox helper binary was found, but is not configured correctly".
-// Disabling the sandbox here avoids forcing users to weaken kernel security
-// (sysctl kernel.apparmor_restrict_unprivileged_userns=0) just to start the app.
-// Only applied on Linux — macOS/Windows keep their working sandbox.
+// On SOME modern Linux (kernel 6.x + AppArmor), unprivileged user namespaces are
+// restricted, which the Chromium SUID sandbox needs. Inside an AppImage (whose
+// chrome-sandbox helper isn't setuid-root) that makes the very first launch
+// hard-crash with "The SUID sandbox helper binary was found, but is not
+// configured correctly" — the exact case the sysctl
+// kernel.apparmor_restrict_unprivileged_userns=0 works around.
+//
+// But disabling the sandbox is NOT free: with --no-sandbox Chromium falls back
+// to a /dev/shm-based shared-memory path that itself fails on some setups (FATAL
+// in platform_shared_memory_region_posix → blank white window). So applying
+// --no-sandbox UNCONDITIONALLY on Linux (as a12–a14 did) broke machines whose
+// sandbox worked perfectly well.
+//
+// Fix: only disable the sandbox when the machine actually has the restriction
+// that would otherwise crash it — i.e. apparmor_restrict_unprivileged_userns == 1.
+// Machines without it keep their working sandbox untouched (restoring a11
+// behaviour for them). When we DO disable it, also route shared memory off
+// /dev/shm so the no-sandbox path can't blank-window.
 if (process.platform === "linux") {
-  app.commandLine.appendSwitch("no-sandbox");
+  let userNsRestricted = false;
+  try {
+    userNsRestricted =
+      fs
+        .readFileSync(
+          "/proc/sys/kernel/apparmor_restrict_unprivileged_userns",
+          "utf8"
+        )
+        .trim() === "1";
+  } catch {
+    // File absent (older kernel / no AppArmor) → the sandbox works; leave it on.
+  }
+  if (userNsRestricted) {
+    app.commandLine.appendSwitch("no-sandbox");
+    app.commandLine.appendSwitch("disable-dev-shm-usage");
+  }
 }
 
 // Change the current working directory to the Resources folder


### PR DESCRIPTION
## Regression fix (Linux blank window on a12–a14)

An alpha tester on **Ubuntu 24.04** reports a **blank white window on a12+**, while **a11 works**:

```
Next.js ready on http://localhost:3000
[FATAL:platform_shared_memory_region_posix.cc(219)] … incorrect permissions on /dev/shm …
Creating shared memory in /dev/shm/.org.chromium.Chromium.* failed: No such process (3)
```

### Root cause
a12 (#257) added `--no-sandbox` **unconditionally** on Linux to dodge the AppImage SUID-sandbox crash on AppArmor-restricted kernels. But "a11 works" proves this tester's **sandbox was fine** — and `--no-sandbox` *disabled* it, forcing Chromium's `/dev/shm` shared-memory fallback, which FATALs on his setup → blank window. The blunt unconditional flag fixed one class of machine and broke another.

### Fix
Apply `--no-sandbox` **only when the machine actually has the restriction that would crash the sandbox** — read `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` and disable the sandbox (plus `--disable-dev-shm-usage`, so the no-sandbox path can't blank-window) only when it's `1`. That's the exact sysctl the *first* Linux tester had to flip. Machines without the restriction keep their working sandbox untouched (restores a11 behaviour).

Strictly better than both prior states:
| Machine | a11 (no flag) | a12–a14 (always `--no-sandbox`) | This fix |
|---|---|---|---|
| AppArmor-restricted | ❌ SUID crash | ✅ runs | ✅ runs (flag applied) |
| Unrestricted (this tester) | ✅ runs | ❌ blank window | ✅ runs (sandbox kept) |

### Validation
⚠️ **Cannot be reproduced on macOS/CI** — this is kernel-config-dependent. Needs real-Linux testing on **both** a restricted and an unrestricted kernel before it rides into an alpha. Suggest testers run the AppImage artifact from this PR's build first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)