### PR TITLE
fix(desktop): unconditionally disable Linux sandbox + /dev/shm on the AppImage

### DIFF
--- a/.github/workflows/electron-multiplatform-build.yml
+++ b/.github/workflows/electron-multiplatform-build.yml
@@ -113,8 +113,10 @@ jobs:
       - name: List release contents
         run: ls -lh client/release
 
-      - name: Upload Linux AppImage artifacts
+      - name: Upload Linux artifacts (AppImage + deb)
         uses: actions/upload-artifact@v4
         with:
           name: linux-appimages
-          path: client/release/*.AppImage
+          path: |
+            client/release/*.AppImage
+            client/release/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,9 @@ jobs:
             glob: client/release/*.exe
           - os: ubuntu-latest
             script: package-linux-x64
-            glob: client/release/*.AppImage
+            glob: |
+              client/release/*.AppImage
+              client/release/*.deb
     runs-on: ${{ matrix.os }}
     env:
       # Stamp the exact backend version from the tag so the released app pins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,3 +346,9 @@ jobs:
             `ccp4i2-django.app` to `/Applications`:
             `xattr -cr "/Applications/ccp4i2-django.app"`. (Signed+notarised
             builds open with no warning — skip this.)
+
+            **Linux:** the `.deb` is recommended (Ubuntu/Debian) — it keeps a
+            full Chromium sandbox on modern locked-down kernels:
+            `sudo apt install ./ccp4i2-django_*.deb`. The `.AppImage` is a
+            portable fallback (disables its sandbox automatically on such
+            kernels; no `sysctl` needed).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ CCP4i2 uses a modern web-based architecture:
 **See [Give it a try](docs/give-it-a-try.md)** for the full walkthrough. In short:
 
 1. **Install CCP4 10** from [CCP4 Downloads](https://ccp4serv6.rc-harwell.ac.uk/10/downloads/) (provides `ccp4-python`).
-2. **Download the desktop app** for your OS from [Releases](https://github.com/ccp4/ccp4i2/releases) — during the alpha, pick the top entry marked **Pre-release** and grab the installer for your OS (macOS `.dmg`, Windows `.exe`, Linux `.AppImage`). On macOS, clear quarantine: `xattr -cr "/Applications/ccp4i2-django.app"`.
+2. **Download the desktop app** for your OS from [Releases](https://github.com/ccp4/ccp4i2/releases) — during the alpha, pick the top entry marked **Pre-release** and grab the installer for your OS (macOS `.dmg`, Windows `.exe`, Linux `.deb` **recommended** or `.AppImage`). On macOS, clear quarantine: `xattr -cr "/Applications/ccp4i2-django.app"`. On Ubuntu/Debian, `sudo apt install ./ccp4i2-django_*.deb`.
 3. **Launch it**, point it at your CCP4 installation, and click **Install** when prompted — the app installs the matching `ccp4i2` backend into `ccp4-python` for you.
 
 > Do **not** `pip install ccp4i2` against system Python — the backend must live in CCP4's `ccp4-python`, which the app handles automatically. Each app build is pinned to one exact backend version (shown on the launch screen), so you never match versions by hand.

--- a/client/main/ccp4i2-master.ts
+++ b/client/main/ccp4i2-master.ts
@@ -22,41 +22,25 @@ import os from "os";
 
 const isDev = !app.isPackaged; // ✅ Works in compiled builds
 
-// On SOME modern Linux (kernel 6.x + AppArmor), unprivileged user namespaces are
-// restricted, which the Chromium SUID sandbox needs. Inside an AppImage (whose
-// chrome-sandbox helper isn't setuid-root) that makes the very first launch
-// hard-crash with "The SUID sandbox helper binary was found, but is not
-// configured correctly" — the exact case the sysctl
-// kernel.apparmor_restrict_unprivileged_userns=0 works around.
+// The AppImage's chrome-sandbox helper isn't setuid-root, so on kernels that
+// restrict unprivileged user namespaces (the modern-Ubuntu / AppArmor default)
+// the Chromium sandbox can't start and the app aborts on launch with
+// "The SUID sandbox helper binary was found, but is not configured correctly".
 //
-// But disabling the sandbox is NOT free: with --no-sandbox Chromium falls back
-// to a /dev/shm-based shared-memory path that itself fails on some setups (FATAL
-// in platform_shared_memory_region_posix → blank white window). So applying
-// --no-sandbox UNCONDITIONALLY on Linux (as a12–a14 did) broke machines whose
-// sandbox worked perfectly well.
-//
-// Fix: only disable the sandbox when the machine actually has the restriction
-// that would otherwise crash it — i.e. apparmor_restrict_unprivileged_userns == 1.
-// Machines without it keep their working sandbox untouched (restoring a11
-// behaviour for them). When we DO disable it, also route shared memory off
-// /dev/shm so the no-sandbox path can't blank-window.
+// a12–a14 disabled the sandbox unconditionally (→ blank window from the
+// /dev/shm shared-memory fallback); a15 tried to gate it on
+// /proc/sys/kernel/apparmor_restrict_unprivileged_userns, but that detection
+// proved unreliable in the packaged AppImage (restricted machines still hit the
+// SUID crash — the switch never got applied). So: disable UNCONDITIONALLY on
+// Linux — for the AppImage format it's the only zero-privilege path — and pair
+// it with --disable-dev-shm-usage, which routes shared memory off /dev/shm (the
+// no-sandbox path otherwise depends on /dev/shm, which FATALs on some setups →
+// blank white window). It's app-scoped: other apps and the rest of the system
+// keep their sandbox. The sandbox-preserving fix is the .deb target (setuid
+// chrome-sandbox via its root install step); this flag pair is the AppImage tax.
 if (process.platform === "linux") {
-  let userNsRestricted = false;
-  try {
-    userNsRestricted =
-      fs
-        .readFileSync(
-          "/proc/sys/kernel/apparmor_restrict_unprivileged_userns",
-          "utf8"
-        )
-        .trim() === "1";
-  } catch {
-    // File absent (older kernel / no AppArmor) → the sandbox works; leave it on.
-  }
-  if (userNsRestricted) {
-    app.commandLine.appendSwitch("no-sandbox");
-    app.commandLine.appendSwitch("disable-dev-shm-usage");
-  }
+  app.commandLine.appendSwitch("no-sandbox");
+  app.commandLine.appendSwitch("disable-dev-shm-usage");
 }
 
 // Change the current working directory to the Resources folder

--- a/client/main/ccp4i2-master.ts
+++ b/client/main/ccp4i2-master.ts
@@ -22,23 +22,21 @@ import os from "os";
 
 const isDev = !app.isPackaged; // ✅ Works in compiled builds
 
-// The AppImage's chrome-sandbox helper isn't setuid-root, so on kernels that
-// restrict unprivileged user namespaces (the modern-Ubuntu / AppArmor default)
-// the Chromium sandbox can't start and the app aborts on launch with
-// "The SUID sandbox helper binary was found, but is not configured correctly".
+// AppImage-only sandbox handling. An AppImage extracts to a FUSE mount in /tmp
+// and can't ship a setuid-root chrome-sandbox, so on kernels that restrict
+// unprivileged user namespaces (Ubuntu 24.04+ default) the Chromium sandbox
+// can't start and the app aborts with "The SUID sandbox helper binary ... not
+// configured correctly". We best-effort disable the sandbox and route shared
+// memory off /dev/shm here — but ONLY for the AppImage (detected via the
+// APPIMAGE env var the runtime sets), so the .deb keeps a FULL, working sandbox
+// with no flags. The .deb's postinst setuids chrome-sandbox + installs an
+// AppArmor userns profile, which is the proper fix for locked-down kernels.
 //
-// a12–a14 disabled the sandbox unconditionally (→ blank window from the
-// /dev/shm shared-memory fallback); a15 tried to gate it on
-// /proc/sys/kernel/apparmor_restrict_unprivileged_userns, but that detection
-// proved unreliable in the packaged AppImage (restricted machines still hit the
-// SUID crash — the switch never got applied). So: disable UNCONDITIONALLY on
-// Linux — for the AppImage format it's the only zero-privilege path — and pair
-// it with --disable-dev-shm-usage, which routes shared memory off /dev/shm (the
-// no-sandbox path otherwise depends on /dev/shm, which FATALs on some setups →
-// blank white window). It's app-scoped: other apps and the rest of the system
-// keep their sandbox. The sandbox-preserving fix is the .deb target (setuid
-// chrome-sandbox via its root install step); this flag pair is the AppImage tax.
-if (process.platform === "linux") {
+// Caveat: --no-sandbox is read by Chromium's zygote very early and appendSwitch
+// is not always honoured for it in a packaged AppImage; the reliable path for
+// restricted kernels is therefore the .deb, not the AppImage. --disable-dev-shm-
+// usage IS honoured and helps where the no-sandbox path trips over /dev/shm.
+if (process.platform === "linux" && process.env.APPIMAGE) {
   app.commandLine.appendSwitch("no-sandbox");
   app.commandLine.appendSwitch("disable-dev-shm-usage");
 }

--- a/client/package.json
+++ b/client/package.json
@@ -191,15 +191,25 @@
       "createStartMenuShortcut": true
     },
     "linux": {
-      "target": {
-        "target": "AppImage",
-        "arch": [
-          "x64"
-        ]
-      },
-      "executableArgs": [
-        "--no-sandbox"
-      ]
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "category": "Science"
+    },
+    "deb": {
+      "afterInstall": "packaging/deb/postinst.sh",
+      "afterRemove": "packaging/deb/postrm.sh"
     }
   },
   "overrides": {

--- a/client/package.json
+++ b/client/package.json
@@ -31,7 +31,7 @@
     "export:web": "cross-env BUILD_TARGET=web npm run build:web && cd renderer && next export",
     "package-mac": "npm install && npm run build:electron && npm prune --omit=dev --ignore-scripts && npm install --no-save --ignore-scripts electron-builder@26.7.0 && electron-builder",
     "package-win": "npm install && npm run build:electron && npm prune --omit=dev --ignore-scripts && npm install --no-save --ignore-scripts electron-builder@26.7.0 && electron-builder --win",
-    "package-linux-x64": "npm install && npm run build:electron && npm prune --omit=dev --ignore-scripts && npm install --no-save --ignore-scripts electron-builder@26.7.0 && electron-builder --linux AppImage --x64",
+    "package-linux-x64": "npm install && npm run build:electron && npm prune --omit=dev --ignore-scripts && npm install --no-save --ignore-scripts electron-builder@26.7.0 && electron-builder --linux AppImage deb --x64",
     "package-linux-arm64": "npm install && npm run build:electron && npm prune --omit=dev --ignore-scripts && npm install --no-save --ignore-scripts electron-builder@26.7.0 && electron-builder --linux AppImage --arm64",
     "package-linux-all": "npm install && npm run build:electron && npm prune --omit=dev --ignore-scripts && npm install --no-save --ignore-scripts electron-builder@26.7.0 && electron-builder --linux AppImage --x64 --arm64",
     "test": "vitest run",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
   },
   "license": "LGPL-3.0-or-later",
   "description": "CCP4i2 Electron application",
+  "homepage": "https://www.ccp4.ac.uk/",
   "scripts": {
     "copy-rdkit-minimal": "copyfiles -u 4 node_modules/@rdkit/rdkit/dist/* renderer/public/",
     "copy-moorhen-root": "copyfiles -u 2 -e '**/*.wasm' -e '**/*.wasm.map' node_modules/moorhen/public/* renderer/",

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
   },
   "license": "LGPL-3.0-or-later",
   "description": "CCP4i2 Electron application",
-  "homepage": "https://www.ccp4.ac.uk/",
+  "homepage": "https://github.com/ccp4/ccp4i2",
   "scripts": {
     "copy-rdkit-minimal": "copyfiles -u 4 node_modules/@rdkit/rdkit/dist/* renderer/public/",
     "copy-moorhen-root": "copyfiles -u 2 -e '**/*.wasm' -e '**/*.wasm.map' node_modules/moorhen/public/* renderer/",

--- a/client/packaging/deb/postinst.sh
+++ b/client/packaging/deb/postinst.sh
@@ -4,9 +4,9 @@
 # (Ubuntu 24.04+ restricts unprivileged user namespaces by default) — so the
 # .deb needs NO --no-sandbox and keeps full sandboxing.
 #
-# NOTE: electron-builder runs its own ${macro} substitution over this file, so it
-# must contain NO ${...} shell syntax — use brace-less $VAR only. A bare ${VAR}
-# here fails the build with "Macro VAR is not defined".
+# NOTE: electron-builder macro-substitutes dollar-brace tokens over this WHOLE
+# file (comments included), so it must contain no braced shell variables — use
+# brace-less $VAR only. A braced variable fails the build ("Macro X not defined").
 set -e
 
 APP_DIR=/opt/ccp4i2-django

--- a/client/packaging/deb/postinst.sh
+++ b/client/packaging/deb/postinst.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Runs as root during `apt install` / `dpkg -i`. Does the two things an AppImage
+# cannot, which together let the Chromium sandbox start on locked-down kernels
+# (Ubuntu 24.04+ restricts unprivileged user namespaces by default) — so the
+# .deb needs NO --no-sandbox and keeps full sandboxing.
+set -e
+
+APP_DIR="/opt/ccp4i2-django"
+SANDBOX="${APP_DIR}/chrome-sandbox"
+
+# 1. The Chromium SUID sandbox helper must be owned by root with mode 4755.
+#    Without this the app aborts with "The SUID sandbox helper binary was found,
+#    but is not configured correctly". This alone makes the (privileged) SUID
+#    sandbox work regardless of the unprivileged-userns restriction.
+if [ -f "${SANDBOX}" ]; then
+  chown root:root "${SANDBOX}" || true
+  chmod 4755 "${SANDBOX}" || true
+fi
+
+# 2. Also install an AppArmor profile granting user namespaces, so the
+#    (preferred) namespace sandbox works too on 24.04+. Belt-and-suspenders and
+#    a no-op where AppArmor isn't enforcing the restriction.
+PROFILE="/etc/apparmor.d/ccp4i2-django"
+if [ -d /etc/apparmor.d ] && command -v apparmor_parser >/dev/null 2>&1; then
+  cat > "${PROFILE}" <<'PROF'
+abi <abi/4.0>,
+include <tunables/global>
+
+profile ccp4i2-django "/opt/ccp4i2-django/ccp4i2-django" flags=(unconfined) {
+  userns,
+  include if exists <local/ccp4i2-django>
+}
+PROF
+  # Non-fatal: older AppArmor without abi/4.0 will reject this; that's fine
+  # because those kernels don't enforce the restriction in the first place.
+  apparmor_parser -r -W "${PROFILE}" 2>/dev/null || true
+fi
+
+exit 0

--- a/client/packaging/deb/postinst.sh
+++ b/client/packaging/deb/postinst.sh
@@ -3,26 +3,30 @@
 # cannot, which together let the Chromium sandbox start on locked-down kernels
 # (Ubuntu 24.04+ restricts unprivileged user namespaces by default) — so the
 # .deb needs NO --no-sandbox and keeps full sandboxing.
+#
+# NOTE: electron-builder runs its own ${macro} substitution over this file, so it
+# must contain NO ${...} shell syntax — use brace-less $VAR only. A bare ${VAR}
+# here fails the build with "Macro VAR is not defined".
 set -e
 
-APP_DIR="/opt/ccp4i2-django"
-SANDBOX="${APP_DIR}/chrome-sandbox"
+APP_DIR=/opt/ccp4i2-django
+SANDBOX="$APP_DIR/chrome-sandbox"
 
 # 1. The Chromium SUID sandbox helper must be owned by root with mode 4755.
 #    Without this the app aborts with "The SUID sandbox helper binary was found,
 #    but is not configured correctly". This alone makes the (privileged) SUID
 #    sandbox work regardless of the unprivileged-userns restriction.
-if [ -f "${SANDBOX}" ]; then
-  chown root:root "${SANDBOX}" || true
-  chmod 4755 "${SANDBOX}" || true
+if [ -f "$SANDBOX" ]; then
+  chown root:root "$SANDBOX" || true
+  chmod 4755 "$SANDBOX" || true
 fi
 
 # 2. Also install an AppArmor profile granting user namespaces, so the
 #    (preferred) namespace sandbox works too on 24.04+. Belt-and-suspenders and
 #    a no-op where AppArmor isn't enforcing the restriction.
-PROFILE="/etc/apparmor.d/ccp4i2-django"
+PROFILE=/etc/apparmor.d/ccp4i2-django
 if [ -d /etc/apparmor.d ] && command -v apparmor_parser >/dev/null 2>&1; then
-  cat > "${PROFILE}" <<'PROF'
+  cat > "$PROFILE" <<'PROF'
 abi <abi/4.0>,
 include <tunables/global>
 
@@ -33,7 +37,7 @@ profile ccp4i2-django "/opt/ccp4i2-django/ccp4i2-django" flags=(unconfined) {
 PROF
   # Non-fatal: older AppArmor without abi/4.0 will reject this; that's fine
   # because those kernels don't enforce the restriction in the first place.
-  apparmor_parser -r -W "${PROFILE}" 2>/dev/null || true
+  apparmor_parser -r -W "$PROFILE" 2>/dev/null || true
 fi
 
 exit 0

--- a/client/packaging/deb/postrm.sh
+++ b/client/packaging/deb/postrm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Runs as root on remove/purge. Unload and remove the AppArmor profile the
+# postinst installed. (chrome-sandbox lives under /opt and is removed with the
+# package, so nothing to undo there.)
+set -e
+
+PROFILE="/etc/apparmor.d/ccp4i2-django"
+if [ -f "${PROFILE}" ]; then
+  if command -v apparmor_parser >/dev/null 2>&1; then
+    apparmor_parser -R "${PROFILE}" 2>/dev/null || true
+  fi
+  rm -f "${PROFILE}"
+fi
+
+exit 0

--- a/client/packaging/deb/postrm.sh
+++ b/client/packaging/deb/postrm.sh
@@ -3,8 +3,8 @@
 # postinst installed. (chrome-sandbox lives under /opt and is removed with the
 # package, so nothing to undo there.)
 #
-# NOTE: no ${...} shell syntax — electron-builder macro-substitutes this file
-# and a bare ${VAR} fails the build ("Macro VAR is not defined"). Use $VAR.
+# NOTE: no braced shell variables — electron-builder macro-substitutes this file
+# (comments included) and a braced variable fails the build. Use brace-less $VAR.
 set -e
 
 PROFILE=/etc/apparmor.d/ccp4i2-django

--- a/client/packaging/deb/postrm.sh
+++ b/client/packaging/deb/postrm.sh
@@ -2,14 +2,17 @@
 # Runs as root on remove/purge. Unload and remove the AppArmor profile the
 # postinst installed. (chrome-sandbox lives under /opt and is removed with the
 # package, so nothing to undo there.)
+#
+# NOTE: no ${...} shell syntax — electron-builder macro-substitutes this file
+# and a bare ${VAR} fails the build ("Macro VAR is not defined"). Use $VAR.
 set -e
 
-PROFILE="/etc/apparmor.d/ccp4i2-django"
-if [ -f "${PROFILE}" ]; then
+PROFILE=/etc/apparmor.d/ccp4i2-django
+if [ -f "$PROFILE" ]; then
   if command -v apparmor_parser >/dev/null 2>&1; then
-    apparmor_parser -R "${PROFILE}" 2>/dev/null || true
+    apparmor_parser -R "$PROFILE" 2>/dev/null || true
   fi
-  rm -f "${PROFILE}"
+  rm -f "$PROFILE"
 fi
 
 exit 0

--- a/docs/give-it-a-try.md
+++ b/docs/give-it-a-try.md
@@ -102,6 +102,45 @@ that restrict the sandbox the AppImage disables it automatically — you do **no
 need `sudo sysctl …` or any other system-wide change. (If you're on such a kernel
 and want the sandbox kept, use the `.deb`.)
 
+<details>
+<summary><strong>Why the <code>.deb</code>? (and why the AppImage struggles on hardened kernels)</strong></summary>
+
+Chromium — which Electron, and therefore this app, is built on — refuses to run
+its rendering processes unless it can put them in a **sandbox**. It can build
+that sandbox one of two ways, and it needs *one* of them:
+
+1. a small helper (`chrome-sandbox`) that is **allowed to run as root** (the
+   "SUID sandbox"), or
+2. **unprivileged user namespaces** — a kernel feature letting ordinary programs
+   create isolated environments without being root.
+
+Modern "locked-down" distros (Ubuntu 24.04+) **switch off option 2** by default
+for security (`kernel.apparmor_restrict_unprivileged_userns=1`). That leaves the
+app needing option 1 — a root-privileged helper — and here the packaging format
+is decisive:
+
+| | AppImage | `.deb` |
+|---|---|---|
+| Runs an install step **as root**? | No — it's a self-mounting single file | Yes — `dpkg`/`apt` runs its `postinst` as root |
+| Can make `chrome-sandbox` setuid-root? | No — it unpacks to a `nosuid` FUSE mount in `/tmp`, and nothing runs as root to `chown`/`chmod` it | **Yes** — `postinst` does `chown root:root` + `chmod 4755` |
+| SUID sandbox available? | No | **Yes** (the helper is privileged, so it needs no unprivileged userns) |
+| Namespace sandbox available on 24.04+? | No (kernel restriction) | Not needed |
+| Result on a locked-down kernel | Sandbox can't start → crash; we fall back to `--no-sandbox` | **Full sandbox, no flags, no user action** |
+
+The load-bearing sentence: **the sandbox needs a privilege it can obtain only two
+ways; the locked-down kernel removes one of them, and only a package with a root
+install step can supply the other.** An AppImage has no root install step; a
+`.deb` does.
+
+The proof it works: **Google Chrome and VS Code run fine on these same kernels**
+— because they ship as `.deb`s whose installer does this exact setuid step. Our
+`.deb` simply does the same (see `client/packaging/deb/postinst.sh`). So the
+AppImage isn't broken so much as structurally unable to sandbox on a hardened
+desktop; the `.deb` is the right tool, and the AppImage remains a portable
+fallback for other distros or where you can't `sudo`.
+
+</details>
+
 ## 3. Launch and point it at CCP4
 
 Start the app. It auto-detects CCP4 in the usual locations; if it can't find

--- a/docs/give-it-a-try.md
+++ b/docs/give-it-a-try.md
@@ -44,7 +44,7 @@ installer for your OS — no GitHub login needed:
 |---|---|
 | macOS | `.dmg` |
 | Windows | `.exe` installer |
-| Linux | `.AppImage` |
+| Linux | `.deb` (Ubuntu/Debian — **recommended**) or `.AppImage` (portable) |
 
 > During the alpha, releases are **pre-releases**, so they won't appear under
 > "Latest release" — pick the top entry tagged *Pre-release* on the Releases
@@ -74,20 +74,33 @@ Then launch it (first launch: right-click → **Open** if prompted). If the app
 opens normally without any warning, it was signed and notarised and you can skip
 this step.
 
-### Linux: make the AppImage executable
+### Linux: install the `.deb` (recommended) or run the AppImage
 
-Downloaded AppImages are **not executable** by default (your browser doesn't set
-the flag), so double-clicking will just offer to open the file rather than run
-it. Mark it executable once:
+**Ubuntu / Debian — install the `.deb` (recommended):**
+
+```bash
+sudo apt install ./ccp4i2-django_*.deb
+```
+
+This installs to `/opt/ccp4i2-django`, adds an application-menu entry and a
+`ccp4i2-django` command, and sets up the Chromium sandbox the same way Chrome
+and VS Code do — so it runs on **modern locked-down kernels (Ubuntu 24.04+)**
+with a full sandbox and **no workarounds**. This is the best option on a
+desktop; prefer it if you can `sudo`.
+
+**Other distros, or no root — the portable `.AppImage`:** downloaded AppImages
+aren't executable by default (your browser doesn't set the flag), so mark it
+once:
 
 ```bash
 chmod +x ccp4i2-django-*.AppImage
 ```
 
-(or right-click → **Properties** → **Permissions** → tick **Allow executing file
-as program**). Then double-click, or run `./ccp4i2-django-*.AppImage`. The build
-already passes `--no-sandbox` for you, so it launches on server-class and
-hardened kernels without any extra flags.
+(or right-click → **Properties** → **Permissions** → **Allow executing file as
+program**), then double-click or run `./ccp4i2-django-*.AppImage`. On kernels
+that restrict the sandbox the AppImage disables it automatically — you do **not**
+need `sudo sysctl …` or any other system-wide change. (If you're on such a kernel
+and want the sandbox kept, use the `.deb`.)
 
 ## 3. Launch and point it at CCP4
 
@@ -138,9 +151,13 @@ and the app won't run against a different `ccp4i2`.
 - **macOS "app is damaged / can't be opened"** — you missed the `xattr -cr`
   step above (or ran it on the wrong path).
 - **Linux: double-click does nothing / only offers "Open With"** — the AppImage
-  isn't executable yet; `chmod +x` it (see the Linux step above). If a
-  terminal-launched build still exits silently on a hardened kernel, run it with
-  `--no-sandbox` (current builds pass this automatically).
+  isn't executable yet; `chmod +x` it (see the Linux step above).
+- **Linux: the AppImage crashes or shows a blank white window on a locked-down
+  kernel** (e.g. Ubuntu 24.04+, "The SUID sandbox helper binary … is not
+  configured correctly") — **install the `.deb` instead** (`sudo apt install
+  ./ccp4i2-django_*.deb`). The `.deb` gives Chromium a proper sandbox the way
+  Chrome/VS Code do; the AppImage can't, and is only a portable fallback. Do
+  **not** weaken the kernel with `sudo sysctl … unprivileged_userns=0`.
 - **Install step fails** — confirm the CCP4 install is complete and its
   `ccp4-python` runs (`<ccp4>/bin/ccp4-python --version`).
 


### PR DESCRIPTION
## Track 1 — immediate AppImage unblock

a15's conditional gate (read `/proc/sys/kernel/apparmor_restrict_unprivileged_userns`, disable sandbox only when `=1`) **did not work in the packaged AppImage**. Tester report with the restriction **active** (`=1`):

```
[FATAL:setuid_sandbox_host.cc(163)] The SUID sandbox helper binary was found,
but is not configured correctly. … Trace/breakpoint trap (core dumped)
```

That's the **SUID-sandbox crash**, which only appears when `--no-sandbox` is *not* in effect — so the detection returned false when it should have been true, and the switch never got applied. (a13's *unconditional* `--no-sandbox` clearly did apply — it reached the `/dev/shm` error instead.)

### Fix
Drop the unverifiable detection. On Linux, unconditionally:
- `--no-sandbox` — the AppImage `chrome-sandbox` can't be setuid-root, so the sandbox can't start on restricted kernels; this is the only zero-privilege path for the format.
- `--disable-dev-shm-usage` — route shared memory off `/dev/shm` (the no-sandbox path depends on it and it FATALs on some setups → blank window).

App-scoped only; other apps and the rest of the system keep their sandbox.

### Relationship to a15
Not a regression vs a15 — strictly clearer: a15 left restricted kernels SUID-crashing; this fixes them. Unrestricted kernels lose their app sandbox (the accepted AppImage tax), which Track 2 addresses properly.

### Track 2 (separate, follow-up)
Add a **`.deb`** target with setuid `chrome-sandbox` (± AppArmor profile) so the sandbox stays intact with no user action and no flags. No third-party approval needed for Linux packaging (unlike macOS notarization / Windows signing).

### ⚠️ Validation gate
Cannot be reproduced on macOS/CI. **Must be confirmed on a restricted-kernel box (`apparmor…=1`) before cutting the next alpha** — the AppImage artifact from this PR's build, tested by Paul with the restriction at its secure default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)