### PR TITLE
fix: up-cycle Moorhen to 1.0.0-beta.1 and restore map drawing

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -44,7 +44,7 @@
         "jspdf": "^3.0.4",
         "jspdf-autotable": "^5.0.2",
         "jszip": "^3.10.1",
-        "moorhen": "file:moorhen-1.0.0-alpha.3-dev.g065becee.tgz",
+        "moorhen": "file:moorhen-1.0.0-beta.1-dev.g343d4287.tgz",
         "next": "^15.3.0",
         "pptxgenjs": "^4.0.1",
         "react": "^19.2.0",
@@ -95,7 +95,7 @@
     },
     "../packages/ccp4i2-api": {
       "name": "@ccp4/ccp4i2-api",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "LGPL-3.0-or-later",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -496,28 +496,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@base-ui/utils": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.6.tgz",
-      "integrity": "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@floating-ui/utils": "^0.2.11",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@ccp4/ccp4i2-api": {
@@ -1593,12 +1571,6 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -3262,249 +3234,11 @@
       "version": "0.3.0",
       "license": "MIT"
     },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@swc/react-compiler": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler/-/react-compiler-1.15.41.tgz",
-      "integrity": "sha512-LpvnhzRHyPAbrBtz7gRlMg5zdA8vV9c1ZuU5uk4oYqy4uld58kwoCdfx/9xbRpFRSkk5UgD9MxTCrh/wCAikJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.26"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/swc"
-      },
-      "optionalDependencies": {
-        "@swc/react-compiler-darwin-arm64": "1.15.41",
-        "@swc/react-compiler-darwin-x64": "1.15.41",
-        "@swc/react-compiler-linux-arm-gnueabihf": "1.15.41",
-        "@swc/react-compiler-linux-arm64-gnu": "1.15.41",
-        "@swc/react-compiler-linux-arm64-musl": "1.15.41",
-        "@swc/react-compiler-linux-ppc64-gnu": "1.15.41",
-        "@swc/react-compiler-linux-s390x-gnu": "1.15.41",
-        "@swc/react-compiler-linux-x64-gnu": "1.15.41",
-        "@swc/react-compiler-linux-x64-musl": "1.15.41",
-        "@swc/react-compiler-win32-arm64-msvc": "1.15.41",
-        "@swc/react-compiler-win32-ia32-msvc": "1.15.41",
-        "@swc/react-compiler-win32-x64-msvc": "1.15.41"
-      }
-    },
-    "node_modules/@swc/react-compiler-darwin-arm64": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-darwin-arm64/-/react-compiler-darwin-arm64-1.15.41.tgz",
-      "integrity": "sha512-aEeeDYYQFyUJqRKsvjIJB1MD2Olh4qvZOtxio1NPFY8jXoRe+bDOjwhkAvWBb1zC/7YcCZ0UCGxK7YFPOzULGA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-darwin-x64": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-darwin-x64/-/react-compiler-darwin-x64-1.15.41.tgz",
-      "integrity": "sha512-iYyqmHhkAa4nEGcbPdCU0D39EFigbKShltqqiR+suGeLwQZy6hQLS7WNZx34pKlM8ky21xzHXct8gfKJlPwKAw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-linux-arm-gnueabihf": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-linux-arm-gnueabihf/-/react-compiler-linux-arm-gnueabihf-1.15.41.tgz",
-      "integrity": "sha512-JRyD5pp7QTeGmxCuiOxMr5hk3leFdUL/6qP4qUK/dxD4QUVv19PkU6DKvOoFm5lrc0O7kjRvmtWlup+kCqAcuw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@swc/react-compiler-linux-arm64-gnu": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-linux-arm64-gnu/-/react-compiler-linux-arm64-gnu-1.15.41.tgz",
-      "integrity": "sha512-X66V+3YDDW/t7KNRMxtMy75OhzDqnF24Vr+4lm4EaSVcJ7M0wt+tQHvliotKaa0Ab7mSFKj7Qckw/HEpujccJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-linux-arm64-musl": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-linux-arm64-musl/-/react-compiler-linux-arm64-musl-1.15.41.tgz",
-      "integrity": "sha512-osoALGcmt6J1xiZ+6DC1d2umFvH4rDWj3jyefw1wv7O/vMHpe8rdKBeOEaCUziIc1ZoE+PeC/1qvRlbamwGWgg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-linux-ppc64-gnu": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-linux-ppc64-gnu/-/react-compiler-linux-ppc64-gnu-1.15.41.tgz",
-      "integrity": "sha512-sqlREcGVXNr/svlqeiuRkJuXzZMX2nGf67KCbTQ32x5kc5rd+H3D4yDW6+N86o34Z44FF0y84YFfxMt0zk/omw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-linux-s390x-gnu": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-linux-s390x-gnu/-/react-compiler-linux-s390x-gnu-1.15.41.tgz",
-      "integrity": "sha512-jC6IGdkpKCutovLADsV/voA0SBgIoWNIHzEGtFF+C9K2LUxetzD5LDR2M5hVqZLakhCXFOf95nrEvcI+5Lo4Jw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-linux-x64-gnu": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-linux-x64-gnu/-/react-compiler-linux-x64-gnu-1.15.41.tgz",
-      "integrity": "sha512-kVDWVDwWsx4HMD878nNTbT3sJH7utyRWgpdcjixJoojQjm+T4N9RfuF1xxSTfYrOlzKvtGTucetBcNAtSRlRig==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-linux-x64-musl": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-linux-x64-musl/-/react-compiler-linux-x64-musl-1.15.41.tgz",
-      "integrity": "sha512-e9VDC616cHNTH7Y4lmZSfAD5R7c9MpPEy5PN3L4sk2oFmNtJsleqxlrMknYqHbJzQRlx1WwONaehCsMsUvgZdg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-win32-arm64-msvc": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-win32-arm64-msvc/-/react-compiler-win32-arm64-msvc-1.15.41.tgz",
-      "integrity": "sha512-Yr43WD4O4RDoKMXFi7w3H4DozEw7/DtK4eGzrujN1dwgK79DgUUIG12mmliBFC1WnyfCRLQFqfknk/5BXBsAwQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-win32-ia32-msvc": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-win32-ia32-msvc/-/react-compiler-win32-ia32-msvc-1.15.41.tgz",
-      "integrity": "sha512-Jz+3S247lK0dI25VkI2pvbN7r3i6j9GuXlsBBGprGORHDrr3tvwyZduXsJijChhr3ra7ZcLfq+VB77tqq/MHzw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/react-compiler-win32-x64-msvc": {
-      "version": "1.15.41",
-      "resolved": "https://registry.npmjs.org/@swc/react-compiler-win32-x64-msvc/-/react-compiler-win32-x64-msvc-1.15.41.tgz",
-      "integrity": "sha512-P/uaCSq56Qi1tKSeajeGd1SgxzLE8seRzoLndf9A7k3cwnWy+yV86MY7GiaydDw8dan3Y0QUWmeLNrQVtwYkFA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/types": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
-      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -8374,20 +8108,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/iris-validation": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/iris-validation/-/iris-validation-0.1.10.tgz",
-      "integrity": "sha512-USA90D99N2idjjd9gmfYBsCKDWTW1hnjGURvSrCEOm3DHXGTxMf9yyG67er02ItM9MCRgK8IYtRYS4t2/OfrgA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
-    "node_modules/iris-validation-backend": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/iris-validation-backend/-/iris-validation-backend-0.0.8.tgz",
-      "integrity": "sha512-oU61b8lx/ob58qB67I9SWOiI4jeUcuwAe71VOxjE+nBQoHND9k7VyqrgtKXGOpNwHpCX25/4OfGT9AuRadJ6cw=="
-    },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
@@ -9501,22 +9221,16 @@
       }
     },
     "node_modules/moorhen": {
-      "version": "1.0.0-alpha.3-dev.g065becee",
-      "resolved": "file:moorhen-1.0.0-alpha.3-dev.g065becee.tgz",
-      "integrity": "sha512-3EVB1YAoK7dryAL4xaF6C3utZRZm80Y7c/0Mo4TM7LbkeQByPUk/tElwdKM3BBdSny6IGCeP6PinF+gS28Oc4g==",
+      "version": "1.0.0-beta.1-dev.g343d4287",
+      "resolved": "file:moorhen-1.0.0-beta.1-dev.g343d4287.tgz",
+      "integrity": "sha512-hhk7j+tHS2+I64KYthEY6ydyLJvCdnH5iuvFsE604Lf06D5edlmyMkAIuT0nbQC2ej6XOPRAj4Xi1dyXNxV3Tw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@apollo/client": "^3.13.8",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@emotion/react": "^11.14.0",
-        "@emotion/styled": "^11.14.1",
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mui/icons-material": "^7.3.4",
-        "@mui/material": "^7.3.4",
-        "@mui/x-tree-view": "^8.14.0",
-        "@swc/react-compiler": "^1.15.32",
         "biojs-io-fasta": "^0.1.17",
         "chart.js": "^4.5.0",
         "chartjs-plugin-annotation": "^3.1.0",
@@ -9525,11 +9239,10 @@
         "gl-matrix": "^3.4.4",
         "graphql": "^16.11.0",
         "html-react-parser": "^5.2.6",
-        "iris-validation": "^0.1.10",
-        "iris-validation-backend": "^0.0.8",
         "jszip": "^3.10.1",
         "localforage": "^1.10.0",
         "notistack": "^3.0.2",
+        "npm": "^11.15.0",
         "pako": "^2.1.0",
         "prismjs": "^1.30.0",
         "protobufjs": "^7.5.4",
@@ -9544,300 +9257,6 @@
         "webpack-merge": "^6.0.1",
         "y-websocket": "^3.0.0",
         "yjs": "^13.6.27"
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.9.tgz",
-      "integrity": "sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/icons-material": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.9.tgz",
-      "integrity": "sha512-BT+zPJXss8Hg/oEMRmHl17Q97bPACG4ufFSfGEdhiE96jOyR5Dz1ty7ZWt1fVGR0y1p+sSgEwQT/MNZQmoWDCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@mui/material": "^7.3.9",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/material": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
-      "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/core-downloads-tracker": "^7.3.9",
-        "@mui/system": "^7.3.9",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.2.3",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.9",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/private-theming": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.9.tgz",
-      "integrity": "sha512-ErIyRQvsiQEq7Yvcvfw9UDHngaqjMy9P3JDPnRAaKG5qhpl2C4tX/W1S4zJvpu+feihmZJStjIyvnv6KDbIrlw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.9",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/styled-engine": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.9.tgz",
-      "integrity": "sha512-JqujWt5bX4okjUPGpVof/7pvgClqh7HvIbsIBIOOlCh2u3wG/Bwp4+E1bc1dXSwkrkp9WUAoNdI5HEC+5HKvMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/system": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.9.tgz",
-      "integrity": "sha512-aL1q9am8XpRrSabv9qWf5RHhJICJql34wnrc1nz0MuOglPRYF/liN+c8VqZdTvUn9qg+ZjRVbKf4sJVFfIDtmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.9",
-        "@mui/styled-engine": "^7.3.9",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.9",
-        "clsx": "^2.1.1",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/types": {
-      "version": "7.4.12",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
-      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/utils": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.9.tgz",
-      "integrity": "sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/types": "^7.4.12",
-        "@types/prop-types": "^15.7.15",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.2.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/x-internals": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.26.0.tgz",
-      "integrity": "sha512-B9OZau5IQUvIxwpJZhoFJKqRpmWf5r0yMmSXjQuqb5WuqM755EuzWJOenY48denGoENzMLT8hQpA0hRTeU2IPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/moorhen/node_modules/@mui/x-tree-view": {
-      "version": "8.27.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-8.27.2.tgz",
-      "integrity": "sha512-gceKjUEqKHBVt5BV0Yscx2NKgbI9z6IgEx3BHToeAupNCIZ7kAlnZUtk+FyIIcN+Vr6CFz5J0zxjnPgfHjbj2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui/utils": "^0.2.3",
-        "@mui/utils": "^7.3.5",
-        "@mui/x-internals": "8.26.0",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
       }
     },
     "node_modules/moorhen/node_modules/uuid": {
@@ -10166,7 +9585,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.7.0",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -10184,7 +9605,6 @@
         "cacache",
         "chalk",
         "ci-info",
-        "cli-columns",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -10235,7 +9655,6 @@
         "validate-npm-package-name",
         "which"
       ],
-      "dev": true,
       "license": "Artistic-2.0",
       "workspaces": [
         "docs",
@@ -10246,71 +9665,70 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.9",
-        "@npmcli/config": "^10.4.5",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
-        "@npmcli/package-json": "^7.0.4",
+        "@npmcli/package-json": "^7.0.5",
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.3",
-        "@sigstore/tuf": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
-        "cli-columns": "^4.0.0",
+        "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^13.0.0",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
-        "init-package-json": "^8.2.4",
-        "is-cidr": "^6.0.1",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.12",
-        "libnpmexec": "^10.1.11",
-        "libnpmfund": "^7.0.12",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.12",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.11",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.3",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.1",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
+        "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.1.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.0.4",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.3",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
-        "ssri": "^13.0.0",
+        "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.2",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^7.0.0",
-        "which": "^6.0.0"
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -10320,25 +9738,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
+    "node_modules/npm/node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -10360,7 +9766,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10376,11 +9782,12 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.9",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -10394,7 +9801,7 @@
         "@npmcli/run-script": "^10.0.0",
         "bin-links": "^6.0.0",
         "cacache": "^20.0.1",
-        "common-ancestor-path": "^1.0.1",
+        "common-ancestor-path": "^2.0.0",
         "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
         "lru-cache": "^11.2.1",
@@ -10423,7 +9830,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.4.5",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10454,17 +9861,17 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "ini": "^6.0.0",
         "lru-cache": "^11.2.1",
         "npm-pick-manifest": "^11.0.1",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
         "which": "^6.0.0"
       },
@@ -10538,7 +9945,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "7.0.4",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10549,7 +9956,7 @@
         "json-parse-even-better-errors": "^5.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10589,7 +9996,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "10.0.3",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10598,8 +10005,7 @@
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "node-gyp": "^12.1.0",
-        "proc-log": "^6.0.0",
-        "which": "^6.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10618,7 +10024,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.0.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10627,7 +10033,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10636,52 +10042,43 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.0.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0",
-        "tuf-js": "^4.0.0"
+        "tuf-js": "^4.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.0.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -10698,31 +10095,16 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
+        "minimatch": "^10.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
@@ -10743,15 +10125,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.1.0",
       "dev": true,
@@ -10765,13 +10138,16 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10799,16 +10175,19 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.3",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10822,8 +10201,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10851,7 +10229,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "dev": true,
       "funding": [
         {
@@ -10866,28 +10244,12 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.1",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "5.0.0"
-      },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
@@ -10900,10 +10262,13 @@
       }
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
@@ -10935,28 +10300,12 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.2",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
@@ -10967,12 +10316,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -11002,17 +10345,17 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "13.0.0",
+      "version": "13.0.6",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -11025,7 +10368,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11069,7 +10412,7 @@
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11079,6 +10422,10 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
@@ -11093,15 +10440,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/npm/node_modules/ini": {
       "version": "6.0.0",
       "dev": true,
@@ -11112,7 +10450,7 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "8.2.4",
+      "version": "8.2.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11122,7 +10460,6 @@
         "promzard": "^3.0.1",
         "read": "^5.0.1",
         "semver": "^7.7.2",
-        "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
@@ -11130,7 +10467,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.0.1",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11138,46 +10475,25 @@
         "node": ">= 12"
       }
     },
-    "node_modules/npm/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.1",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/isexe": {
-      "version": "3.1.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
@@ -11233,12 +10549,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.12",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -11252,19 +10568,19 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.11",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "read": "^5.0.1",
         "semver": "^7.3.7",
         "signal-exit": "^4.1.0",
@@ -11275,12 +10591,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.12",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11300,12 +10616,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.12",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -11315,7 +10631,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11359,7 +10675,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11375,21 +10691,23 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.2",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.3",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -11398,7 +10716,6 @@
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "ssri": "^13.0.0"
       },
       "engines": {
@@ -11406,25 +10723,25 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.1.1",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -11442,44 +10759,32 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "5.0.0",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "iconv-lite": "^0.7.2"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
@@ -11506,25 +10811,19 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "ISC"
     },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
@@ -11567,7 +10866,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.1.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11575,12 +10874,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.5.2",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -11663,7 +10962,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "10.0.3",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11691,13 +10990,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11744,11 +11043,12 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.0.4",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/git": "^7.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -11762,7 +11062,6 @@
         "npm-pick-manifest": "^11.0.1",
         "npm-registry-fetch": "^19.0.0",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "sigstore": "^4.0.0",
         "ssri": "^13.0.0",
         "tar": "^7.4.3"
@@ -11789,7 +11088,7 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -11798,14 +11097,14 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11853,19 +11152,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -11907,15 +11193,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
@@ -11924,7 +11201,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11948,17 +11225,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.0.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "@sigstore/verify": "^3.0.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11975,12 +11252,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -12002,26 +11279,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "dev": true,
@@ -12039,13 +11296,13 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.22",
+      "version": "3.0.23",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12054,32 +11311,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/supports-color": {
@@ -12095,7 +11326,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.2",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -12106,15 +11337,6 @@
         "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -12132,13 +11354,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12165,7 +11387,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12186,41 +11408,26 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "4.0.0",
-        "debug": "^4.4.1",
-        "make-fetch-happen": "^15.0.0"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -12229,28 +11436,8 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12268,12 +11455,12 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "6.0.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
@@ -12283,12 +11470,11 @@
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -12296,10 +11482,13 @@
       }
     },
     "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.24",

--- a/client/package.json
+++ b/client/package.json
@@ -74,7 +74,7 @@
     "jspdf": "^3.0.4",
     "jspdf-autotable": "^5.0.2",
     "jszip": "^3.10.1",
-    "moorhen": "file:moorhen-1.0.0-alpha.3-dev.g065becee.tgz",
+    "moorhen": "file:moorhen-1.0.0-beta.1-dev.g343d4287.tgz",
     "next": "^15.3.0",
     "pptxgenjs": "^4.0.1",
     "react": "^19.2.0",

--- a/client/renderer/components/moorhen/campaign-control-panel.tsx
+++ b/client/renderer/components/moorhen/campaign-control-panel.tsx
@@ -235,7 +235,9 @@ export const CampaignControlPanel: React.FC<CampaignControlPanelProps> = ({
         // Add new representations
         for (const rep of added) {
           try {
-            await mol.addRepresentation(rep, "/*/*/*/*");
+            // `added` are ToggleButton representation keys typed loosely as
+            // string[] through MUI onChange; narrow to the Moorhen union.
+            await mol.addRepresentation(rep as moorhen.RepresentationStyles, "/*/*/*/*");
           } catch (err) {
             console.error(`Failed to add ${rep} for molecule ${mol.name}:`, err);
           }

--- a/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/campaign-moorhen-wrapper.tsx
@@ -69,7 +69,7 @@ import {
   SceneResolveResult,
 } from "../../lib/moorhen-scene-resolver";
 import { parseScene, serialiseScene } from "../../lib/scene";
-import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp, makeMoorhenMapInstance } from "../../lib/moorhen-map-file";
 import type { MoorhenScene, SceneFileRef } from "../../types/moorhen-scene";
 import { CampaignMoorhenTabbedPanel } from "./campaign-moorhen-tabbed-panel";
 import type { SceneBundleAssets } from "./moorhen-scenes-panel";
@@ -130,7 +130,9 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
       for (const mol of currentMolecules) {
         for (const rep of toAdd) {
           try {
-            await mol.addRepresentation(rep, "/*/*/*/*");
+            // reps arrive as string[] from URL-restore state; they are the
+            // ToggleButton representation vocabulary, so narrow to the union.
+            await mol.addRepresentation(rep as moorhen.RepresentationStyles, "/*/*/*/*");
           } catch (err) {
             console.error(`Failed to add ${rep} to ${mol.name}:`, err);
           }
@@ -457,23 +459,22 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
         }
       }
       try {
-        const newMap = new MoorhenMap(
-          commandCentre as RefObject<moorhen.CommandCentre>,
-          store as any,
-        );
+        const mapInstance = makeMoorhenMapInstance(commandCentre, store);
+        let newMap: moorhen.Map;
         if (ref.kind === "map") {
           // mode-0 -> float (sane stats); masks also dodge coot's EM cell-clamp.
           const mapBytes = ccp4Mode0ToFloat(bytes as ArrayBuffer);
-          await newMap.loadToCootFromMapData(
+          newMap = await MoorhenMap.loadToCootFromMapData(
             new Uint8Array(sceneMap.isMask ? ccp4DodgeEmClamp(mapBytes) : mapBytes),
             sceneMap.name,
             !!sceneMap.isDifference,
+            mapInstance,
           );
           (newMap as any).isCcp4MapFile = true;
           if (sceneMap.isMask) markMaskMap(newMap);
         } else {
           const cols = sceneMap.columns ?? {};
-          await newMap.loadToCootFromMtzData(
+          newMap = await MoorhenMap.loadToCootFromMtzData(
             new Uint8Array(bytes as ArrayBuffer),
             sceneMap.name,
             {
@@ -486,6 +487,7 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
               calcStructFact: !!cols.calcStructFact,
               isDifference: !!sceneMap.isDifference,
             } as moorhen.selectedMtzColumns,
+            mapInstance,
           );
         }
         if (newMap.molNo === -1) return null;
@@ -749,21 +751,22 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     mapSubType: number = 1
   ) => {
     if (!commandCentre.current) return;
-    const newMap = new MoorhenMap(
-      commandCentre as RefObject<moorhen.CommandCentre>,
-      store as any
-    );
     // subType: 1=normal, 2=difference, 3=anomalous difference
     // Both difference and anomalous maps use isDifference=true for contouring
     const isDiffMap = mapSubType === 2 || mapSubType === 3;
     try {
       const mtzData = await apiArrayBuffer(url);
-      await newMap.loadToCootFromMtzData(new Uint8Array(mtzData), mapName, {
-        F: "F",
-        PHI: "PHI",
-        useWeight: false,
-        isDifference: isDiffMap,
-      });
+      const newMap = await MoorhenMap.loadToCootFromMtzData(
+        new Uint8Array(mtzData),
+        mapName,
+        {
+          F: "F",
+          PHI: "PHI",
+          useWeight: false,
+          isDifference: isDiffMap,
+        } as moorhen.selectedMtzColumns,
+        makeMoorhenMapInstance(commandCentre, store),
+      );
       newMap.uniqueId = url;
       // Store the original sub_type for proper labeling and coloring
       (newMap as any).mapSubType = mapSubType;
@@ -807,17 +810,19 @@ const CampaignMoorhenWrapper: React.FC<CampaignMoorhenWrapperProps> = ({
     opts: { isMask?: boolean } = {}
   ) => {
     if (!commandCentre.current) return;
-    const newMap = new MoorhenMap(
-      commandCentre as RefObject<moorhen.CommandCentre>,
-      store as any
-    );
+    let newMap: moorhen.Map | undefined;
     try {
       // Convert mode-0 (int8) CCP4 maps to float so Moorhen reads sane stats
       // (no-op if already float). For masks, also nudge the P1/orthogonal cell
       // off 90° so coot contours periodically instead of clamping to the cell box.
       let mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
       if (opts.isMask) mapData = ccp4DodgeEmClamp(mapData);
-      await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
+      newMap = await MoorhenMap.loadToCootFromMapData(
+        new Uint8Array(mapData),
+        mapName,
+        false,
+        makeMoorhenMapInstance(commandCentre, store),
+      );
       if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
       newMap.uniqueId = url;
       // Tag so the lifter captures it as a kind: "map" ref (not MTZ).

--- a/client/renderer/components/moorhen/moorhen-control-panel.tsx
+++ b/client/renderer/components/moorhen/moorhen-control-panel.tsx
@@ -118,7 +118,7 @@ export const MoorhenControlPanel: React.FC<MoorhenControlPanelProps> = ({
   }, [molecules]);
 
   const toggleRep = useCallback(
-    async (mol: moorhen.Molecule, repKey: string) => {
+    async (mol: moorhen.Molecule, repKey: moorhen.RepresentationStyles) => {
       if (mol.molNo == null) return;
       const current = molReps.get(mol.molNo) || new Set<string>();
       const isActive = current.has(repKey);

--- a/client/renderer/components/moorhen/moorhen-wrapper.tsx
+++ b/client/renderer/components/moorhen/moorhen-wrapper.tsx
@@ -55,7 +55,7 @@ import {
   fetchPdbContents,
 } from "../../lib/moorhen-scene-prompt";
 import { useSceneNlCapability, generateScene } from "./use-scene-nl-capability";
-import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp } from "../../lib/moorhen-map-file";
+import { applyMaskDefaults, isMaskSubType, markMaskMap, ccp4Mode0ToFloat, ccp4DodgeEmClamp, makeMoorhenMapInstance, primeXtalMapContourStats } from "../../lib/moorhen-map-file";
 import {
   liftSceneStraight,
   MapRenderState,
@@ -367,19 +367,22 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     mapSubType: number = 1
   ) => {
     if (!commandCentre.current) return;
-    const newMap = new MoorhenMap(
-      commandCentre as RefObject<moorhen.CommandCentre>,
-      store as any
-    );
+    let loadedMap: moorhen.Map | undefined;
     const isDiffMap = mapSubType === 2 || mapSubType === 3;
     try {
       const mtzData = await apiArrayBuffer(url);
-      await newMap.loadToCootFromMtzData(new Uint8Array(mtzData), mapName, {
-        F: "F",
-        PHI: "PHI",
-        useWeight: false,
-        isDifference: isDiffMap,
-      });
+      const newMap = await MoorhenMap.loadToCootFromMtzData(
+        new Uint8Array(mtzData),
+        mapName,
+        {
+          F: "F",
+          PHI: "PHI",
+          useWeight: false,
+          isDifference: isDiffMap,
+        } as moorhen.selectedMtzColumns,
+        makeMoorhenMapInstance(commandCentre, store),
+      );
+      loadedMap = newMap;
       newMap.uniqueId = url;
       (newMap as any).mapSubType = mapSubType;
       if (mapSubType === 3) {
@@ -411,7 +414,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
       console.warn(err);
       console.warn(`Cannot fetch map from ${url}`);
     }
-    return newMap;
+    return loadedMap;
   }, [commandCentre, store, dispatch]);
 
   // Load a real-space CCP4 map file (application/CCP4-map), e.g. a mask. Unlike
@@ -423,17 +426,19 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
     opts: { isMask?: boolean } = {},
   ) => {
     if (!commandCentre.current) return;
-    const newMap = new MoorhenMap(
-      commandCentre as RefObject<moorhen.CommandCentre>,
-      store as any
-    );
+    let newMap: moorhen.Map | undefined;
     try {
       // Convert mode-0 (int8) CCP4 maps to float so Moorhen reads sane stats
       // (no-op if already float). For masks, also nudge the P1/orthogonal cell
       // off 90° so coot contours periodically instead of clamping to the cell box.
       let mapData = ccp4Mode0ToFloat(await apiArrayBuffer(url));
       if (opts.isMask) mapData = ccp4DodgeEmClamp(mapData);
-      await newMap.loadToCootFromMapData(new Uint8Array(mapData), mapName, false);
+      newMap = await MoorhenMap.loadToCootFromMapData(
+        new Uint8Array(mapData),
+        mapName,
+        false,
+        makeMoorhenMapInstance(commandCentre, store),
+      );
       if (newMap.molNo === -1) throw new Error("Cannot read the fetched map file...");
       newMap.uniqueId = url;
       // Tag so the lifter captures it as a kind: "map" ref (not MTZ).
@@ -957,24 +962,23 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         }
       }
       try {
-        const newMap = new MoorhenMap(
-          commandCentre as RefObject<moorhen.CommandCentre>,
-          store as any,
-        );
+        const mapInstance = makeMoorhenMapInstance(commandCentre, store);
+        let newMap: moorhen.Map;
         if (ref.kind === "map") {
           // Real-space CCP4 map file (incl. masks): load directly, no columns.
           // mode-0 -> float (sane stats); masks also dodge coot's EM cell-clamp.
           const mapBytes = ccp4Mode0ToFloat(bytes as ArrayBuffer);
-          await newMap.loadToCootFromMapData(
+          newMap = await MoorhenMap.loadToCootFromMapData(
             new Uint8Array(sceneMap.isMask ? ccp4DodgeEmClamp(mapBytes) : mapBytes),
             sceneMap.name,
             !!sceneMap.isDifference,
+            mapInstance,
           );
           (newMap as any).isCcp4MapFile = true;
           if (sceneMap.isMask) markMaskMap(newMap);
         } else {
           const cols = sceneMap.columns ?? {};
-          await newMap.loadToCootFromMtzData(
+          newMap = await MoorhenMap.loadToCootFromMtzData(
             new Uint8Array(bytes as ArrayBuffer),
             sceneMap.name,
             {
@@ -987,6 +991,7 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
               calcStructFact: !!cols.calcStructFact,
               isDifference: !!sceneMap.isDifference,
             } as moorhen.selectedMtzColumns,
+            mapInstance,
           );
         }
         if (newMap.molNo === -1) return null;
@@ -1028,16 +1033,15 @@ const MoorhenWrapper: React.FC<MoorhenWrapperProps> = ({ fileIds, viewParam, job
         )) as moorhen.WorkerResponse<number>;
         const newMolNo = result?.data?.result?.result;
         if (newMolNo == null || newMolNo === -1) return null;
-        const newMap = new MoorhenMap(
-          commandCentre as RefObject<moorhen.CommandCentre>,
-          store as any,
-        );
+        const newMap = new MoorhenMap(makeMoorhenMapInstance(commandCentre, store));
         newMap.molNo = newMolNo;
         newMap.name = name;
         // Inherit the difference-map flag from the source; a mask of a
         // difference map is still a difference map.
         newMap.isDifference = !!(sourceMap as any).isDifference;
-        await newMap.getSuggestedSettings();
+        // beta.1 replaced getSuggestedSettings(); populate rmsd/suggested level
+        // directly (masked map has no fileHeader, so full initialise() can't run).
+        await primeXtalMapContourStats(newMap);
         // Provenance stamp: a masked map's recipe is unrecoverable from its
         // grid bytes (Moorhen persists only the bytes). Stamp the uniqueId so
         // the capturer can round-trip maps WE masked as maskMaps recipes.

--- a/client/renderer/lib/moorhen-map-file.ts
+++ b/client/renderer/lib/moorhen-map-file.ts
@@ -21,6 +21,46 @@ import {
 /** File.sub_type marking a CCP4-map file as a mask (CMapDataFile.SUBTYPE_MASK). */
 export const MASK_SUBTYPE = 4;
 
+/**
+ * Moorhen beta.1 reworked MoorhenMap: the constructor and the (now static)
+ * loadToCootFrom* factory methods take a single MoorhenInstance instead of the
+ * old `(commandCentreRef, store)` pair, and `this.commandCentre` is now the
+ * CommandCentre object itself (not a ref). On the load / contour / suggested-
+ * settings paths the class only reads `.commandCentre` and `.store` off the
+ * instance, so a minimal shim over the wrapper's existing ref + store is enough
+ * — no full InstanceManager wiring required. Use this at every MoorhenMap load
+ * site so maps actually reach coot again.
+ */
+export function makeMoorhenMapInstance(
+  commandCentreRef: { current: unknown } | null | undefined,
+  store: unknown,
+): any {
+  return { commandCentre: commandCentreRef?.current ?? null, store };
+}
+
+/**
+ * Populate the contour-relevant stats (mapRmsd, suggestedContourLevel) on a
+ * freshly MTZ-loaded MoorhenMap.
+ *
+ * Moorhen beta.1's static MoorhenMap.loadToCootFromMtzData — unlike
+ * loadToCootFromMapData — does NOT run map.initialise(), so mapRmsd stays null.
+ * MoorhenMapManager then contours xtal maps at `1 * mapRmsd === 0` (difference
+ * maps at `3 * mapRmsd === 0`), i.e. the whole cell fills with noise-level
+ * density. We can't just call initialise() here because it needs an MTZ
+ * fileHeader the static loader never attaches; but these two coot calls need
+ * only the map's molNo, so they safely reproduce the stats the manager reads.
+ * Best-effort: swallow errors so a stats hiccup never blocks the map drawing.
+ */
+export async function primeXtalMapContourStats(map: any): Promise<void> {
+  if (!map) return;
+  try {
+    await map.fetchMapRmsd?.();
+    await map.fetchSuggestedLevelXtal?.();
+  } catch (err) {
+    console.warn("Failed to prime map contour stats:", err);
+  }
+}
+
 // --------------------------------------------------------------------------
 // CCP4 map mode-0 -> float conversion
 //


### PR DESCRIPTION
## Summary

Up-cycles the Moorhen dependency **1.0.0-alpha.3 → 1.0.0-beta.1** (`dev.g343d4287`) and adapts to its reworked `MoorhenMap` API, which had silently broken map loading and contouring in the job/scene viewers.

### What broke in beta.1
- `MoorhenMap` constructor now takes a single `MoorhenInstance` (was `commandCentreRef` + `store`); `loadToCootFromMtzData` / `loadToCootFromMapData` are now **static** factory methods taking the instance as their last arg. The old instance-method calls threw and were swallowed by `try/catch`, so **maps never loaded**.
- The static MTZ loader (unlike the map-file one) didn't run `initialise()`, so `mapRmsd`/`suggestedContourLevel` stayed null and `MoorhenMapManager` contoured xtal maps at **0** (whole cell filled with noise). *Fixed upstream in the beta.1 tarball.*
- `addRepresentation`'s style arg is now the `RepresentationStyles` literal union rather than a plain `string`.

### Changes here
- Add `makeMoorhenMapInstance()` shim (`{ commandCentre, store }`) and route all five `MoorhenMap` load sites through the new static factories.
- Narrow representation keys to `moorhen.RepresentationStyles` at the three `addRepresentation` call sites (param-tighten where sourced from an `as const` list; boundary-assert where they arrive as `string[]` from MUI `onChange` / URL-restore state).
- Keep one `primeXtalMapContourStats()` call on the by-hand masked-map path (`handleMaskSceneMap`), which has no loader to run `initialise()`. The transient priming workaround has been removed from the loader paths now that the fix is upstream.

### Verification
- `npx tsc --noEmit -p renderer/tsconfig.json` → **0 errors**.
- Installed bundle confirmed to carry the upstream contour fix; `renderer/public/MoorhenAssets/**` refreshed via `copy-assets`.
- Manually confirmed in the desktop app: maps load and contour at sensible sigma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)