### PR TITLE
tooling: self-contained Ubuntu 24.04 Linux test VM

### DIFF
--- a/deploy/linux-test-vm/README.md
+++ b/deploy/linux-test-vm/README.md
@@ -1,0 +1,71 @@
+# CCP4i2 Linux test VM
+
+A self-contained, throwaway **Ubuntu 24.04** desktop VM in Azure for reproducing
+how the CCP4i2 Electron app behaves on a **modern, locked-down kernel** — i.e.
+one where `kernel.apparmor_restrict_unprivileged_userns=1` by default. That
+restriction is what breaks the AppImage's Chromium sandbox (the SUID-sandbox
+crash / blank window seen from a12+), and it does **not** exist on Ubuntu 22.04 —
+so a 22.04 rig reproduces nothing. This one does.
+
+It owns its **own resource group and VNet**, with no dependency on any shared or
+production network, so it can be created and deleted freely.
+
+## Prerequisites
+
+- `az` logged in to the usual subscription.
+- An SSH public key at `~/.ssh/id_ed25519.pub` (or set `SSH_PUBKEY_FILE`).
+- The [Microsoft Remote Desktop] client for the GUI (RDP).
+
+## Quick start
+
+```bash
+cd deploy/linux-test-vm
+
+# Create the RG + VM (prompts for an admin password; locks SSH/RDP to your IP)
+CCP4_VM_PASSWORD='Str0ng-Pass!' ./deploy-linux-test-vm.sh deploy
+
+# Wait for the desktop to finish installing, then install CCP4 + fetch artifacts
+./deploy-linux-test-vm.sh wait-ready
+./deploy-linux-test-vm.sh setup 'https://.../ccp4-XXXX-linux.tar.gz'
+
+# RDP in to click around; or drive it over SSH
+./deploy-linux-test-vm.sh rdp
+./deploy-linux-test-vm.sh ssh 'cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns'
+```
+
+## Day-to-day
+
+| Command | What it does |
+|---|---|
+| `deploy` | Create the RG + VM (idempotent-ish; re-running redeploys the template) |
+| `start` / `stop` | Boot / deallocate (stop billing) |
+| `allow-ip` | Re-point the firewall at your current IP (run after your IP changes) |
+| `wait-ready` | Poll until cloud-init has finished provisioning the desktop |
+| `ssh [cmd]` | SSH in, or run a one-off command on the VM |
+| `rdp` | Print the RDP connection details |
+| `setup <CCP4_URL>` | On the VM: install CCP4, test `pip install ccp4i2`, fetch AppImage + `.deb`, install the `.deb` |
+| `delete` | Delete the **entire** resource group |
+
+Auto-shutdown is 19:00 GMT to avoid surprise bills; `start` brings it back.
+
+## What to test
+
+On this kernel the `.deb` and the AppImage should diverge:
+
+- **`.deb`** — its `postinst` sets `chrome-sandbox` to `root:root` mode `4755`
+  and installs an AppArmor `userns` profile, so the Chromium sandbox starts
+  normally. **Expected: launches with a full sandbox, no flags.**
+- **AppImage** — can't ship a setuid `chrome-sandbox`, so it falls back to
+  `--no-sandbox` (+ `--disable-dev-shm-usage`). **Expected: the portable
+  fallback**, with the caveats documented in the app.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `linux-test-vm.bicep` | Self-contained infra: RG-local VNet/subnet, NSG, public IP, NIC, VM (Ubuntu 24.04), auto-shutdown |
+| `linux-test-vm.cloud-init.yaml` | xfce4 + xrdp desktop, Electron/AppImage runtime libs (handles the 24.04 `t64` renames), software GL |
+| `deploy-linux-test-vm.sh` | Lifecycle wrapper around `az` |
+| `setup-linux-test-vm.sh` | Runs **on** the VM: CCP4 + ccp4i2 install + artifact fetch/install |
+
+[Microsoft Remote Desktop]: https://apps.microsoft.com/detail/9wzdncrfj3ps

--- a/deploy/linux-test-vm/deploy-linux-test-vm.sh
+++ b/deploy/linux-test-vm/deploy-linux-test-vm.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Deploy or manage the CCP4i2 Ubuntu 24.04 Linux test VM.
+#
+# A self-contained, throwaway rig for reproducing the Electron app's behaviour on
+# a modern locked-down kernel (24.04 restricts unprivileged user namespaces by
+# default -- the thing that breaks the AppImage sandbox and that 22.04 can't
+# show). It owns its own resource group + VNet, so it has zero dependency on any
+# shared/production infrastructure and can be created and deleted freely.
+#
+# Usage:
+#   CCP4_VM_PASSWORD='...' ./deploy-linux-test-vm.sh deploy   # Create RG + VM
+#   ./deploy-linux-test-vm.sh start                            # Start (deallocated -> running)
+#   ./deploy-linux-test-vm.sh stop                             # Deallocate (stop billing)
+#   ./deploy-linux-test-vm.sh ip                               # Show public IP
+#   ./deploy-linux-test-vm.sh ssh [cmd...]                     # SSH in (or run a command)
+#   ./deploy-linux-test-vm.sh rdp                              # Show RDP details
+#   ./deploy-linux-test-vm.sh allow-ip                         # Re-point NSG at your current IP
+#   ./deploy-linux-test-vm.sh wait-ready                       # Poll until cloud-init has finished
+#   ./deploy-linux-test-vm.sh setup <CCP4_URL>                 # Install CCP4 + test ccp4i2 install
+#   ./deploy-linux-test-vm.sh delete                           # Delete the whole resource group
+#
+# Override any default with an env var (RESOURCE_GROUP, LOCATION, PREFIX,
+# ADMIN_USER, SSH_PUBKEY_FILE, VM_SIZE).
+
+set -e -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-ccp4i2-linux-test-rg}"
+LOCATION="${LOCATION:-uksouth}"
+PREFIX="${PREFIX:-ccp4i2-linux-test}"
+ADMIN_USER="${ADMIN_USER:-ccp4admin}"
+SSH_PUBKEY_FILE="${SSH_PUBKEY_FILE:-$HOME/.ssh/id_ed25519.pub}"
+VM_SIZE="${VM_SIZE:-Standard_D4s_v5}"
+VM_NAME="${PREFIX}-vm"
+NSG_NAME="${VM_NAME}-nsg"
+BICEP_FILE="$SCRIPT_DIR/linux-test-vm.bicep"
+
+detect_ip() {
+  local ip
+  ip=$(curl -4 -s --max-time 6 https://ifconfig.me 2>/dev/null || curl -s https://ifconfig.me)
+  if [[ "$ip" == *:* ]]; then echo "${ip}/128"; else echo "${ip}/32"; fi
+}
+
+public_ip() {
+  az vm show -d --name "$VM_NAME" -g "$RESOURCE_GROUP" --query publicIps -o tsv
+}
+
+case "${1:-}" in
+  deploy)
+    IP_CIDR="$(detect_ip)"
+    echo "Locking access to your current IP: $IP_CIDR"
+
+    if [[ -z "${CCP4_VM_PASSWORD:-}" ]]; then
+      echo "Enter a password for the VM admin account ($ADMIN_USER):"
+      echo "  (12+ chars: upper, lower, number, special) -- used for RDP + password SSH"
+      read -r -s CCP4_VM_PASSWORD
+      echo ""
+    fi
+
+    if [[ ! -f "$SSH_PUBKEY_FILE" ]]; then
+      echo "ERROR: SSH public key not found at $SSH_PUBKEY_FILE" >&2
+      echo "       Set SSH_PUBKEY_FILE=/path/to/key.pub or generate one with ssh-keygen." >&2
+      exit 1
+    fi
+    SSH_PUBKEY="$(cat "$SSH_PUBKEY_FILE")"
+
+    echo "Ensuring resource group $RESOURCE_GROUP ($LOCATION) exists..."
+    az group create --name "$RESOURCE_GROUP" --location "$LOCATION" -o none
+
+    echo "Deploying Linux test VM to $RESOURCE_GROUP..."
+    az deployment group create \
+      --resource-group "$RESOURCE_GROUP" \
+      --template-file "$BICEP_FILE" \
+      --parameters \
+        prefix="$PREFIX" \
+        vmSize="$VM_SIZE" \
+        adminPassword="$CCP4_VM_PASSWORD" \
+        adminSshPublicKey="$SSH_PUBKEY" \
+        allowedSourceIp="$IP_CIDR" \
+      --query "properties.outputs" \
+      --output table
+
+    PUBLIC_IP="$(public_ip)"
+    echo ""
+    echo "VM deployed at $PUBLIC_IP"
+    echo "  SSH: ssh $ADMIN_USER@$PUBLIC_IP"
+    echo "  RDP: Microsoft Remote Desktop -> $PUBLIC_IP (user $ADMIN_USER)"
+    echo ""
+    echo "cloud-init installs the desktop in the background (~3-5 min)."
+    echo "Poll with:  $0 wait-ready   then:  $0 setup <CCP4_BUILD_URL>"
+    echo "Auto-shutdown is 7pm GMT. Run '$0 stop' to deallocate manually."
+    ;;
+
+  start)
+    az vm start --name "$VM_NAME" --resource-group "$RESOURCE_GROUP"
+    echo "Started. Public IP: $(public_ip)"
+    echo "Reminder: run '$0 allow-ip' if your IP changed since last time."
+    ;;
+
+  stop)
+    az vm deallocate --name "$VM_NAME" --resource-group "$RESOURCE_GROUP"
+    echo "Deallocated. No compute charges while stopped."
+    ;;
+
+  ip)
+    public_ip
+    ;;
+
+  ssh)
+    shift
+    exec ssh -o StrictHostKeyChecking=accept-new "$ADMIN_USER@$(public_ip)" "$@"
+    ;;
+
+  rdp)
+    echo "RDP: Microsoft Remote Desktop -> $(public_ip) (user $ADMIN_USER)"
+    ;;
+
+  allow-ip)
+    IP_CIDR="$(detect_ip)"
+    echo "Re-pointing NSG rules AllowSSH + AllowRDP at $IP_CIDR ..."
+    az network nsg rule update -g "$RESOURCE_GROUP" --nsg-name "$NSG_NAME" \
+      -n AllowSSH --source-address-prefixes "$IP_CIDR" -o none
+    az network nsg rule update -g "$RESOURCE_GROUP" --nsg-name "$NSG_NAME" \
+      -n AllowRDP --source-address-prefixes "$IP_CIDR" -o none
+    echo "Done."
+    ;;
+
+  wait-ready)
+    IP="$(public_ip)"
+    echo "Polling $VM_NAME for the cloud-init breadcrumb (up to ~10 min)..."
+    for _ in $(seq 1 60); do
+      if ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8 \
+           "$ADMIN_USER@$IP" 'test -f /var/lib/ccp4i2-cloudinit-done' 2>/dev/null; then
+        echo "[OK] cloud-init finished; desktop is ready."
+        exit 0
+      fi
+      sleep 10
+    done
+    echo "[WARN] breadcrumb not seen yet -- cloud-init may still be running." >&2
+    exit 1
+    ;;
+
+  setup)
+    CCP4_URL="${2:-}"
+    if [[ -z "$CCP4_URL" ]]; then
+      echo "Usage: $0 setup <CCP4_BUILD_URL>" >&2
+      exit 2
+    fi
+    IP="$(public_ip)"
+    echo "Copying setup-linux-test-vm.sh to $VM_NAME ..."
+    scp -o StrictHostKeyChecking=accept-new \
+      "$SCRIPT_DIR/setup-linux-test-vm.sh" "$ADMIN_USER@$IP:/tmp/setup-linux-test-vm.sh"
+    echo "Running setup on the VM (CCP4 download + ccp4i2 install)..."
+    ssh -o StrictHostKeyChecking=accept-new "$ADMIN_USER@$IP" \
+      "bash /tmp/setup-linux-test-vm.sh '$CCP4_URL'"
+    ;;
+
+  delete)
+    echo "This deletes the ENTIRE resource group '$RESOURCE_GROUP' (VM, disk, VNet,"
+    echo "NIC, public IP, NSG -- everything). The rig owns its own RG, so this is clean."
+    read -r -p "Are you sure? (y/N) " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+      az group delete --name "$RESOURCE_GROUP" --yes
+      echo "Done."
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 {deploy|start|stop|ip|ssh|rdp|allow-ip|wait-ready|setup <url>|delete}"
+    exit 1
+    ;;
+esac

--- a/deploy/linux-test-vm/linux-test-vm.bicep
+++ b/deploy/linux-test-vm/linux-test-vm.bicep
@@ -166,7 +166,9 @@ resource vm 'Microsoft.Compute/virtualMachines@2023-07-01' = {
       imageReference: {
         publisher: 'Canonical'
         offer: 'ubuntu-24_04-lts'
-        sku: 'server-gen2'
+        // For the 24.04 offer, 'server' is the Gen2 image ('server-gen1' is Gen1);
+        // the old '<ver>-lts-gen2' convention doesn't apply here.
+        sku: 'server'
         version: 'latest'
       }
       osDisk: {

--- a/deploy/linux-test-vm/linux-test-vm.bicep
+++ b/deploy/linux-test-vm/linux-test-vm.bicep
@@ -1,0 +1,213 @@
+// Self-contained Ubuntu 24.04 desktop test VM for exercising the CCP4i2 Electron
+// app (AppImage + .deb) on a MODERN, locked-down kernel.
+//
+// Why 24.04: it ships kernel.apparmor_restrict_unprivileged_userns=1 by default
+// — the exact restriction that breaks the AppImage's Chromium sandbox and that
+// 22.04 simply does not have. A 22.04 rig green-lights everything and reproduces
+// nothing.
+//
+// Deliberately self-contained (own VNet/subnet, no shared/private network): this
+// is a throwaway rig, so the whole resource group can be created and deleted
+// freely without touching any other infrastructure.
+
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+@description('Resource naming prefix')
+param prefix string = 'ccp4i2-linux-test'
+
+@description('VM administrator username')
+param adminUsername string = 'ccp4admin'
+
+@description('VM administrator password (used for RDP/xrdp and password SSH)')
+@secure()
+param adminPassword string
+
+@description('SSH public key for key-based SSH login')
+param adminSshPublicKey string
+
+@description('VM size - D4s_v5 gives 4 vCPU, 16GB RAM')
+param vmSize string = 'Standard_D4s_v5'
+
+@description('Auto-shutdown time in GMT (HHMM, e.g. 1900 = 7pm) to avoid burning money')
+param autoShutdownTime string = '1900'
+
+@description('Your IP address (CIDR) for SSH + RDP access, e.g. 1.2.3.4/32')
+param allowedSourceIp string
+
+var vmName = '${prefix}-vm'
+var nicName = '${vmName}-nic'
+var publicIpName = '${vmName}-pip'
+var nsgName = '${vmName}-nsg'
+var osDiskName = '${vmName}-osdisk'
+var vnetName = '${prefix}-vnet'
+var subnetName = 'default'
+
+// SSH + RDP restricted to your IP
+resource nsg 'Microsoft.Network/networkSecurityGroups@2023-05-01' = {
+  name: nsgName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowSSH'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '22'
+          sourceAddressPrefix: allowedSourceIp
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 1000
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowRDP'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '3389'
+          sourceAddressPrefix: allowedSourceIp
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 1010
+          direction: 'Inbound'
+        }
+      }
+    ]
+  }
+}
+
+// Own VNet + subnet — no dependency on any shared network.
+resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+  name: vnetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [ '10.42.0.0/24' ]
+    }
+    subnets: [
+      {
+        name: subnetName
+        properties: {
+          addressPrefix: '10.42.0.0/24'
+          networkSecurityGroup: {
+            id: nsg.id
+          }
+        }
+      }
+    ]
+  }
+}
+
+resource publicIp 'Microsoft.Network/publicIPAddresses@2023-05-01' = {
+  name: publicIpName
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+}
+
+resource nic 'Microsoft.Network/networkInterfaces@2023-05-01' = {
+  name: nicName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          publicIPAddress: {
+            id: publicIp.id
+          }
+          subnet: {
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnetName, subnetName)
+          }
+        }
+      }
+    ]
+  }
+  dependsOn: [
+    vnet
+  ]
+}
+
+// Ubuntu 24.04 LTS (Noble) — the modern locked-down kernel we need to reproduce.
+resource vm 'Microsoft.Compute/virtualMachines@2023-07-01' = {
+  name: vmName
+  location: location
+  properties: {
+    hardwareProfile: {
+      vmSize: vmSize
+    }
+    osProfile: {
+      computerName: 'ccp4i2linux'
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+      // Password auth stays ON (xrdp login needs it); SSH key added too.
+      linuxConfiguration: {
+        disablePasswordAuthentication: false
+        ssh: {
+          publicKeys: [
+            {
+              path: '/home/${adminUsername}/.ssh/authorized_keys'
+              keyData: adminSshPublicKey
+            }
+          ]
+        }
+      }
+      customData: loadFileAsBase64('linux-test-vm.cloud-init.yaml')
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'Canonical'
+        offer: 'ubuntu-24_04-lts'
+        sku: 'server-gen2'
+        version: 'latest'
+      }
+      osDisk: {
+        name: osDiskName
+        createOption: 'FromImage'
+        managedDisk: {
+          storageAccountType: 'Premium_LRS'
+        }
+        // CCP4 extracted (~15GB) + tarball (~6GB) + headroom
+        diskSizeGB: 256
+      }
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: nic.id
+        }
+      ]
+    }
+  }
+}
+
+// Auto-shutdown to avoid burning money if left running.
+resource autoShutdown 'Microsoft.DevTestLab/schedules@2018-09-15' = {
+  name: 'shutdown-computevm-${vmName}'
+  location: location
+  properties: {
+    status: 'Enabled'
+    taskType: 'ComputeVmShutdownTask'
+    dailyRecurrence: {
+      time: autoShutdownTime
+    }
+    timeZoneId: 'GMT Standard Time'
+    targetResourceId: vm.id
+    notificationSettings: {
+      status: 'Disabled'
+    }
+  }
+}
+
+output vmName string = vm.name
+output publicIpAddress string = publicIp.properties.ipAddress
+output sshCommand string = 'ssh ${adminUsername}@${publicIp.properties.ipAddress}'
+output adminUsername string = adminUsername

--- a/deploy/linux-test-vm/linux-test-vm.cloud-init.yaml
+++ b/deploy/linux-test-vm/linux-test-vm.cloud-init.yaml
@@ -1,0 +1,61 @@
+#cloud-config
+# Provisions an Ubuntu 24.04 desktop good enough to (a) run the CCP4i2 Electron
+# AppImage / install the .deb over RDP and click the in-app "Install" button, and
+# (b) test the headless `ccp4-python -m pip install ccp4i2` path over SSH.
+#
+# 24.04 (not 22.04) on purpose: it ships
+# kernel.apparmor_restrict_unprivileged_userns=1 by default, the restriction that
+# breaks the AppImage sandbox on modern desktops. CCP4/ccp4i2 are NOT installed
+# here -- that's setup-linux-test-vm.sh (needs a CCP4 build URL).
+
+package_update: true
+package_upgrade: false
+
+packages:
+  # Lightweight desktop + RDP (connect with Microsoft Remote Desktop). xfce is
+  # deliberately minimal so software GL rendering copes.
+  - xfce4
+  - xfce4-goodies
+  - xrdp
+  - dbus-x11
+  - xorgxrdp
+  # AppImage runtime (needs FUSE)
+  - fuse
+  # Electron/Chromium deps NOT touched by the t64 rename (safe to list here)
+  - libnss3
+  - libgbm1
+  - libdrm2
+  - libxshmfence1
+  - libxdamage1
+  # Software OpenGL (llvmpipe) so Moorhen's WebGL2 canvas has a backend
+  - mesa-utils
+  - libgl1-mesa-dri
+  # Convenience
+  - git
+  - curl
+  - wget
+  - unzip
+  - jq
+
+runcmd:
+  # Electron/AppImage libs renamed by the 24.04 64-bit time_t transition
+  # (libfuse2 -> libfuse2t64, libasound2 -> libasound2t64, libgtk-3-0 ->
+  # libgtk-3-0t64). Install the t64 names, falling back to the old ones for
+  # portability; `|| true` so a rename can never abort cloud-init.
+  - [ bash, -lc, "apt-get install -y libfuse2t64 libasound2t64 libgtk-3-0t64 || apt-get install -y libfuse2 libasound2 libgtk-3-0 || true" ]
+  # xrdp session -> xfce for the ccp4admin user
+  - [ bash, -lc, "echo xfce4-session > /home/ccp4admin/.xsession" ]
+  - [ bash, -lc, "chown ccp4admin:ccp4admin /home/ccp4admin/.xsession" ]
+  # xrdp needs to read the TLS cert
+  - [ bash, -lc, "adduser xrdp ssl-cert" ]
+  - [ bash, -lc, "systemctl enable xrdp" ]
+  - [ bash, -lc, "systemctl restart xrdp" ]
+  # Make sure SSH password auth is on (belt-and-braces; RDP uses the password too)
+  - [ bash, -lc, "sed -i 's/^#\\?PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config" ]
+  - [ bash, -lc, "systemctl restart ssh || systemctl restart sshd || true" ]
+  # Software GL by default so remote sessions don't fall over on a missing GPU
+  - [ bash, -lc, "echo 'export LIBGL_ALWAYS_SOFTWARE=1' >> /home/ccp4admin/.profile" ]
+  # Drop a breadcrumb the deploy script can poll on to know cloud-init finished
+  - [ bash, -lc, "touch /var/lib/ccp4i2-cloudinit-done" ]
+
+final_message: "CCP4i2 Linux test VM (Ubuntu 24.04) ready after $UPTIME seconds"

--- a/deploy/linux-test-vm/linux-test-vm.cloud-init.yaml
+++ b/deploy/linux-test-vm/linux-test-vm.cloud-init.yaml
@@ -43,8 +43,11 @@ runcmd:
   # libgtk-3-0t64). Install the t64 names, falling back to the old ones for
   # portability; `|| true` so a rename can never abort cloud-init.
   - [ bash, -lc, "apt-get install -y libfuse2t64 libasound2t64 libgtk-3-0t64 || apt-get install -y libfuse2 libasound2 libgtk-3-0 || true" ]
-  # xrdp session -> xfce for the ccp4admin user
-  - [ bash, -lc, "echo xfce4-session > /home/ccp4admin/.xsession" ]
+  # xrdp session -> xfce for the ccp4admin user. Use startxfce4 (the full
+  # launcher that wires up D-Bus/session) rather than xfce4-session alone, which
+  # can fail on the first RDP connect with "no session managers, no window
+  # managers" if bits aren't ready yet.
+  - [ bash, -lc, "echo startxfce4 > /home/ccp4admin/.xsession" ]
   - [ bash, -lc, "chown ccp4admin:ccp4admin /home/ccp4admin/.xsession" ]
   # xrdp needs to read the TLS cert
   - [ bash, -lc, "adduser xrdp ssl-cert" ]

--- a/deploy/linux-test-vm/setup-linux-test-vm.sh
+++ b/deploy/linux-test-vm/setup-linux-test-vm.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Runs ON the Ubuntu 24.04 test VM. Installs a CCP4 build, exercises the exact
+# install mechanism the Electron app uses (pip-into-ccp4-python), and fetches
+# BOTH desktop artifacts (AppImage + .deb) so you can compare sandbox behaviour
+# on a locked-down kernel.
+#
+#   bash setup-linux-test-vm.sh <CCP4_BUILD_URL> [BRANCH]
+#
+# Deliberately does NOT abort on a failed pip install -- reproducing pip's
+# complaints on a fresh build is the point. Everything is logged to
+# ~/ccp4i2-setup.log so you can read the raw failure.
+
+CCP4_URL="${1:?Usage: setup-linux-test-vm.sh <CCP4_BUILD_URL> [BRANCH]}"
+BRANCH="${2:-django}"
+HOME_DIR="$HOME"
+CCP4_PARENT="$HOME_DIR/ccp4-test"
+LOG="$HOME_DIR/ccp4i2-setup.log"
+DESKTOP="$HOME_DIR/Desktop"
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== CCP4i2 Linux test VM setup  $(date -u) ==="
+echo "Kernel userns restriction (1 = locked down like modern Ubuntu):"
+cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null || echo "  (knob absent -- not a restricted kernel)"
+
+# --- 1. Download + extract CCP4 -------------------------------------------
+mkdir -p "$CCP4_PARENT"
+TARBALL="$CCP4_PARENT/$(basename "${CCP4_URL%%\?*}")"
+if [[ ! -f "$TARBALL" ]]; then
+  echo "--- Downloading CCP4 build ---"
+  echo "    $CCP4_URL"
+  wget --continue --show-progress -O "$TARBALL" "$CCP4_URL"
+else
+  echo "[OK] CCP4 tarball already present: $TARBALL"
+fi
+
+echo "--- Extracting (this takes a few minutes) ---"
+tar -xf "$TARBALL" -C "$CCP4_PARENT"
+
+# Find the CCP4 root (the dir containing bin/ccp4.setup-sh)
+CCP4_SETUP="$(find "$CCP4_PARENT" -maxdepth 3 -name ccp4.setup-sh -path '*/bin/*' 2>/dev/null | head -1)"
+if [[ -z "$CCP4_SETUP" ]]; then
+  echo "ERROR: could not find bin/ccp4.setup-sh under $CCP4_PARENT" >&2
+  echo "       Extracted contents:" >&2
+  ls -la "$CCP4_PARENT" >&2
+  exit 1
+fi
+CCP4_ROOT="$(cd "$(dirname "$CCP4_SETUP")/.." && pwd)"
+echo "[OK] CCP4 root: $CCP4_ROOT"
+
+# Some tarball builds ship a relocation fixup (BINARY.setup / install.sh).
+if [[ -x "$CCP4_ROOT/BINARY.setup" ]]; then
+  echo "--- Running BINARY.setup (path relocation) ---"
+  ( cd "$CCP4_ROOT" && ./BINARY.setup ) || echo "[WARN] BINARY.setup returned non-zero (may be fine)"
+fi
+
+# --- 2. Verify ccp4-python + gemmi ----------------------------------------
+echo "--- Sourcing CCP4 environment ---"
+# shellcheck disable=SC1090
+source "$CCP4_SETUP"
+
+echo "--- ccp4-python sanity ---"
+ccp4-python --version || echo "[WARN] ccp4-python --version failed"
+ccp4-python -c "import gemmi; print('gemmi', gemmi.__version__, 'OK')" \
+  || echo "[WARN] gemmi import failed"
+
+# --- 3. Exercise the install mechanism (the flaky bit) --------------------
+echo ""
+echo "=== ATTEMPTING: ccp4-python -m pip install ccp4i2 (verbose) ==="
+echo "    Any failure below is the thing we're here to diagnose."
+set -x
+ccp4-python -m pip install --upgrade pip 2>&1 | tail -5
+ccp4-python -m pip install --verbose ccp4i2
+PIP_RC=$?
+set +x
+echo "=== pip install ccp4i2 exit code: $PIP_RC ==="
+if [[ $PIP_RC -ne 0 ]]; then
+  echo "[EXPECTED-POSSIBLE] pip failed. Full transcript in $LOG."
+  echo "--- pip check (pre-existing breakage in this build) ---"
+  ccp4-python -m pip check || true
+fi
+
+# --- 4. Fetch BOTH desktop artifacts (AppImage + .deb) from CI ------------
+echo ""
+echo "--- Fetching CCP4i2 Linux artifacts from CI (if gh is available/authed) ---"
+mkdir -p "$DESKTOP"
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  gh run download --repo ccp4/ccp4i2 --name linux-appimages --dir "$DESKTOP" \
+    && chmod +x "$DESKTOP"/*.AppImage 2>/dev/null \
+    && echo "[OK] Artifacts in $DESKTOP:" && ls -1 "$DESKTOP"/*.AppImage "$DESKTOP"/*.deb 2>/dev/null \
+    || echo "[WARN] gh download failed -- grab the artifacts manually."
+else
+  echo "gh not installed/authed. Download the Linux artifacts manually from:"
+  echo "  https://github.com/ccp4/ccp4i2/actions/workflows/electron-multiplatform-build.yml"
+  echo "  (artifact: linux-appimages -- contains BOTH the .AppImage and the .deb)"
+fi
+
+# --- 4b. Install the .deb (the sandbox-correct path) ----------------------
+DEB="$(ls "$DESKTOP"/*.deb 2>/dev/null | head -1)"
+if [[ -n "$DEB" ]]; then
+  echo ""
+  echo "--- Installing the .deb (postinst setuids chrome-sandbox) ---"
+  echo "    sudo apt-get install -y '$DEB'"
+  sudo apt-get install -y "$DEB" || sudo dpkg -i "$DEB" || echo "[WARN] .deb install failed -- see above."
+  echo "chrome-sandbox perms (want '-rwsr-xr-x root root'):"
+  ls -l /opt/ccp4i2-django/chrome-sandbox 2>/dev/null || echo "  (chrome-sandbox not found at expected path)"
+fi
+
+# --- 5. Persist the CCP4 env for future logins ----------------------------
+if ! grep -q 'ccp4.setup-sh' "$HOME_DIR/.bashrc" 2>/dev/null; then
+  echo "source '$CCP4_SETUP'" >> "$HOME_DIR/.bashrc"
+  echo "[OK] Added CCP4 source line to ~/.bashrc"
+fi
+
+cat <<EOF
+
+=== Setup done ===
+CCP4 root:   $CCP4_ROOT
+Full log:    $LOG
+
+Compare sandbox behaviour on this locked-down kernel:
+  - .deb (should work WITH the sandbox, no flags):  ccp4i2-django
+    (launch from an RDP terminal; the app is installed under /opt/ccp4i2-django)
+  - AppImage (the format that struggles here):      $DESKTOP/*.AppImage
+
+Headless install path:
+  ccp4-python -m pip install ccp4i2
+
+EOF


### PR DESCRIPTION
## Why

The AppImage sandbox bugs (SUID crash / blank window) that shipped in a12–a15 were invisible to us because the materia Linux VM is **Ubuntu 22.04**, which has no `kernel.apparmor_restrict_unprivileged_userns` knob at all — it green-lights every sandbox path and reproduces nothing. Every "VM test passed" was a false negative.

This adds a **self-contained Ubuntu 24.04** rig, where that restriction is on by default, so it actually reproduces the failure and we can validate fixes ourselves instead of round-tripping through a tester in Chicago.

## What

Under `deploy/linux-test-vm/`:

- **`linux-test-vm.bicep`** — RG-local VNet/subnet, NSG (SSH/RDP locked to your IP), public IP, NIC, Ubuntu 24.04 VM (`Canonical:ubuntu-24_04-lts:server-gen2`), auto-shutdown. **Self-contained** (own VNet, no shared/private network) — materia's VM needed a toe in materia's private vnet; a ccp4i2 test box needs none.
- **`linux-test-vm.cloud-init.yaml`** — xfce4 + xrdp desktop, software GL, Electron/AppImage runtime libs. Handles the 24.04 **`t64` library renames** (`libfuse2`→`libfuse2t64`, etc.) that would break a naive copy of the 22.04 list.
- **`deploy-linux-test-vm.sh`** — `az` lifecycle: `deploy` (creates its own RG) / `start` / `stop` / `ssh` / `rdp` / `allow-ip` / `wait-ready` / `setup <CCP4_URL>` / `delete` (removes the whole RG).
- **`setup-linux-test-vm.sh`** — on the VM: install CCP4, test the pip path, fetch **both** artifacts, install the `.deb`, and check the `chrome-sandbox` setuid bit.
- **`README.md`**.

## Notes

- Own resource group under the usual subscription; nothing shared with prod infra.
- `bash -n` clean; `az bicep build` compiles.
- Pairs with the client-side Linux fix + `.deb` target in #261 — this is how we validate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)