### PR TITLE
Move projects on disk, and repair paths left behind by earlier moves

### DIFF
--- a/client/main/ccp4i2-ipc.ts
+++ b/client/main/ccp4i2-ipc.ts
@@ -271,15 +271,30 @@ export const installIpcHandlers = (
     "browse-path",
     async (
       _event,
-      opts: { mode?: "directory" | "file"; title?: string } = {}
+      opts: {
+        mode?: "directory" | "file";
+        title?: string;
+        message?: string;
+        buttonLabel?: string;
+      } = {}
     ): Promise<string | null> => {
       const mainWindow: BrowserWindow | null = getMainWindow();
       if (!mainWindow) return null;
-      const properties: Array<"openDirectory" | "openFile"> =
-        opts.mode === "file" ? ["openFile"] : ["openDirectory"];
+      // "createDirectory" gives the macOS panel its New Folder button; without
+      // it the user can only pick somewhere that already exists.
+      const properties: Array<
+        "openDirectory" | "openFile" | "createDirectory"
+      > =
+        opts.mode === "file"
+          ? ["openFile"]
+          : ["openDirectory", "createDirectory"];
       const result = await dialog.showOpenDialog(mainWindow, {
         properties,
         title: opts.title,
+        // macOS ignores `title` on an open panel, so anything the user needs to
+        // read has to go in `message`.
+        message: opts.message ?? opts.title,
+        buttonLabel: opts.buttonLabel,
       });
       if (result.canceled || result.filePaths.length === 0) return null;
       return result.filePaths[0];

--- a/client/renderer/components/move-project-dialog.tsx
+++ b/client/renderer/components/move-project-dialog.tsx
@@ -1,0 +1,501 @@
+"use client";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { DriveFileMove, FolderOpen } from "@mui/icons-material";
+import { useApi } from "../api";
+import { Project } from "../types/models";
+
+/** One file the rebase would rewrite. */
+interface Rewrite {
+  path: string;
+  occurrences: number;
+}
+
+/** Server summary of a planned or completed move / repair. */
+interface MoveSummary {
+  source: string;
+  destination: string;
+  rewrites: Rewrite[];
+  total_occurrences: number;
+  caches_to_delete: string[];
+  rewritten?: number;
+  cross_device?: boolean;
+  same_filesystem?: boolean;
+  stale_roots?: Record<string, number>;
+  skipped?: {
+    binary: number;
+    provenance: number;
+    too_large: string[];
+  };
+}
+
+/** Open the native directory picker; returns null in the web build. */
+async function browseDirectory(message: string): Promise<string | null> {
+  const api = typeof window !== "undefined" ? window.electronAPI : undefined;
+  if (!api?.invoke) return null;
+  try {
+    return (
+      (await api.invoke("browse-path", {
+        mode: "directory",
+        title: message,
+        message,
+        buttonLabel: "Use this folder",
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function canBrowse(): boolean {
+  return typeof window !== "undefined" && Boolean(window.electronAPI?.invoke);
+}
+
+/** Join a parent directory and a folder name using the parent's separator. */
+function joinPath(parent: string, name: string): string {
+  const separator = parent.includes("\\") && !parent.includes("/") ? "\\" : "/";
+  return `${parent.replace(/[\\/]+$/, "")}${separator}${name}`;
+}
+
+/** Last path component, whichever separator the platform uses. */
+function baseName(path: string): string {
+  const parts = path.replace(/[\\/]+$/, "").split(/[\\/]/);
+  return parts[parts.length - 1] ?? path;
+}
+
+/** Everything but the last path component. */
+function dirName(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return index > 0 ? trimmed.slice(0, index) : "";
+}
+
+interface MoveProjectDialogProps {
+  project: Project | null;
+  open: boolean;
+  onClose: () => void;
+  /** Called after a successful move or repair so the caller can refresh. */
+  onMoved?: () => void;
+}
+
+/**
+ * Move a project to a new directory, or repair paths left behind by an earlier
+ * move.
+ *
+ * The dialog always runs a dry run first: the user sees exactly which files
+ * would be rewritten before anything is touched.
+ */
+export function MoveProjectDialog({
+  project,
+  open,
+  onClose,
+  onMoved,
+}: MoveProjectDialogProps) {
+  const api = useApi();
+
+  // Kept as two fields rather than one path so there is no ambiguity about
+  // whether the project's own folder name is included: the user picks the
+  // folder to move *into*, and names the folder that will be created in it.
+  const [parentDir, setParentDir] = useState("");
+  const [folderName, setFolderName] = useState("");
+  const [plan, setPlan] = useState<MoveSummary | null>(null);
+  const [result, setResult] = useState<MoveSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [planning, setPlanning] = useState(false);
+  const [moving, setMoving] = useState(false);
+  const [repairingRoot, setRepairingRoot] = useState<string | null>(null);
+  /** Set from the last move/repair result; otherwise the fetched value wins. */
+  const [staleRootsOverride, setStaleRootsOverride] = useState<Record<
+    string,
+    number
+  > | null>(null);
+
+  // The projects list uses a lightweight serializer that omits `directory`, so
+  // fetch the full record to learn where the project actually lives.
+  const { data: detail } = api.get<Project>(
+    open && project ? `projects/${project.id}/` : null
+  );
+  const currentDirectory = detail?.directory ?? project?.directory ?? "";
+
+  const destination =
+    parentDir && folderName ? joinPath(parentDir, folderName) : "";
+  const unchanged = Boolean(destination) && destination === currentDirectory;
+
+  // Scanning a project for leftover roots costs a full tree walk, so only ask
+  // for it while the dialog is actually open.
+  const { data: staleRootsResponse, mutate: refreshStaleRoots } = api.get<any>(
+    open && project ? `projects/${project.id}/stale_roots/` : null
+  );
+
+  const staleRoots: Record<string, number> =
+    staleRootsOverride ??
+    (staleRootsResponse?.data ?? staleRootsResponse)?.stale_roots ??
+    {};
+
+  // Reset whenever the dialog is opened for a (possibly different) project.
+  useEffect(() => {
+    if (!open) return;
+    // Seed from where the project is now: a move usually keeps the folder name
+    // and changes the parent, so only one field needs touching.
+    setParentDir(dirName(currentDirectory));
+    setFolderName(baseName(currentDirectory));
+    setPlan(null);
+    setResult(null);
+    setError(null);
+    setStaleRootsOverride(null);
+  }, [open, project?.id, currentDirectory]);
+
+  const handleBrowse = useCallback(async () => {
+    if (!project) return;
+    const parent = await browseDirectory(
+      `Choose the folder to move "${project.name}" into. ` +
+        "A new folder for the project will be created inside it."
+    );
+    if (!parent) return;
+    setParentDir(parent);
+    setPlan(null);
+    setResult(null);
+    setError(null);
+  }, [project]);
+
+  const runDryRun = useCallback(async () => {
+    if (!project || !destination) return;
+    setPlanning(true);
+    setError(null);
+    setPlan(null);
+    try {
+      const response: any = await api.post(`projects/${project.id}/move/`, {
+        directory: destination,
+        dry_run: true,
+      });
+      if (response?.success === false) {
+        setError(response?.error ?? "Could not plan the move");
+        return;
+      }
+      setPlan(response?.data ?? response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPlanning(false);
+    }
+  }, [project, destination]);
+
+  // Run the preview automatically once the destination stops changing. Gating
+  // the Move button on a manual Preview click just made it look broken, and the
+  // dry run is read-only, so there is no reason to make the user ask for it.
+  useEffect(() => {
+    if (!open || !destination || unchanged || result || moving) return;
+    const timer = setTimeout(() => {
+      void runDryRun();
+    }, 700);
+    return () => clearTimeout(timer);
+  }, [open, destination, unchanged, result, moving, runDryRun]);
+
+  const runMove = useCallback(async () => {
+    if (!project || !destination) return;
+    setMoving(true);
+    setError(null);
+    try {
+      const response: any = await api.post(`projects/${project.id}/move/`, {
+        directory: destination,
+      });
+      if (response?.success === false) {
+        setError(response?.error ?? "Could not move the project");
+        return;
+      }
+      const summary: MoveSummary = response?.data ?? response;
+      setResult(summary);
+      setPlan(null);
+      setStaleRootsOverride(summary.stale_roots ?? {});
+      refreshStaleRoots();
+      onMoved?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMoving(false);
+    }
+  }, [project, destination, onMoved, refreshStaleRoots]);
+
+  const repairRoot = useCallback(
+    async (oldRoot: string) => {
+      if (!project) return;
+      setRepairingRoot(oldRoot);
+      setError(null);
+      try {
+        const response: any = await api.post(
+          `projects/${project.id}/repair_paths/`,
+          { old_directory: oldRoot }
+        );
+        if (response?.success === false) {
+          setError(response?.error ?? "Could not repair paths");
+          return;
+        }
+        const summary: MoveSummary = response?.data ?? response;
+        setResult(summary);
+        setStaleRootsOverride(summary.stale_roots ?? {});
+        refreshStaleRoots();
+        onMoved?.();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setRepairingRoot(null);
+      }
+    },
+    [project, onMoved, refreshStaleRoots]
+  );
+
+  const busy = planning || moving || repairingRoot !== null;
+  const staleRootEntries = useMemo(
+    () => Object.entries(staleRoots),
+    [staleRoots]
+  );
+
+  if (!project) return null;
+
+  return (
+    <Dialog open={open} onClose={busy ? undefined : onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <DriveFileMove color="primary" />
+          <span>Move &quot;{project.name}&quot;</span>
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Currently at
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{ fontFamily: "monospace", wordBreak: "break-all", mb: 2 }}
+        >
+          {currentDirectory}
+        </Typography>
+
+        <Stack direction="row" spacing={1} alignItems="flex-start">
+          <TextField
+            fullWidth
+            size="small"
+            label="Move into this folder"
+            helperText="An existing folder. The project gets its own new folder inside it."
+            value={parentDir}
+            disabled={busy}
+            onChange={(event) => {
+              setParentDir(event.target.value);
+              setPlan(null);
+              setResult(null);
+            }}
+          />
+          {canBrowse() && (
+            <Button
+              variant="outlined"
+              startIcon={<FolderOpen />}
+              onClick={handleBrowse}
+              disabled={busy}
+              sx={{ whiteSpace: "nowrap", mt: 0.25 }}
+            >
+              Browse
+            </Button>
+          )}
+        </Stack>
+
+        <TextField
+          fullWidth
+          size="small"
+          label="Project folder name"
+          helperText="Created for you - it must not already exist."
+          value={folderName}
+          disabled={busy}
+          onChange={(event) => {
+            setFolderName(event.target.value);
+            setPlan(null);
+            setResult(null);
+          }}
+          sx={{ mt: 2 }}
+        />
+
+        {destination && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              The project will end up at
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ fontFamily: "monospace", wordBreak: "break-all" }}
+            >
+              {destination}
+            </Typography>
+            {unchanged && (
+              <Typography variant="body2" color="warning.main" sx={{ mt: 1 }}>
+                That is where the project already is.
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {planning && <LinearProgress sx={{ mt: 2 }} />}
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {plan && (
+          <Box sx={{ mt: 2 }}>
+            <Alert severity="info">
+              <AlertTitle>
+                {plan.rewrites.length} file
+                {plan.rewrites.length === 1 ? "" : "s"} will be updated
+              </AlertTitle>
+              <Typography variant="body2">
+                {plan.total_occurrences} path reference
+                {plan.total_occurrences === 1 ? "" : "s"} will be rewritten, and{" "}
+                {plan.caches_to_delete.length} cached report
+                {plan.caches_to_delete.length === 1 ? "" : "s"} deleted (these
+                regenerate on demand).
+              </Typography>
+              {plan.same_filesystem === false && (
+                <Typography variant="body2" sx={{ mt: 1 }}>
+                  The destination is on a different filesystem, so the project
+                  will be copied and then the original removed. This needs
+                  enough free space for a second copy, and will take longer
+                  than a move within one disk.
+                </Typography>
+              )}
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                Logs and command scripts are left untouched: they record what
+                actually ran.
+              </Typography>
+            </Alert>
+
+            <List dense sx={{ maxHeight: 220, overflow: "auto", mt: 1 }}>
+              {plan.rewrites.map((rewrite) => (
+                <ListItem key={rewrite.path} disableGutters>
+                  <ListItemText
+                    primaryTypographyProps={{
+                      variant: "body2",
+                      sx: { fontFamily: "monospace", wordBreak: "break-all" },
+                    }}
+                    primary={rewrite.path}
+                    secondary={`${rewrite.occurrences} reference${
+                      rewrite.occurrences === 1 ? "" : "s"
+                    }`}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        )}
+
+        {result && (
+          <Alert severity="success" sx={{ mt: 2 }}>
+            <AlertTitle>Done</AlertTitle>
+            <Typography variant="body2">
+              {result.rewritten ?? 0} file
+              {(result.rewritten ?? 0) === 1 ? "" : "s"} updated. The project is
+              now at{" "}
+              <Box component="span" sx={{ fontFamily: "monospace" }}>
+                {result.destination}
+              </Box>
+              .
+            </Typography>
+          </Alert>
+        )}
+
+        {staleRootEntries.length > 0 && (
+          <>
+            <Divider sx={{ my: 2 }} />
+            <Alert severity="warning">
+              <AlertTitle>This project also refers to other locations</AlertTitle>
+              <Typography variant="body2" gutterBottom>
+                Paths from an earlier move, an import from another machine, or a
+                drive that has since been renamed. Rewrite them to point at the
+                project&apos;s current directory:
+              </Typography>
+              <Stack spacing={1} sx={{ mt: 1 }}>
+                {staleRootEntries.map(([root, count]) => (
+                  <Stack
+                    key={root}
+                    direction="row"
+                    spacing={1}
+                    alignItems="center"
+                    flexWrap="wrap"
+                  >
+                    <Box
+                      component="span"
+                      sx={{
+                        fontFamily: "monospace",
+                        fontSize: "0.8rem",
+                        wordBreak: "break-all",
+                        flexGrow: 1,
+                      }}
+                    >
+                      {root}
+                    </Box>
+                    <Chip size="small" label={`${count} refs`} />
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={busy}
+                      onClick={() => repairRoot(root)}
+                      startIcon={
+                        repairingRoot === root ? (
+                          <CircularProgress size={14} />
+                        ) : undefined
+                      }
+                    >
+                      Repair
+                    </Button>
+                  </Stack>
+                ))}
+              </Stack>
+            </Alert>
+          </>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>
+          {result ? "Close" : "Cancel"}
+        </Button>
+        {/* The preview runs itself; this is for retrying after a bad path. */}
+        <Button
+          onClick={runDryRun}
+          disabled={busy || !destination || unchanged || Boolean(result)}
+        >
+          Re-check
+        </Button>
+        <Button
+          variant="contained"
+          onClick={runMove}
+          disabled={busy || !destination || unchanged || Boolean(result)}
+          startIcon={moving ? <CircularProgress size={16} /> : <DriveFileMove />}
+        >
+          Move project
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default MoveProjectDialog;

--- a/client/renderer/components/projects-table.tsx
+++ b/client/renderer/components/projects-table.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useMemo, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import {
@@ -21,6 +21,7 @@ import {
   Clear,
   Delete,
   Download,
+  DriveFileMove,
   FolderOpen,
   Schedule,
   Science,
@@ -40,6 +41,8 @@ import { DataTable, Column } from "./data-table";
 import { VirtualizedCardGrid } from "./virtualized-card-grid";
 import { ProjectTagChips } from "./project-tag-chips";
 import { ViewMode, ViewModeToggle } from "./view-mode-toggle";
+import { MoveProjectDialog } from "./move-project-dialog";
+import { isElectron } from "../utils/platform";
 
 // Type for campaign info returned from API
 interface CampaignInfo {
@@ -89,6 +92,7 @@ const ProjectCard = React.memo(
     onToggleSelection,
     onNavigate,
     onExport,
+    onMove,
     onDelete,
   }: {
     project: Project;
@@ -96,6 +100,8 @@ const ProjectCard = React.memo(
     onToggleSelection: () => void;
     onNavigate: () => void;
     onExport: () => void;
+    /** Omitted in the web build, where there is no local filesystem to move to. */
+    onMove?: () => void;
     onDelete: () => void;
   }) => {
     const isRecent =
@@ -219,6 +225,24 @@ const ProjectCard = React.memo(
                 <Download fontSize="small" />
               </IconButton>
             </Tooltip>
+            {onMove && (
+              <Tooltip title="Move project on disk">
+                <IconButton
+                  className="action-button"
+                  size="small"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onMove();
+                  }}
+                  sx={{
+                    color: "primary.main",
+                    "&:hover": { bgcolor: "primary.50" },
+                  }}
+                >
+                  <DriveFileMove fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
             <Tooltip title="Delete project">
               <IconButton
                 className="action-button"
@@ -268,6 +292,14 @@ export default function ProjectsTable() {
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const deleteDialog = useDeleteDialog();
   const { setMessage } = usePopcorn();
+  const [projectToMove, setProjectToMove] = useState<Project | null>(null);
+  // Moving a project means moving a directory on the machine running the
+  // server, with a native folder picker to choose where. Neither exists in the
+  // browser build, so the action is desktop-only. Resolved in an effect rather
+  // than inline so the server-rendered markup and the first client render
+  // agree.
+  const [canMoveProjects, setCanMoveProjects] = useState(false);
+  useEffect(() => setCanMoveProjects(isElectron()), []);
 
   // Get campaign info for all projects
   const projectIds = useMemo(
@@ -572,7 +604,7 @@ export default function ProjectsTable() {
       {
         key: "actions",
         label: "",
-        width: 100,
+        width: canMoveProjects ? 140 : 100,
         render: (_, project) => (
           <Stack
             direction="row"
@@ -589,6 +621,17 @@ export default function ProjectsTable() {
                 <Download fontSize="small" />
               </IconButton>
             </Tooltip>
+            {canMoveProjects && (
+              <Tooltip title="Move project on disk">
+                <IconButton
+                  size="small"
+                  onClick={() => setProjectToMove(project)}
+                  sx={{ color: "primary.main" }}
+                >
+                  <DriveFileMove fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
             <Tooltip title="Delete project">
               <IconButton
                 size="small"
@@ -602,7 +645,7 @@ export default function ProjectsTable() {
         ),
       },
     ],
-    [selectedIds, campaignInfo, router]
+    [selectedIds, campaignInfo, router, canMoveProjects]
   );
 
   // Card renderer for virtualized grid
@@ -618,10 +661,13 @@ export default function ProjectsTable() {
         }}
         onNavigate={() => router.push(`/ccp4i2/project/${project.id}`)}
         onExport={() => exportProject(project)}
+        onMove={
+          canMoveProjects ? () => setProjectToMove(project) : undefined
+        }
         onDelete={() => deleteProjects([project])}
       />
     ),
-    [selectedIds, router]
+    [selectedIds, router, canMoveProjects]
   );
 
   if (projects === undefined) return <LinearProgress />;
@@ -803,6 +849,15 @@ export default function ProjectsTable() {
               Try adjusting your search term
             </Typography>
           </Box>
+        )}
+
+        {canMoveProjects && (
+          <MoveProjectDialog
+            project={projectToMove}
+            open={Boolean(projectToMove)}
+            onClose={() => setProjectToMove(null)}
+            onMoved={() => mutate()}
+          />
         )}
       </Box>
     </Box>

--- a/client/renderer/components/projects-table.tsx
+++ b/client/renderer/components/projects-table.tsx
@@ -3,7 +3,10 @@ import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import {
+  Alert,
+  AlertTitle,
   Box,
+  Button,
   Card,
   CardContent,
   Checkbox,
@@ -23,6 +26,7 @@ import {
   Download,
   DriveFileMove,
   FolderOpen,
+  LinkOff,
   Schedule,
   Science,
   StarBorder,
@@ -42,6 +46,7 @@ import { VirtualizedCardGrid } from "./virtualized-card-grid";
 import { ProjectTagChips } from "./project-tag-chips";
 import { ViewMode, ViewModeToggle } from "./view-mode-toggle";
 import { MoveProjectDialog } from "./move-project-dialog";
+import { ReconnectProjectsDialog } from "./reconnect-projects-dialog";
 import { isElectron } from "../utils/platform";
 
 // Type for campaign info returned from API
@@ -301,6 +306,22 @@ export default function ProjectsTable() {
   const [canMoveProjects, setCanMoveProjects] = useState(false);
   useEffect(() => setCanMoveProjects(isElectron()), []);
 
+  const [reconnectOpen, setReconnectOpen] = useState(false);
+  // Projects whose recorded directory is no longer on disk - a renamed drive,
+  // a projects folder moved outside CCP4i2. Desktop only: on the web the
+  // directories live on the server and the user cannot go and find them.
+  const { data: missingResponse, mutate: refreshMissing } = api.get<any>(
+    canMoveProjects ? "projects/missing_directories/" : null
+  );
+  const brokenProjects = useMemo(
+    () => (missingResponse?.data ?? missingResponse)?.projects ?? [],
+    [missingResponse]
+  );
+  const brokenIds = useMemo(
+    () => new Set<number>(brokenProjects.map((p: any) => p.id)),
+    [brokenProjects]
+  );
+
   // Get campaign info for all projects
   const projectIds = useMemo(
     () => (projects || []).map((p) => p.id),
@@ -522,9 +543,16 @@ export default function ProjectsTable() {
                 )}
               </Box>
               <Box sx={{ minWidth: 0 }}>
-                <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
-                  {project.name}
-                </Typography>
+                <Stack direction="row" spacing={0.5} alignItems="center">
+                  <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
+                    {project.name}
+                  </Typography>
+                  {brokenIds.has(project.id) && (
+                    <Tooltip title="This project's folder cannot be found on disk">
+                      <LinkOff sx={{ fontSize: 16, color: "warning.main" }} />
+                    </Tooltip>
+                  )}
+                </Stack>
                 <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
                   {new Date(project.last_access).getTime() >
                     Date.now() - 7 * 24 * 60 * 60 * 1000 && (
@@ -621,7 +649,7 @@ export default function ProjectsTable() {
                 <Download fontSize="small" />
               </IconButton>
             </Tooltip>
-            {canMoveProjects && (
+            {canMoveProjects && !brokenIds.has(project.id) && (
               <Tooltip title="Move project on disk">
                 <IconButton
                   size="small"
@@ -645,7 +673,7 @@ export default function ProjectsTable() {
         ),
       },
     ],
-    [selectedIds, campaignInfo, router, canMoveProjects]
+    [selectedIds, campaignInfo, router, canMoveProjects, brokenIds]
   );
 
   // Card renderer for virtualized grid
@@ -662,12 +690,14 @@ export default function ProjectsTable() {
         onNavigate={() => router.push(`/ccp4i2/project/${project.id}`)}
         onExport={() => exportProject(project)}
         onMove={
-          canMoveProjects ? () => setProjectToMove(project) : undefined
+          canMoveProjects && !brokenIds.has(project.id)
+            ? () => setProjectToMove(project)
+            : undefined
         }
         onDelete={() => deleteProjects([project])}
       />
     ),
-    [selectedIds, router, canMoveProjects]
+    [selectedIds, router, canMoveProjects, brokenIds]
   );
 
   if (projects === undefined) return <LinearProgress />;
@@ -693,6 +723,30 @@ export default function ProjectsTable() {
         overflow: "hidden",
       }}
     >
+      {brokenProjects.length > 0 && (
+        <Alert
+          severity="warning"
+          icon={<LinkOff />}
+          sx={{ mb: 2, flexShrink: 0 }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => setReconnectOpen(true)}
+            >
+              Reconnect
+            </Button>
+          }
+        >
+          <AlertTitle>
+            {brokenProjects.length} project
+            {brokenProjects.length === 1 ? "" : "s"} cannot be found on disk
+          </AlertTitle>
+          If a drive was renamed or the projects folder moved, say where they
+          are now and they will be reconnected. Nothing is moved or deleted.
+        </Alert>
+      )}
+
       {/* Header with search, view toggle, and selection actions */}
       <Box sx={{ mb: 2, flexShrink: 0 }}>
         {selectedIds.size === 0 ? (
@@ -852,12 +906,26 @@ export default function ProjectsTable() {
         )}
 
         {canMoveProjects && (
-          <MoveProjectDialog
-            project={projectToMove}
-            open={Boolean(projectToMove)}
-            onClose={() => setProjectToMove(null)}
-            onMoved={() => mutate()}
-          />
+          <>
+            <MoveProjectDialog
+              project={projectToMove}
+              open={Boolean(projectToMove)}
+              onClose={() => setProjectToMove(null)}
+              onMoved={() => {
+                mutate();
+                refreshMissing();
+              }}
+            />
+            <ReconnectProjectsDialog
+              open={reconnectOpen}
+              onClose={() => setReconnectOpen(false)}
+              brokenProjects={brokenProjects}
+              onReconnected={() => {
+                mutate();
+                refreshMissing();
+              }}
+            />
+          </>
         )}
       </Box>
     </Box>

--- a/client/renderer/components/reconnect-projects-dialog.tsx
+++ b/client/renderer/components/reconnect-projects-dialog.tsx
@@ -1,0 +1,473 @@
+"use client";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { CheckCircle, FolderOpen, LinkOff } from "@mui/icons-material";
+import { useApi } from "../api";
+
+interface BrokenProject {
+  id: number;
+  uuid: string;
+  name: string;
+  directory: string;
+}
+
+interface MappedProject {
+  id: number;
+  name: string;
+  old_directory: string;
+  new_directory: string;
+  reason?: string;
+  rewritten?: number;
+  error?: string;
+}
+
+interface RootRebaseSummary {
+  old_root: string;
+  new_root: string;
+  matched: MappedProject[];
+  missing: MappedProject[];
+  unaffected: { id: number; name: string }[];
+  relocated?: MappedProject[];
+  failed?: MappedProject[];
+  preference_updated?: boolean;
+}
+
+/** Open the native directory picker; returns null in the web build. */
+async function browseDirectory(message: string): Promise<string | null> {
+  const api = typeof window !== "undefined" ? window.electronAPI : undefined;
+  if (!api?.invoke) return null;
+  try {
+    return (
+      (await api.invoke("browse-path", {
+        mode: "directory",
+        title: message,
+        message,
+        buttonLabel: "Use this folder",
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function canBrowse(): boolean {
+  return typeof window !== "undefined" && Boolean(window.electronAPI?.invoke);
+}
+
+/** Everything but the last path component. */
+function dirName(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return index > 0 ? trimmed.slice(0, index) : "";
+}
+
+/**
+ * The deepest folder all these paths share.
+ *
+ * When a drive is renamed every project moves together, so their common parent
+ * is almost always the root that changed — which saves the user working out
+ * what to type.
+ */
+function commonParent(paths: string[]): string {
+  if (paths.length === 0) return "";
+  const split = (p: string) => dirName(p).split(/[\\/]/);
+  let prefix = split(paths[0]);
+  for (const path of paths.slice(1)) {
+    const parts = split(path);
+    let i = 0;
+    while (i < prefix.length && i < parts.length && prefix[i] === parts[i]) i++;
+    prefix = prefix.slice(0, i);
+  }
+  const joined = prefix.join("/");
+  return joined === "" && paths[0].startsWith("/") ? "/" : joined;
+}
+
+interface ReconnectProjectsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  brokenProjects: BrokenProject[];
+  /** Called after anything changes so the caller can refresh. */
+  onReconnected?: () => void;
+}
+
+/**
+ * Reconnect projects whose recorded directory is no longer on disk.
+ *
+ * A renamed drive or a projects folder moved outside CCP4i2 invalidates every
+ * project at once, so this works on the storage root rather than project by
+ * project: say where the projects used to be and where they are now, and each
+ * one is re-pointed and its internal paths rebased. Nothing is moved.
+ */
+export function ReconnectProjectsDialog({
+  open,
+  onClose,
+  brokenProjects,
+  onReconnected,
+}: ReconnectProjectsDialogProps) {
+  const api = useApi();
+
+  const [oldRoot, setOldRoot] = useState("");
+  const [newRoot, setNewRoot] = useState("");
+  const [plan, setPlan] = useState<RootRebaseSummary | null>(null);
+  const [result, setResult] = useState<RootRebaseSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [planning, setPlanning] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [locating, setLocating] = useState<number | null>(null);
+
+  const suggestedOldRoot = useMemo(
+    () => commonParent(brokenProjects.map((p) => p.directory)),
+    [brokenProjects]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setOldRoot(suggestedOldRoot);
+    setNewRoot("");
+    setPlan(null);
+    setResult(null);
+    setError(null);
+  }, [open, suggestedOldRoot]);
+
+  const runDryRun = useCallback(async () => {
+    if (!oldRoot || !newRoot) return;
+    setPlanning(true);
+    setError(null);
+    setPlan(null);
+    try {
+      const response: any = await api.post("projects/rebase_root/", {
+        old_root: oldRoot,
+        new_root: newRoot,
+        dry_run: true,
+      });
+      if (response?.success === false) {
+        setError(response?.error ?? "Could not work out the mapping");
+        return;
+      }
+      setPlan(response?.data ?? response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPlanning(false);
+    }
+  }, [oldRoot, newRoot]);
+
+  // Same reasoning as the move dialog: the check is read-only, so there is no
+  // point making the user ask for it.
+  useEffect(() => {
+    if (!open || !oldRoot || !newRoot || oldRoot === newRoot || result) return;
+    const timer = setTimeout(() => {
+      void runDryRun();
+    }, 700);
+    return () => clearTimeout(timer);
+  }, [open, oldRoot, newRoot, result, runDryRun]);
+
+  const handleBrowse = useCallback(async () => {
+    const chosen = await browseDirectory(
+      "Choose the folder the projects are in now"
+    );
+    if (!chosen) return;
+    setNewRoot(chosen);
+    setPlan(null);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const apply = useCallback(async () => {
+    if (!oldRoot || !newRoot) return;
+    setApplying(true);
+    setError(null);
+    try {
+      const response: any = await api.post("projects/rebase_root/", {
+        old_root: oldRoot,
+        new_root: newRoot,
+      });
+      if (response?.success === false) {
+        setError(response?.error ?? "Could not reconnect the projects");
+        return;
+      }
+      setResult(response?.data ?? response);
+      setPlan(null);
+      onReconnected?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
+    }
+  }, [oldRoot, newRoot, onReconnected]);
+
+  /** Point one stubborn project at a folder the user picks by hand. */
+  const locate = useCallback(
+    async (project: BrokenProject) => {
+      const chosen = await browseDirectory(
+        `Find the folder for "${project.name}"`
+      );
+      if (!chosen) return;
+      setLocating(project.id);
+      setError(null);
+      try {
+        const response: any = await api.post(
+          `projects/${project.id}/relocate/`,
+          { directory: chosen }
+        );
+        if (response?.success === false) {
+          setError(response?.error ?? `Could not reconnect ${project.name}`);
+          return;
+        }
+        onReconnected?.();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLocating(null);
+      }
+    },
+    [onReconnected]
+  );
+
+  const busy = planning || applying || locating !== null;
+  const stillBroken = result
+    ? [...(result.missing ?? []), ...(result.failed ?? [])]
+    : [];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={busy ? undefined : onClose}
+      maxWidth="md"
+      fullWidth
+    >
+      <DialogTitle>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <LinkOff color="warning" />
+          <span>Reconnect projects</span>
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {brokenProjects.length} project
+          {brokenProjects.length === 1 ? "" : "s"} cannot be found where CCP4i2
+          recorded {brokenProjects.length === 1 ? "it" : "them"}. If a drive was
+          renamed or the projects folder was moved, say where they are now and
+          they will be reconnected. Nothing is moved.
+        </Typography>
+
+        <TextField
+          fullWidth
+          size="small"
+          label="They used to be in"
+          helperText="Taken from the projects that are missing - edit if it is not right."
+          value={oldRoot}
+          disabled={busy}
+          onChange={(event) => {
+            setOldRoot(event.target.value);
+            setPlan(null);
+            setResult(null);
+          }}
+          sx={{ mt: 2 }}
+        />
+
+        <Stack direction="row" spacing={1} alignItems="flex-start" sx={{ mt: 2 }}>
+          <TextField
+            fullWidth
+            size="small"
+            label="They are now in"
+            value={newRoot}
+            disabled={busy}
+            onChange={(event) => {
+              setNewRoot(event.target.value);
+              setPlan(null);
+              setResult(null);
+            }}
+          />
+          {canBrowse() && (
+            <Button
+              variant="outlined"
+              startIcon={<FolderOpen />}
+              onClick={handleBrowse}
+              disabled={busy}
+              sx={{ whiteSpace: "nowrap", mt: 0.25 }}
+            >
+              Browse
+            </Button>
+          )}
+        </Stack>
+
+        {planning && <LinearProgress sx={{ mt: 2 }} />}
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {plan && (
+          <Box sx={{ mt: 2 }}>
+            <Alert severity={plan.matched.length > 0 ? "info" : "warning"}>
+              <AlertTitle>
+                {plan.matched.length} of {plan.matched.length + plan.missing.length}{" "}
+                found in the new location
+              </AlertTitle>
+              {plan.matched.length > 0 && (
+                <Typography variant="body2">
+                  Each will be re-pointed and the paths inside its files
+                  rebased. Projects elsewhere are left alone.
+                </Typography>
+              )}
+              {plan.matched.length === 0 && (
+                <Typography variant="body2">
+                  Nothing was found under that folder. Check it is the folder
+                  that directly contains the project folders.
+                </Typography>
+              )}
+            </Alert>
+
+            <List dense sx={{ maxHeight: 240, overflow: "auto", mt: 1 }}>
+              {plan.matched.map((entry) => (
+                <ListItem key={entry.id} disableGutters>
+                  <CheckCircle
+                    fontSize="small"
+                    color="success"
+                    sx={{ mr: 1, flexShrink: 0 }}
+                  />
+                  <ListItemText
+                    primary={entry.name}
+                    secondary={entry.new_directory}
+                    secondaryTypographyProps={{
+                      sx: { fontFamily: "monospace", wordBreak: "break-all" },
+                    }}
+                  />
+                </ListItem>
+              ))}
+              {plan.missing.map((entry) => (
+                <ListItem key={entry.id} disableGutters>
+                  <LinkOff
+                    fontSize="small"
+                    color="warning"
+                    sx={{ mr: 1, flexShrink: 0 }}
+                  />
+                  <ListItemText
+                    primary={entry.name}
+                    secondary={`${entry.reason} at ${entry.new_directory}`}
+                    secondaryTypographyProps={{
+                      sx: { fontFamily: "monospace", wordBreak: "break-all" },
+                    }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        )}
+
+        {result && (
+          <Alert severity="success" sx={{ mt: 2 }}>
+            <AlertTitle>
+              Reconnected {result.relocated?.length ?? 0} project
+              {(result.relocated?.length ?? 0) === 1 ? "" : "s"}
+            </AlertTitle>
+            {result.preference_updated && (
+              <Typography variant="body2">
+                Your default projects folder was updated to match, so new
+                projects will be created in the right place.
+              </Typography>
+            )}
+          </Alert>
+        )}
+
+        {stillBroken.length > 0 && (
+          <>
+            <Divider sx={{ my: 2 }} />
+            <Alert severity="warning">
+              <AlertTitle>Still not found</AlertTitle>
+              <Typography variant="body2" gutterBottom>
+                These did not move with the rest. Point each one at its folder:
+              </Typography>
+              <Stack spacing={1} sx={{ mt: 1 }}>
+                {stillBroken.map((entry) => {
+                  const project = brokenProjects.find((p) => p.id === entry.id);
+                  return (
+                    <Stack
+                      key={entry.id}
+                      direction="row"
+                      spacing={1}
+                      alignItems="center"
+                      flexWrap="wrap"
+                    >
+                      <Box component="span" sx={{ flexGrow: 1 }}>
+                        {entry.name}
+                      </Box>
+                      <Chip
+                        size="small"
+                        label={entry.error ?? entry.reason ?? "not found"}
+                      />
+                      {canBrowse() && project && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          disabled={busy}
+                          onClick={() => locate(project)}
+                          startIcon={
+                            locating === entry.id ? (
+                              <CircularProgress size={14} />
+                            ) : (
+                              <FolderOpen />
+                            )
+                          }
+                        >
+                          Locate
+                        </Button>
+                      )}
+                    </Stack>
+                  );
+                })}
+              </Stack>
+            </Alert>
+          </>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>
+          {result ? "Close" : "Cancel"}
+        </Button>
+        <Button
+          onClick={runDryRun}
+          disabled={busy || !oldRoot || !newRoot || Boolean(result)}
+        >
+          Re-check
+        </Button>
+        <Button
+          variant="contained"
+          onClick={apply}
+          disabled={
+            busy || !plan || plan.matched.length === 0 || Boolean(result)
+          }
+          startIcon={applying ? <CircularProgress size={16} /> : undefined}
+        >
+          Reconnect
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default ReconnectProjectsDialog;

--- a/docs/MOVING_PROJECTS.md
+++ b/docs/MOVING_PROJECTS.md
@@ -1,0 +1,130 @@
+# Moving a project on disk
+
+Users move projects: onto a bigger disk, into a tidier folder, off a laptop and
+onto a share. Sometimes the path changes without them doing anything at all —
+a mounted drive gets renamed by an administrator and every absolute path in the
+project points at somewhere that no longer exists.
+
+Qt-i2 could move a project but left jobs broken afterwards. This document
+records where the breakage comes from and how the Django app handles it.
+
+## The data model is nearly location-independent
+
+Very little in CCP4i2 actually records where a project lives:
+
+* `Project.directory` — the one absolute path in the database. `Job.directory`
+  and `File.path` are both derived from it.
+* `CDataFile` serialises as `project` (UUID) + `relPath` + `baseName` +
+  `dbFileId`. Nothing absolute:
+
+  ```xml
+  <CPdbDataFile>
+    <project>b18b4fa2450311f0bd4a56d135b7511f</project>
+    <baseName>XYZIN_PARTIAL-coordinates.pdb</baseName>
+    <relPath>CCP4_JOBS/job_2</relPath>
+    <dbFileId>c069d452451311f0bd4a56d135b7511f</dbFileId>
+  </CPdbDataFile>
+  ```
+
+`CDataFile.getFullPath()` is also mildly self-healing: an absolute `baseName`
+that no longer exists is discarded in favour of `relPath` when one is set.
+
+So a move is, to a first approximation, `mv` plus one `UPDATE`.
+
+## Where absolute paths still leak in
+
+Base classes are clean. The leakage is all in plugin-level code and in files
+that programs write for themselves. Measured across twelve real projects:
+
+| File | Written by | Re-read? |
+|---|---|---|
+| `program.xml` | the CCP4 program itself (aimless writes `<MTZmergedfilename>`) | by report classes |
+| `params.xml`, `input_params.xml` | base serialiser — but only plugin-set scalars are absolute | clone, re-run |
+| `*.scene.xml` | ccp4mg | yes — breaks the 3D view |
+| `script.py`, `state*.py`, `*.scm` | Coot wrappers | yes — breaks Coot relaunch |
+| `job.ccp4db.xml`, `DATABASE.db.xml` | legacy Qt-i2 | on import |
+| `report.html`, `report_xml.xml` | report generator | cached, regenerable |
+| `log.txt`, `stdout.txt`, `com.txt`, `*.log` | provenance | no |
+
+### Plugin-level emitters, fixed at source
+
+Three places were writing absolute paths into `params.xml`, where they then
+propagated into every downstream job that inherited the parameter:
+
+* `phaser_pipeline` set `KILLFILEPATH` to `<pipeline work dir>/INTERRUPT`. It no
+  longer sets it at all: each phaser wrapper already defaults to
+  `<its own work dir>/INTERRUPT`, which is also what
+  `CPluginScript.isInterrupted()` watches.
+* `aimless` stored `HKLOUT_BASENAME` as a full path. It now stores a bare
+  basename and joins it with the work directory at the point of use. An
+  absolute value inherited from an older job is stripped back to its basename,
+  which incidentally fixes those jobs too.
+* `phaser_EP_AUTO` built the "- original hand" annotation from
+  `str(outputData.MAPOUT[0])` — the file object, whose `__str__` is its full
+  path — instead of `str(...annotation)`. Corrected for `MAPOUT` and
+  `LLGMAPOUT`.
+
+Nothing can be done at source about `program.xml`: the program writes it.
+
+## What a move does
+
+`server/ccp4i2/db/move_project.py`.
+
+1. **Preflight.** Destination must be absolute, must not exist, must have a
+   writable parent, must not be inside the project. No job may be queued,
+   running or running remotely — but a `PENDING` job is a task that has been
+   created and not yet run, so those do not block. No other project may claim
+   the destination.
+2. **Move the bytes.** `os.rename` when the destination is on the same
+   filesystem — atomic, instant, and no second copy of what can be a
+   multi-gigabyte project. Cross-device falls back to `copytree`, and the
+   source is only removed once the database has been updated, so an interrupted
+   move always leaves one complete tree.
+3. **Rebase.** Rewrite the old root to the new one in every text file that is
+   not provenance, not a regenerable cache and not binary. Binaries are
+   identified by sniffing for a NUL byte, not by trusting the extension.
+4. **Delete the caches.** `report_xml.xml`, `report.html`, `report_tmp.html` —
+   they regenerate on demand.
+5. **Commit.** `Project.directory` is updated last. Any failure after step 2
+   rolls back: the rewrites are inverted and the directory renamed back (or,
+   cross-device, the partial copy discarded).
+
+Logs, stdout, stderr and command scripts are deliberately left alone. They are
+the record of what actually ran, and rewriting them would falsify it.
+
+A journal file (`.ccp4i2-move.json`) sits at the destination root while the
+rebase is in flight, so a tree left half-rebased by a crash can be recognised.
+
+## Repairing paths without moving
+
+A project may point somewhere that is neither its old nor its new home: a mount
+renamed underneath it, an import from another machine, an earlier move. Every
+operation reports these as `stale_roots` — a map of root to reference count —
+and `repair_project_paths` rewrites any one of them onto the current directory,
+in place, moving nothing.
+
+## API
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /projects/{id}/move/` | `{directory, dry_run?}` — relocate and rebase |
+| `POST /projects/{id}/repair_paths/` | `{old_directory, dry_run?}` — rebase in place |
+| `GET /projects/{id}/stale_roots/` | roots the project still refers to |
+
+`PATCH`ing `Project.directory` directly is rejected by the serializer: it would
+leave the record pointing at a directory still sitting somewhere else.
+
+The frontend surfaces all of this through `move-project-dialog.tsx`, reached
+from the move icon on each row and card of the projects table. It always runs
+the dry run first, so the user sees exactly which files will change before
+anything is touched.
+
+## Known gap: importing a project zip
+
+`import_ccp4_project_zip` accepts a `relocate_path` and updates
+`Project.directory`, but does not rebase the paths inside the extracted files —
+the same breakage this document describes, arriving by a different route.
+Wiring the rebase into import is complicated by job renumbering: an imported
+`job_3` may become `job_7`, so a plain root substitution is not enough; the
+substitution list would have to be built from `import_i2xml_result["job_map"]`
+as well as the root.

--- a/docs/MOVING_PROJECTS.md
+++ b/docs/MOVING_PROJECTS.md
@@ -103,6 +103,31 @@ operation reports these as `stale_roots` — a map of root to reference count �
 and `repair_project_paths` rewrites any one of them onto the current directory,
 in place, moving nothing.
 
+## When the database itself points nowhere
+
+The three operations above all assume the project directory is where
+`Project.directory` says it is. A renamed drive breaks that assumption: the
+database is intact, the files are intact, but the recorded path names a place
+that no longer exists. Moving cannot help — there is nothing at the source to
+move — and repairing cannot help either, because it rebases *onto* the recorded
+directory.
+
+`relocate_project` handles it: point a project at where its directory actually
+is now, update the record, and rebase the paths inside from the old root to the
+new one. Nothing is moved. The destination is checked for one of `CCP4_JOBS`,
+`CCP4_IMPORTED_FILES`, `CCP4_COOT` or `CCP4_PROJECT_FILES` first, so a mistyped
+or mis-picked folder is refused rather than rewritten through.
+
+A drive rename invalidates *every* project at once, and re-pointing nineteen of
+them one at a time is no kind of recovery path. `rebase_projects_root` takes the
+old and new locations of the store, maps each project beneath the old root onto
+its counterpart under the new one, and re-points the ones that are actually
+there. Projects that cannot be found are reported and left alone — one failure
+does not abandon the rest — and projects that were never on that drive are
+untouched. `update_projects_dir_preference` follows the move in
+`preferences.json` as well, so the next new project is not created back in the
+location that has gone.
+
 ## API
 
 | Endpoint | Purpose |
@@ -110,14 +135,23 @@ in place, moving nothing.
 | `POST /projects/{id}/move/` | `{directory, dry_run?}` — relocate and rebase |
 | `POST /projects/{id}/repair_paths/` | `{old_directory, dry_run?}` — rebase in place |
 | `GET /projects/{id}/stale_roots/` | roots the project still refers to |
+| `POST /projects/{id}/relocate/` | `{directory, dry_run?}` — re-point a project whose directory has gone |
+| `GET /projects/missing_directories/` | projects whose recorded directory is not on disk |
+| `POST /projects/rebase_root/` | `{old_root, new_root, dry_run?, update_preference?}` — the drive-rename case |
 
 `PATCH`ing `Project.directory` directly is rejected by the serializer: it would
 leave the record pointing at a directory still sitting somewhere else.
 
-The frontend surfaces all of this through `move-project-dialog.tsx`, reached
-from the move icon on each row and card of the projects table. It always runs
-the dry run first, so the user sees exactly which files will change before
-anything is touched.
+The frontend surfaces moving and repairing through `move-project-dialog.tsx`,
+reached from the move icon on each row and card of the projects table, and
+reconnection through `reconnect-projects-dialog.tsx`, reached from a banner that
+appears when any project directory is missing. Both run the dry run
+automatically, so the user sees what will change before anything is touched.
+Projects that cannot be found are flagged in the list and do not offer a move,
+which could not work until they are reconnected.
+
+Both dialogs are desktop-only: the directories live on the machine running the
+server, and choosing where they are needs a native folder picker.
 
 ## Known gap: importing a project zip
 

--- a/server/ccp4i2/api/ProjectViewSet.py
+++ b/server/ccp4i2/api/ProjectViewSet.py
@@ -822,6 +822,129 @@ class ProjectViewSet(ModelViewSet):
     @action(
         detail=True,
         methods=["post"],
+        serializer_class=serializers.ProjectSerializer,
+    )
+    def relocate(self, request, pk=None):
+        """
+        Record that a project now lives somewhere else, and rebase its paths.
+
+        Nothing is moved. This is for the case where the directory is intact
+        but its absolute path changed underneath the user - a drive renamed, a
+        share remounted, a projects folder moved outside CCP4i2 - so the
+        database points at somewhere that no longer exists. ``move`` cannot
+        help there, because it needs the files to still be where the database
+        says they are.
+
+        POST body:
+            directory (str): where the project actually is now.
+            dry_run (bool, optional): report what would change without doing it.
+        """
+        from ..db.move_project import MoveProjectError, relocate_project
+
+        the_project = self.get_object()
+        directory = request.data.get("directory")
+        if not directory:
+            return api_error("No directory supplied", status=400)
+
+        dry_run = str(request.data.get("dry_run", "")).lower() in ("1", "true", "yes")
+
+        try:
+            return api_success(
+                relocate_project(
+                    the_project, pathlib.Path(directory), dry_run=dry_run
+                )
+            )
+        except MoveProjectError as err:
+            logger.warning("Refused to re-point project %s: %s", the_project.name, err)
+            return api_error(str(err), status=400)
+        except Exception as err:
+            logger.exception("Failed to re-point project %s", the_project.name)
+            return api_error(str(err), status=500)
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="missing_directories",
+        serializer_class=serializers.ProjectSerializer,
+    )
+    def missing_directories(self, request):
+        """
+        List projects whose recorded directory is no longer on disk.
+
+        A whole storage root going away - a renamed drive, a share that now
+        mounts elsewhere - invalidates every project at once, so this is
+        reported for the store as a whole rather than project by project.
+        """
+        from ..db.move_project import directory_is_missing
+
+        broken = [
+            {
+                "id": project.pk,
+                "uuid": str(project.uuid),
+                "name": project.name,
+                "directory": project.directory,
+            }
+            for project in models.Project.objects.all().order_by("name")
+            if directory_is_missing(project)
+        ]
+        return api_success(
+            {"count": len(broken), "projects": broken}
+        )
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="rebase_root",
+        serializer_class=serializers.ProjectSerializer,
+    )
+    def rebase_root(self, request):
+        """
+        Re-point every project that moved with a change of storage root.
+
+        For the drive-rename case: given where the project store used to be and
+        where it is now, map each project onto its counterpart and re-point the
+        ones that are actually there. Projects that cannot be found are
+        reported and left alone.
+
+        POST body:
+            old_root (str): where the projects used to be.
+            new_root (str): where they are now.
+            dry_run (bool, optional): report the mapping without applying it.
+            update_preference (bool, optional): follow the move in
+                preferences.json too, so new projects are created in the right
+                place. Defaults to true on a real run.
+        """
+        from ..db.move_project import (
+            rebase_projects_root,
+            update_projects_dir_preference,
+        )
+
+        old_root = request.data.get("old_root")
+        new_root = request.data.get("new_root")
+        if not old_root or not new_root:
+            return api_error("Both old_root and new_root are required", status=400)
+
+        dry_run = str(request.data.get("dry_run", "")).lower() in ("1", "true", "yes")
+        update_preference = str(
+            request.data.get("update_preference", "true")
+        ).lower() in ("1", "true", "yes")
+
+        try:
+            summary = rebase_projects_root(old_root, new_root, dry_run=dry_run)
+            if not dry_run and update_preference:
+                summary["preference_updated"] = update_projects_dir_preference(
+                    old_root, new_root
+                )
+            return api_success(summary)
+        except Exception as err:
+            logger.exception(
+                "Failed to re-point projects from %s to %s", old_root, new_root
+            )
+            return api_error(str(err), status=500)
+
+    @action(
+        detail=True,
+        methods=["post"],
         url_path="repair_paths",
         serializer_class=serializers.ProjectSerializer,
     )

--- a/server/ccp4i2/api/ProjectViewSet.py
+++ b/server/ccp4i2/api/ProjectViewSet.py
@@ -778,6 +778,124 @@ class ProjectViewSet(ModelViewSet):
         methods=["post"],
         serializer_class=serializers.ProjectSerializer,
     )
+    def move(self, request, pk=None):
+        """
+        Move a project to a new location on disk.
+
+        The project directory is relocated and every absolute path that CCP4i2
+        still reads back - job parameters, Coot scripts, ccp4mg scenes - is
+        rebased onto the new root. Cached reports are deleted and regenerate on
+        demand; logs and command scripts are left as the historical record they
+        are.
+
+        POST body:
+            directory (str): destination path, including the project directory
+                name itself.
+            dry_run (bool, optional): report what would change without doing it.
+
+        Returns a summary of the files rewritten, plus ``stale_roots``: any
+        other locations still referenced inside the project, which a follow-up
+        ``repair_paths`` call can clean up.
+        """
+        from ..db.move_project import MoveProjectError, dry_run_move, move_project
+
+        the_project = self.get_object()
+        destination = request.data.get("directory")
+        if not destination:
+            return api_error("No destination directory supplied", status=400)
+
+        dry_run = str(request.data.get("dry_run", "")).lower() in ("1", "true", "yes")
+
+        try:
+            if dry_run:
+                return api_success(dry_run_move(the_project, pathlib.Path(destination)))
+            return api_success(move_project(the_project, pathlib.Path(destination)))
+        except MoveProjectError as err:
+            logger.warning("Refused to move project %s: %s", the_project.name, err)
+            return api_error(str(err), status=400)
+        except Exception as err:
+            logger.exception(
+                "Failed to move project %s to %s", the_project.name, destination
+            )
+            return api_error(str(err), status=500)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="repair_paths",
+        serializer_class=serializers.ProjectSerializer,
+    )
+    def repair_paths(self, request, pk=None):
+        """
+        Rewrite stale absolute paths without moving anything.
+
+        For the case where the project directory never moved but its absolute
+        path changed underneath the user - a renamed mount point, a
+        reorganised share - or where an earlier move or import left references
+        to a previous location behind.
+
+        POST body:
+            old_directory (str): the root to replace.
+            dry_run (bool, optional): report what would change without doing it.
+        """
+        from ..db.move_project import MoveProjectError, repair_project_paths
+
+        the_project = self.get_object()
+        old_directory = request.data.get("old_directory")
+        if not old_directory:
+            return api_error("No old_directory supplied", status=400)
+
+        dry_run = str(request.data.get("dry_run", "")).lower() in ("1", "true", "yes")
+
+        try:
+            return api_success(
+                repair_project_paths(the_project, old_directory, dry_run=dry_run)
+            )
+        except MoveProjectError as err:
+            logger.warning("Refused to repair project %s: %s", the_project.name, err)
+            return api_error(str(err), status=400)
+        except Exception as err:
+            logger.exception("Failed to repair paths for project %s", the_project.name)
+            return api_error(str(err), status=500)
+
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="stale_roots",
+        serializer_class=serializers.ProjectSerializer,
+    )
+    def stale_roots(self, request, pk=None):
+        """
+        List locations other than the project's own that it still refers to.
+
+        Each entry is a candidate ``old_directory`` for ``repair_paths``.
+        """
+        from ..db.move_project import find_stale_roots
+
+        the_project = self.get_object()
+        directory = pathlib.Path(the_project.directory)
+        if not directory.is_dir():
+            return api_error(
+                f"Project directory {directory} does not exist", status=400
+            )
+        try:
+            return api_success(
+                {
+                    "directory": str(directory),
+                    "stale_roots": find_stale_roots(directory, str(directory)),
+                }
+            )
+        except Exception as err:
+            logger.exception(
+                "Failed to scan for stale roots in project %s", the_project.name
+            )
+            return api_error(str(err), status=500)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        serializer_class=serializers.ProjectSerializer,
+    )
     def export(self, request, pk=None):
         the_project = models.Project.objects.get(pk=pk)
 

--- a/server/ccp4i2/api/serializers.py
+++ b/server/ccp4i2/api/serializers.py
@@ -93,6 +93,21 @@ class ProjectSerializer(ModelSerializer):
                 attrs["directory"] = str(
                     Path(settings.CCP4I2_PROJECTS_DIR) / slugify(attrs["name"])
                 )
+        elif "directory" in attrs and attrs["directory"] != instance.directory:
+            # Changing this field alone would leave the record pointing at a
+            # directory that is still sitting somewhere else, with every job's
+            # baked-in absolute path stale. Relocating a project is a job for
+            # POST /projects/{id}/move/, which moves the bytes and rebases the
+            # paths as one operation.
+            raise ValidationError(
+                {
+                    "directory": (
+                        "A project's directory cannot be changed directly. Use "
+                        "the project move endpoint, which relocates the files "
+                        "and updates the paths inside them."
+                    )
+                }
+            )
         return super().validate(attrs)
 
     def create(self, validated_data):

--- a/server/ccp4i2/db/move_project.py
+++ b/server/ccp4i2/db/move_project.py
@@ -641,8 +641,9 @@ def repair_project_paths(
 
     if not Path(new_root).is_dir():
         raise MoveProjectError(
-            f"Project directory {new_root} does not exist. Point the project at its "
-            "current location first."
+            f"Project directory {new_root} does not exist, so there is nothing here "
+            "to repair. If the directory is intact but its path changed, re-point "
+            "the project at its current location instead."
         )
     if old_root == new_root:
         raise MoveProjectError(
@@ -662,6 +663,235 @@ def repair_project_paths(
     summary["rewritten"] = len(rewritten)
     summary["stale_roots"] = find_stale_roots(Path(new_root), new_root)
     return summary
+
+
+# ---------------------------------------------------------------------------
+# Re-pointing a project whose recorded directory has gone stale
+# ---------------------------------------------------------------------------
+
+
+def directory_is_missing(project: Project) -> bool:
+    """True when the database points somewhere that is no longer there."""
+    return not Path(project.directory).is_dir()
+
+
+def looks_like_a_project(directory: Path) -> bool:
+    """Cheap sanity check that ``directory`` really is a CCP4i2 project.
+
+    Guards against a mistyped or mis-picked folder: re-pointing a project at
+    somebody's Downloads folder and then rewriting paths through it would be a
+    poor way to find out.
+    """
+    return any((directory / marker).is_dir() for marker in PROJECT_MARKERS)
+
+
+def preflight_relocate(project: Project, new_directory: Path) -> Path:
+    """Validate a re-point and return the resolved directory."""
+    new_directory = Path(new_directory).expanduser()
+    if not new_directory.is_absolute():
+        raise MoveProjectError(f"{new_directory} must be an absolute path.")
+    new_directory = Path(os.path.normpath(str(new_directory)))
+
+    if not new_directory.is_dir():
+        raise MoveProjectError(f"{new_directory} does not exist.")
+    if not looks_like_a_project(new_directory):
+        raise MoveProjectError(
+            f"{new_directory} does not look like a CCP4i2 project directory: "
+            "none of CCP4_JOBS, CCP4_IMPORTED_FILES, CCP4_COOT or "
+            "CCP4_PROJECT_FILES is present."
+        )
+    if str(new_directory) == str(Path(project.directory)):
+        raise MoveProjectError(
+            "The project is already recorded at that location."
+        )
+
+    clash = (
+        Project.objects.filter(directory=str(new_directory))
+        .exclude(pk=project.pk)
+        .first()
+    )
+    if clash is not None:
+        raise MoveProjectError(
+            f"Project '{clash.name}' is already registered at {new_directory}."
+        )
+
+    running = _running_jobs(project)
+    if running:
+        raise MoveProjectError(
+            "Cannot re-point a project with jobs still running or queued "
+            f"(job {', '.join(str(number) for number in running[:5])})."
+        )
+
+    return new_directory
+
+
+def relocate_project(
+    project: Project, new_directory: Path, dry_run: bool = False
+) -> Dict:
+    """Record that a project now lives somewhere else, and rebase its paths.
+
+    Nothing is moved. This is for the case where the directory is intact but
+    its absolute path changed underneath the user -- a drive renamed, a share
+    remounted elsewhere, a projects folder moved with the Finder -- so the
+    database is pointing at somewhere that no longer exists.
+
+    The move operation cannot help there: it needs the files to still be where
+    the database says they are.
+    """
+    new_directory = preflight_relocate(project, new_directory)
+    old_root = str(Path(project.directory))
+    new_root = str(new_directory)
+
+    plan = plan_rebase(new_directory, old_root, new_root)
+    summary = plan.as_dict(relative_to=new_directory)
+    summary.update(
+        {
+            "source": old_root,
+            "destination": new_root,
+            "dry_run": dry_run,
+            "directory_was_missing": not Path(old_root).is_dir(),
+        }
+    )
+
+    if dry_run:
+        summary["rewritten"] = 0
+        summary["stale_roots"] = find_stale_roots(new_directory, new_root)
+        return summary
+
+    rewritten: List[Path] = []
+    try:
+        rewritten = apply_rebase(plan)
+        with transaction.atomic():
+            project.directory = new_root
+            project.save(update_fields=["directory"])
+    except Exception as err:
+        logger.exception("Re-pointing project %s failed; rolling back", project.name)
+        undo_rebase(rewritten, old_root, new_root)
+        raise MoveProjectError(
+            f"Could not re-point the project, and the rewrites were undone: {err}"
+        ) from err
+
+    logger.info("Re-pointed project '%s' from %s to %s", project.name, old_root, new_root)
+    summary["rewritten"] = len(rewritten)
+    summary["stale_roots"] = find_stale_roots(new_directory, new_root)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# The whole store moved: one drive rename, every project stale
+# ---------------------------------------------------------------------------
+
+
+def _under(root: str, candidate: str) -> bool:
+    """True when ``candidate`` is ``root`` itself or sits beneath it."""
+    root = root.rstrip("/\\")
+    if candidate == root:
+        return True
+    return candidate.startswith(root + "/") or candidate.startswith(root + "\\")
+
+
+def plan_root_rebase(old_root: str, new_root: str) -> Dict:
+    """Work out which projects a change of storage root accounts for.
+
+    Renaming a drive or moving a projects folder invalidates every project at
+    once, and re-pointing nineteen of them one at a time is no kind of recovery
+    path. Given the old and new locations of the store, this maps each project
+    beneath the old root onto its counterpart under the new one and reports
+    which of them can actually be found there.
+    """
+    old_root = str(Path(old_root)).rstrip("/\\")
+    new_root = str(Path(new_root)).rstrip("/\\")
+
+    matched, missing, unaffected = [], [], []
+    for project in Project.objects.all().order_by("name"):
+        directory = str(Path(project.directory))
+        if not _under(old_root, directory):
+            unaffected.append({"id": project.pk, "name": project.name})
+            continue
+        remainder = directory[len(old_root):].lstrip("/\\")
+        candidate = Path(new_root) / remainder if remainder else Path(new_root)
+        entry = {
+            "id": project.pk,
+            "name": project.name,
+            "old_directory": directory,
+            "new_directory": str(candidate),
+        }
+        if candidate.is_dir() and looks_like_a_project(candidate):
+            matched.append(entry)
+        else:
+            entry["reason"] = (
+                "not found" if not candidate.is_dir() else "not a project directory"
+            )
+            missing.append(entry)
+
+    return {
+        "old_root": old_root,
+        "new_root": new_root,
+        "matched": matched,
+        "missing": missing,
+        "unaffected": unaffected,
+    }
+
+
+def rebase_projects_root(
+    old_root: str, new_root: str, dry_run: bool = False
+) -> Dict:
+    """Re-point every project that moved with a change of storage root.
+
+    Projects that cannot be found under the new root are reported and left
+    alone; one project failing does not abandon the rest, since a partial
+    recovery is better than none and the survivors can be retried.
+    """
+    summary = plan_root_rebase(old_root, new_root)
+    summary["dry_run"] = dry_run
+
+    if dry_run:
+        summary["relocated"] = []
+        summary["failed"] = []
+        return summary
+
+    relocated, failed = [], []
+    for entry in summary["matched"]:
+        project = Project.objects.get(pk=entry["id"])
+        try:
+            result = relocate_project(project, Path(entry["new_directory"]))
+            relocated.append({**entry, "rewritten": result["rewritten"]})
+        except Exception as err:
+            logger.exception("Could not re-point project %s", project.name)
+            failed.append({**entry, "error": str(err)})
+
+    summary["relocated"] = relocated
+    summary["failed"] = failed
+    logger.info(
+        "Re-pointed %d project(s) from %s to %s (%d failed, %d not found)",
+        len(relocated),
+        summary["old_root"],
+        summary["new_root"],
+        len(failed),
+        len(summary["missing"]),
+    )
+    return summary
+
+
+def update_projects_dir_preference(old_root: str, new_root: str) -> bool:
+    """Follow the store move in ``preferences.json`` as well.
+
+    Without this the database is repaired but the next new project is still
+    created in the location that no longer exists.
+    """
+    from ..config import preferences
+
+    prefs = preferences.load_preferences()
+    current = prefs.get("projectsDir")
+    if not current or not _under(str(Path(old_root)).rstrip("/\\"), str(Path(current))):
+        return False
+
+    remainder = str(Path(current))[len(str(Path(old_root)).rstrip("/\\")):].lstrip("/\\")
+    updated = str(Path(new_root) / remainder) if remainder else str(Path(new_root))
+    prefs["projectsDir"] = updated
+    preferences.save_preferences(prefs)
+    logger.info("Updated projectsDir preference from %s to %s", current, updated)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/server/ccp4i2/db/move_project.py
+++ b/server/ccp4i2/db/move_project.py
@@ -1,0 +1,706 @@
+"""Move a project to a new location on disk, or repair its paths in place.
+
+The CCP4i2 data model is very nearly location-independent: ``CDataFile`` is
+serialised as ``project`` (UUID) + ``relPath`` + ``baseName``, and the only
+absolute path in the database is :attr:`Project.directory`. Moving a project is
+therefore mostly ``mv`` plus one field update.
+
+What spoils it is *leakage*: a handful of places bake an absolute path into a
+file inside the project directory.
+
+* Programs that write their own XML (``program.xml`` from aimless/pointless
+  carries ``<MTZmergedfilename>``). We cannot fix these at source.
+* Generated scripts that are re-read by a viewer -- Coot's ``script.py`` and
+  saved state, ccp4mg's ``*.scene.xml``.
+* Legacy database dumps (``DATABASE.db.xml``, ``job.ccp4db.xml``) read on import.
+* Cached reports, which are simply deleted here and regenerated on demand.
+
+This module rewrites the first three groups and deletes the fourth. It
+deliberately leaves log files, stdout/stderr and command scripts alone: those
+are a historical record of what actually ran, and rewriting them would falsify
+it.
+
+Two entry points:
+
+``move_project``
+    Relocate the bytes and rebase the paths. Uses :func:`os.rename` when the
+    destination is on the same filesystem (atomic, instant, no extra disk) and
+    falls back to copy-verify-delete across devices.
+
+``repair_project_paths``
+    Rebase paths without moving anything, for the case where the directory
+    stayed put but its absolute path changed underneath the user -- a renamed
+    mount point, a reorganised network share.
+"""
+
+import errno
+import json
+import logging
+import os
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from django.db import transaction
+
+from .models import Job, Project
+
+logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+
+#: Written at the destination root while a move is in flight so that a crashed
+#: move can be diagnosed (and the half-rebased tree recognised) afterwards.
+JOURNAL_NAME = ".ccp4i2-move.json"
+
+#: Regenerated on demand by ``get_job_report_xml``; deleting is cheaper and
+#: safer than rewriting.
+CACHE_PATTERNS = (
+    "report_xml.xml",
+    "report.html",
+    "report_tmp.html",
+    "report_tmp.previous_*.html",
+    "diagnostic_report.html",
+)
+
+#: Provenance. These record what ran, with the paths it ran against; rewriting
+#: them would misrepresent history, and nothing reads them back as input.
+PROVENANCE_NAMES = frozenset(
+    {
+        "log.txt",
+        "stdout.txt",
+        "stderr.txt",
+        "com.txt",
+        "diagnostic.xml",
+    }
+)
+PROVENANCE_PREFIXES = ("stdout.", "stderr.", "log.")
+PROVENANCE_SUFFIXES = (".log", ".txt")
+
+#: Never opened as text, whatever their content. Coordinate and reflection
+#: files are excluded on principle as well as on prudence: a path inside a PDB
+#: REMARK is part of that file's own provenance, not a CCP4i2 reference.
+BINARY_SUFFIXES = frozenset(
+    {
+        ".mtz", ".map", ".ccp4", ".mrc", ".pkl", ".pickle", ".npy", ".npz",
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tif", ".tiff", ".ico",
+        ".pdf", ".zip", ".gz", ".bz2", ".xz", ".tar", ".tgz", ".7z",
+        ".so", ".dylib", ".dll", ".exe", ".pyc", ".pyo",
+        ".pdb", ".ent", ".cif", ".mmcif", ".sca", ".hkl", ".mmtf", ".bin",
+    }
+)
+
+#: Files larger than this are not slurped into memory. Anything holding a
+#: project path reference is orders of magnitude smaller.
+MAX_REWRITE_BYTES = 64 * 1024 * 1024
+
+
+class MoveProjectError(Exception):
+    """Raised when a move or repair cannot be completed."""
+
+
+@dataclass
+class RewriteCandidate:
+    """One file that contains the old root and would be rewritten."""
+
+    path: Path
+    occurrences: int
+
+    def as_dict(self, relative_to: Path) -> Dict:
+        try:
+            name = str(self.path.relative_to(relative_to))
+        except ValueError:
+            name = str(self.path)
+        return {"path": name, "occurrences": self.occurrences}
+
+
+@dataclass
+class RebasePlan:
+    """What a rebase would do. Safe to compute without touching anything."""
+
+    old_root: str
+    new_root: str
+    rewrites: List[RewriteCandidate] = field(default_factory=list)
+    caches: List[Path] = field(default_factory=list)
+    skipped_binary: List[Path] = field(default_factory=list)
+    skipped_provenance: List[Path] = field(default_factory=list)
+    skipped_too_large: List[Path] = field(default_factory=list)
+
+    @property
+    def total_occurrences(self) -> int:
+        return sum(candidate.occurrences for candidate in self.rewrites)
+
+    def as_dict(self, relative_to: Path) -> Dict:
+        return {
+            "old_root": self.old_root,
+            "new_root": self.new_root,
+            "rewrites": [c.as_dict(relative_to) for c in self.rewrites],
+            "total_occurrences": self.total_occurrences,
+            "caches_to_delete": [str(p.relative_to(relative_to)) for p in self.caches],
+            "skipped": {
+                "binary": len(self.skipped_binary),
+                "provenance": len(self.skipped_provenance),
+                "too_large": [str(p) for p in self.skipped_too_large],
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Path variants
+# ---------------------------------------------------------------------------
+
+
+def path_variants(root: str) -> Dict[str, str]:
+    """Spellings of ``root`` that may appear inside project files, by form.
+
+    A Windows root shows up both as ``C:\\Users\\me\\Proj`` and, because plenty
+    of code normalises separators, as ``C:/Users/me/Proj``; inside a JSON string
+    or a Python literal the backslashes may also be doubled.
+
+    Keyed by form rather than returned as a list so that an old root and a new
+    root pair up by *meaning*. Pairing positionally would mismatch the moment
+    the two roots have different shapes -- moving a POSIX project onto a Windows
+    share, say -- and silently corrupt whatever it touched.
+    """
+    root = root.rstrip("/\\")
+    posix = root.replace("\\", "/")
+    windows = root.replace("/", "\\")
+    return {
+        "native": root,
+        "posix": posix,
+        "windows": windows,
+        "windows_escaped": windows.replace("\\", "\\\\"),
+    }
+
+
+def substitution_map(old_root: str, new_root: str) -> List[tuple]:
+    """Ordered (old, new) pairs, longest old-spelling first.
+
+    Longest first so that the doubled-backslash spelling is matched before the
+    plain one can consume half of it.
+    """
+    old_variants = path_variants(old_root)
+    new_variants = path_variants(new_root)
+
+    pairs = []
+    for form, old in old_variants.items():
+        new = new_variants[form]
+        if old and old != new and (old, new) not in pairs:
+            pairs.append((old, new))
+
+    pairs.sort(key=lambda pair: len(pair[0]), reverse=True)
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def is_provenance(path: Path) -> bool:
+    """True for files that record what ran, and so must not be rewritten."""
+    name = path.name
+    if name in PROVENANCE_NAMES:
+        return True
+    if any(name.startswith(prefix) for prefix in PROVENANCE_PREFIXES):
+        return True
+    return path.suffix.lower() in PROVENANCE_SUFFIXES
+
+
+def is_cache(path: Path) -> bool:
+    """True for regenerable report caches, which are deleted rather than fixed."""
+    from fnmatch import fnmatch
+
+    return any(fnmatch(path.name, pattern) for pattern in CACHE_PATTERNS)
+
+
+def read_text_if_textual(path: Path) -> Optional[str]:
+    """Return the file's text, or ``None`` if it is binary or unreadable.
+
+    Sniffs for a NUL byte rather than trusting the extension, so an unexpected
+    binary with a ``.xml`` name cannot be corrupted.
+    """
+    try:
+        with open(path, "rb") as handle:
+            head = handle.read(8192)
+            if b"\0" in head:
+                return None
+            handle.seek(0)
+            raw = handle.read()
+    except OSError as err:
+        logger.warning("Could not read %s: %s", path, err)
+        return None
+    for encoding in ("utf-8", "latin-1"):
+        try:
+            return raw.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Planning
+# ---------------------------------------------------------------------------
+
+
+def plan_rebase(root: Path, old_root: str, new_root: str) -> RebasePlan:
+    """Walk ``root`` and work out what a rebase would change.
+
+    Purely read-only, so it can back a dry-run in the UI.
+    """
+    plan = RebasePlan(old_root=old_root, new_root=new_root)
+    substitutions = substitution_map(old_root, new_root)
+    needles = [old for old, _ in substitutions]
+
+    for path in sorted(root.rglob("*")):
+        if path.is_dir() or path.is_symlink():
+            continue
+        if path.name == JOURNAL_NAME:
+            continue
+        if is_cache(path):
+            plan.caches.append(path)
+            continue
+        if is_provenance(path):
+            plan.skipped_provenance.append(path)
+            continue
+        if path.suffix.lower() in BINARY_SUFFIXES:
+            plan.skipped_binary.append(path)
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size > MAX_REWRITE_BYTES:
+            plan.skipped_too_large.append(path)
+            continue
+
+        text = read_text_if_textual(path)
+        if text is None:
+            plan.skipped_binary.append(path)
+            continue
+        occurrences = sum(text.count(needle) for needle in needles)
+        if occurrences:
+            plan.rewrites.append(RewriteCandidate(path=path, occurrences=occurrences))
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Detecting roots left over from an earlier location
+# ---------------------------------------------------------------------------
+
+#: The top-level directories every CCP4i2 project has. An absolute path
+#: containing one of them implies a project root: everything to its left.
+PROJECT_MARKERS = ("CCP4_JOBS", "CCP4_IMPORTED_FILES", "CCP4_COOT", "CCP4_PROJECT_FILES")
+
+STALE_ROOT_RE = re.compile(
+    r"(?:[A-Za-z]:[\\/]|/)[^\s\"'<>|*?]*?"
+    r"(?=[\\/]{1,2}(?:" + "|".join(PROJECT_MARKERS) + r")\b)"
+)
+
+
+def _normalise_root(text: str) -> str:
+    """Tidy a root recovered from arbitrary text into a comparable form.
+
+    Un-doubles escaped backslashes and strips the extra slashes a ``file:///``
+    URL contributes, while leaving a UNC prefix (``\\\\server\\share``,
+    ``//server/share``) intact -- those leading separators are part of the path.
+    """
+    is_unc = text.startswith("\\\\\\\\") or text.startswith("//")
+    text = text.replace("\\\\", "\\")
+    if not is_unc:
+        text = re.sub(r"^/{2,}", "/", text)
+    elif text.startswith("///"):
+        # file:/// followed by a rooted POSIX path, not a UNC share.
+        text = re.sub(r"^/{2,}", "/", text)
+    return text.rstrip("/\\")
+
+
+def find_stale_roots(root: Path, current_root: str) -> Dict[str, int]:
+    """Count references to project roots other than ``current_root``.
+
+    A project that has been moved or imported before may still carry paths from
+    an even earlier location -- a previous move, a different machine, a mount
+    point that has since been renamed. A rebase only knows about the one root
+    it was asked to replace, so this reports the others rather than leaving the
+    user to discover them when something silently fails to open.
+    """
+    current = _normalise_root(str(current_root))
+    counts: Dict[str, int] = {}
+
+    for path in sorted(root.rglob("*")):
+        if path.is_dir() or path.is_symlink():
+            continue
+        if path.name == JOURNAL_NAME or is_cache(path) or is_provenance(path):
+            continue
+        if path.suffix.lower() in BINARY_SUFFIXES:
+            continue
+        try:
+            if path.stat().st_size > MAX_REWRITE_BYTES:
+                continue
+        except OSError:
+            continue
+        text = read_text_if_textual(path)
+        if text is None:
+            continue
+        for match in STALE_ROOT_RE.finditer(text):
+            found = _normalise_root(match.group(0))
+            if found and found != current:
+                counts[found] = counts.get(found, 0) + 1
+
+    return dict(sorted(counts.items(), key=lambda item: item[1], reverse=True))
+
+
+# ---------------------------------------------------------------------------
+# Applying
+# ---------------------------------------------------------------------------
+
+
+def apply_rebase(plan: RebasePlan, delete_caches: bool = True) -> List[Path]:
+    """Carry out ``plan``. Returns the files actually rewritten.
+
+    The caller keeps the returned list so that a later failure can be undone by
+    running the inverse substitution over exactly those files.
+    """
+    substitutions = substitution_map(plan.old_root, plan.new_root)
+    rewritten: List[Path] = []
+
+    for candidate in plan.rewrites:
+        text = read_text_if_textual(candidate.path)
+        if text is None:
+            continue
+        updated = text
+        for old, new in substitutions:
+            updated = updated.replace(old, new)
+        if updated == text:
+            continue
+        _write_preserving_mode(candidate.path, updated)
+        rewritten.append(candidate.path)
+
+    if delete_caches:
+        for cache in plan.caches:
+            try:
+                cache.unlink()
+            except OSError as err:
+                logger.warning("Could not delete cached report %s: %s", cache, err)
+
+    logger.info(
+        "Rebased %d file(s) from %s to %s", len(rewritten), plan.old_root, plan.new_root
+    )
+    return rewritten
+
+
+def undo_rebase(paths: List[Path], old_root: str, new_root: str) -> None:
+    """Run the inverse substitution over ``paths``, best effort."""
+    substitutions = substitution_map(new_root, old_root)
+    for path in paths:
+        text = read_text_if_textual(path)
+        if text is None:
+            continue
+        updated = text
+        for old, new in substitutions:
+            updated = updated.replace(old, new)
+        if updated != text:
+            try:
+                _write_preserving_mode(path, updated)
+            except OSError as err:
+                logger.error("Could not roll back rewrite of %s: %s", path, err)
+
+
+def _write_preserving_mode(path: Path, text: str) -> None:
+    """Write ``text`` to ``path``, keeping its permission bits."""
+    try:
+        mode = path.stat().st_mode
+    except OSError:
+        mode = None
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        handle.write(text)
+    if mode is not None:
+        try:
+            os.chmod(path, mode)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+#: Statuses that mean a job may still be writing into the project directory.
+#: PENDING is deliberately absent: it is the state of a task that has been
+#: created and is still being edited, not one that has been submitted, so a
+#: project full of half-filled-in tasks must still be movable. Matches the
+#: active set used by ``api.views.active_jobs`` and
+#: ``navigation.dependencies``.
+ACTIVE_JOB_STATUSES = (
+    Job.Status.QUEUED,
+    Job.Status.RUNNING,
+    Job.Status.RUNNING_REMOTELY,
+)
+
+
+def _running_jobs(project: Project) -> List[str]:
+    return list(
+        project.jobs.filter(status__in=ACTIVE_JOB_STATUSES).values_list(
+            "number", flat=True
+        )
+    )
+
+
+def preflight_move(project: Project, destination: Path) -> Path:
+    """Validate a proposed move and return the resolved destination.
+
+    Raises :class:`MoveProjectError` with a message fit to show the user.
+    """
+    source = Path(project.directory)
+    destination = Path(destination).expanduser()
+
+    if not source.is_dir():
+        raise MoveProjectError(
+            f"Project directory {source} does not exist. Use repair rather than move "
+            "if the directory is intact but its path has changed."
+        )
+
+    # The server's working directory is not something the user can see, so a
+    # relative destination would mean somewhere they did not choose.
+    if not destination.is_absolute():
+        raise MoveProjectError(
+            f"Destination {destination} must be an absolute path."
+        )
+    destination = Path(os.path.normpath(str(destination)))
+
+    if destination == source:
+        raise MoveProjectError("Destination is the project's current location.")
+    if destination.exists():
+        raise MoveProjectError(f"Destination {destination} already exists.")
+
+    parent = destination.parent
+    if not parent.is_dir():
+        raise MoveProjectError(f"Destination parent directory {parent} does not exist.")
+    if not os.access(parent, os.W_OK):
+        raise MoveProjectError(f"Destination parent directory {parent} is not writable.")
+
+    resolved_source = source.resolve()
+    if resolved_source in destination.resolve().parents or destination.resolve() == resolved_source:
+        raise MoveProjectError(
+            "Destination is inside the project directory; that would nest the "
+            "project inside itself."
+        )
+
+    clash = (
+        Project.objects.filter(directory=str(destination))
+        .exclude(pk=project.pk)
+        .first()
+    )
+    if clash is not None:
+        raise MoveProjectError(
+            f"Project '{clash.name}' is already registered at {destination}."
+        )
+
+    running = _running_jobs(project)
+    if running:
+        raise MoveProjectError(
+            "Cannot move a project with jobs still running or queued "
+            f"(job {', '.join(str(number) for number in running[:5])}). "
+            "Wait for them to finish, or stop them first."
+        )
+
+    return destination
+
+
+# ---------------------------------------------------------------------------
+# Journal
+# ---------------------------------------------------------------------------
+
+
+def _write_journal(root: Path, old_root: str, new_root: str, state: str) -> None:
+    try:
+        (root / JOURNAL_NAME).write_text(
+            json.dumps(
+                {"old_root": old_root, "new_root": new_root, "state": state},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    except OSError as err:
+        logger.warning("Could not write move journal in %s: %s", root, err)
+
+
+def _clear_journal(root: Path) -> None:
+    try:
+        (root / JOURNAL_NAME).unlink()
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def dry_run_move(project: Project, destination: Path) -> Dict:
+    """Validate a move and report what it would rewrite, changing nothing."""
+    destination = preflight_move(project, destination)
+    source = Path(project.directory)
+    plan = plan_rebase(source, str(source), str(destination))
+    result = plan.as_dict(relative_to=source)
+    result["source"] = str(source)
+    result["destination"] = str(destination)
+    result["same_filesystem"] = _same_filesystem(source, destination.parent)
+    # Roots from an earlier life that this move will not touch.
+    result["stale_roots"] = find_stale_roots(source, str(source))
+    return result
+
+
+def move_project(project: Project, destination: Path) -> Dict:
+    """Move ``project`` to ``destination`` and rebase its paths.
+
+    Same-filesystem moves use :func:`os.rename`: atomic, instant, and no
+    second copy of what can be a multi-gigabyte project. Cross-device moves
+    copy first and only delete the source once the database has been updated,
+    so an interrupted move always leaves one complete, usable tree.
+    """
+    destination = preflight_move(project, destination)
+    source = Path(project.directory)
+    old_root, new_root = str(source), str(destination)
+
+    cross_device = not _same_filesystem(source, destination.parent)
+    logger.info(
+        "Moving project '%s' from %s to %s (%s)",
+        project.name,
+        old_root,
+        new_root,
+        "copy across devices" if cross_device else "rename in place",
+    )
+
+    if cross_device:
+        shutil.copytree(source, destination, symlinks=True)
+    else:
+        try:
+            os.rename(source, destination)
+        except OSError as err:
+            # st_dev said same filesystem but rename disagreed -- bind mounts and
+            # some network filesystems do this. Fall back rather than fail.
+            if err.errno != errno.EXDEV:
+                raise MoveProjectError(f"Could not move project: {err}") from err
+            cross_device = True
+            shutil.copytree(source, destination, symlinks=True)
+
+    _write_journal(destination, old_root, new_root, "rebasing")
+
+    rewritten: List[Path] = []
+    try:
+        plan = plan_rebase(destination, old_root, new_root)
+        rewritten = apply_rebase(plan)
+
+        with transaction.atomic():
+            project.directory = new_root
+            project.save(update_fields=["directory"])
+    except Exception as err:
+        logger.exception("Move failed after relocating bytes; rolling back")
+        _rollback(source, destination, rewritten, old_root, new_root, cross_device)
+        raise MoveProjectError(f"Move failed and was rolled back: {err}") from err
+
+    _clear_journal(destination)
+
+    if cross_device:
+        try:
+            shutil.rmtree(source)
+        except OSError as err:
+            # The move itself succeeded; the leftover is untidy, not broken.
+            logger.error("Moved project but could not remove %s: %s", source, err)
+
+    summary = plan.as_dict(relative_to=destination)
+    summary.update(
+        {
+            "source": old_root,
+            "destination": new_root,
+            "rewritten": len(rewritten),
+            "cross_device": cross_device,
+            # Anything still pointing somewhere else entirely -- an earlier
+            # move, an import from another machine, a renamed mount. Offer
+            # these to the user as candidates for a follow-up repair.
+            "stale_roots": find_stale_roots(destination, new_root),
+        }
+    )
+    return summary
+
+
+def repair_project_paths(
+    project: Project, old_root: str, dry_run: bool = False
+) -> Dict:
+    """Rewrite stale ``old_root`` references without moving anything.
+
+    For the case the directory never moved but its absolute path changed --
+    a mount point renamed outside the user's control, a share reorganised.
+    """
+    new_root = str(Path(project.directory))
+    old_root = str(old_root).rstrip("/\\")
+
+    if not Path(new_root).is_dir():
+        raise MoveProjectError(
+            f"Project directory {new_root} does not exist. Point the project at its "
+            "current location first."
+        )
+    if old_root == new_root:
+        raise MoveProjectError(
+            "The old and new roots are the same; there is nothing to repair."
+        )
+
+    plan = plan_rebase(Path(new_root), old_root, new_root)
+    summary = plan.as_dict(relative_to=Path(new_root))
+    summary.update({"source": old_root, "destination": new_root, "dry_run": dry_run})
+
+    if dry_run:
+        summary["rewritten"] = 0
+        summary["stale_roots"] = find_stale_roots(Path(new_root), new_root)
+        return summary
+
+    rewritten = apply_rebase(plan)
+    summary["rewritten"] = len(rewritten)
+    summary["stale_roots"] = find_stale_roots(Path(new_root), new_root)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _same_filesystem(source: Path, destination_parent: Path) -> bool:
+    try:
+        return os.stat(source).st_dev == os.stat(destination_parent).st_dev
+    except OSError:
+        return False
+
+
+def _rollback(
+    source: Path,
+    destination: Path,
+    rewritten: List[Path],
+    old_root: str,
+    new_root: str,
+    cross_device: bool,
+) -> None:
+    """Put things back as they were, as far as we still can."""
+    if cross_device:
+        # The source was never touched -- discard the partial copy.
+        shutil.rmtree(destination, ignore_errors=True)
+        return
+
+    undo_rebase(rewritten, old_root, new_root)
+    _clear_journal(destination)
+    try:
+        os.rename(destination, source)
+    except OSError as err:
+        logger.error(
+            "Could not rename %s back to %s: %s. The project directory is at %s; "
+            "its database record still says %s.",
+            destination,
+            source,
+            err,
+            destination,
+            source,
+        )

--- a/server/ccp4i2/pipelines/phaser_pipeline/script/phaser_pipeline.py
+++ b/server/ccp4i2/pipelines/phaser_pipeline/script/phaser_pipeline.py
@@ -55,7 +55,10 @@ class phaser_pipeline(CPluginScript):
                     #setattr(self.phaserPlugin.container.keywords,attrName,attr)
                     getattr(self.phaserPlugin.container.keywords,attrName).set(attr)
         self.phaserPlugin.container.inputData.set(self.container.inputData)
-        self.phaserPlugin.container.inputData.KILLFILEPATH.set(os.path.join(self.getWorkDirectory(),'INTERRUPT'))
+        # KILLFILEPATH is deliberately left unset: each phaser wrapper defaults to
+        # <its own work directory>/INTERRUPT, matching CPluginScript.isInterrupted().
+        # Setting it here baked an absolute path into the subjob's params.xml, which
+        # then went stale whenever the project was moved on disk.
         self.oldXMLLength = 0
         self.phaserPlugin.callbackObject.addResponder(self.phaserXMLUpdated)
         rv = self.phaserPlugin.process()

--- a/server/ccp4i2/pipelines/phaser_pipeline/wrappers/phaser_EP_AUTO/script/phaser_EP_AUTO.py
+++ b/server/ccp4i2/pipelines/phaser_pipeline/wrappers/phaser_EP_AUTO/script/phaser_EP_AUTO.py
@@ -221,9 +221,9 @@ class phaser_EP_AUTO(phaser_MR.phaser_MR):
             map.annotation.set('Phased map')
             map.subType = 1
         if len(self.container.outputData.MAPOUT)>0:
-            self.container.outputData.MAPOUT[0].annotation.set(str(self.container.outputData.MAPOUT[0]) + ' - original hand')
+            self.container.outputData.MAPOUT[0].annotation.set(str(self.container.outputData.MAPOUT[0].annotation) + ' - original hand')
         if len(self.container.outputData.MAPOUT)>1:
-            self.container.outputData.MAPOUT[1].annotation.set(str(self.container.outputData.MAPOUT[1]) + ' - reversed hand')
+            self.container.outputData.MAPOUT[1].annotation.set(str(self.container.outputData.MAPOUT[1].annotation) + ' - reversed hand')
 
         while len(self.container.outputData.HKLOUT) > 0:
             self.container.outputData.HKLOUT.remove(self.container.outputData.HKLOUT[-1])
@@ -241,8 +241,8 @@ class phaser_EP_AUTO(phaser_MR.phaser_MR):
             llgMap.contentFlag = 1
             llgMap.subType = 2
         if len(self.container.outputData.LLGMAPOUT)>0:
-            self.container.outputData.LLGMAPOUT[0].annotation.set(str(self.container.outputData.LLGMAPOUT[0]) + ' - original hand')
+            self.container.outputData.LLGMAPOUT[0].annotation.set(str(self.container.outputData.LLGMAPOUT[0].annotation) + ' - original hand')
         if len(self.container.outputData.LLGMAPOUT)>1:
-            self.container.outputData.LLGMAPOUT[1].annotation.set(str(self.container.outputData.LLGMAPOUT[1]) + ' - reversed hand')
+            self.container.outputData.LLGMAPOUT[1].annotation.set(str(self.container.outputData.LLGMAPOUT[1].annotation) + ' - reversed hand')
         
         return CPluginScript.SUCCEEDED

--- a/server/ccp4i2/tests/db/test_move_project.py
+++ b/server/ccp4i2/tests/db/test_move_project.py
@@ -1,0 +1,452 @@
+"""Tests for moving a project on disk and rebasing its absolute paths."""
+
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from ...db.models import Job, Project
+from ...db.move_project import (
+    JOURNAL_NAME,
+    MoveProjectError,
+    apply_rebase,
+    dry_run_move,
+    find_stale_roots,
+    move_project,
+    path_variants,
+    plan_rebase,
+    repair_project_paths,
+    substitution_map,
+)
+
+
+def make_project_tree(root: Path, project_root_text: str) -> None:
+    """Build a miniature project containing every class of path leakage."""
+    job = root / "CCP4_JOBS" / "job_1"
+    job.mkdir(parents=True)
+    (root / "CCP4_IMPORTED_FILES").mkdir()
+
+    # Portable: relPath + baseName. Must survive untouched.
+    (job / "params.xml").write_text(
+        "<params>\n"
+        "  <CPdbDataFile>\n"
+        "    <baseName>XYZOUT.pdb</baseName>\n"
+        "    <relPath>CCP4_JOBS/job_1</relPath>\n"
+        "  </CPdbDataFile>\n"
+        f"  <KILLFILEPATH>{project_root_text}/CCP4_JOBS/job_1/INTERRUPT</KILLFILEPATH>\n"
+        "</params>\n",
+        encoding="utf-8",
+    )
+    # Program-authored XML.
+    (job / "program.xml").write_text(
+        f"<AIMLESS><MTZmergedfilename>{project_root_text}/CCP4_JOBS/job_1/HKLOUT.mtz"
+        "</MTZmergedfilename></AIMLESS>\n",
+        encoding="utf-8",
+    )
+    # Generated script re-read by a viewer.
+    (job / "script.py").write_text(
+        f"filePath = r'{project_root_text}/CCP4_JOBS/job_1/XYZOUT.pdb'\n",
+        encoding="utf-8",
+    )
+    (job / "scene_1.scene.xml").write_text(
+        f"<scene><filename>{project_root_text}/CCP4_JOBS/job_1/XYZOUT.pdb</filename></scene>\n",
+        encoding="utf-8",
+    )
+    # Provenance: must be left exactly as it was.
+    (job / "log.txt").write_text(
+        f"Opening {project_root_text}/CCP4_JOBS/job_1/HKLIN.mtz\n", encoding="utf-8"
+    )
+    (job / "stdout.txt").write_text(
+        f"wrote {project_root_text}/CCP4_JOBS/job_1/HKLOUT.mtz\n", encoding="utf-8"
+    )
+    # Regenerable caches: must be deleted.
+    (job / "report_xml.xml").write_text(
+        f"<report>{project_root_text}/CCP4_JOBS/job_1/XYZOUT.pdb</report>\n",
+        encoding="utf-8",
+    )
+    (job / "report.html").write_text(
+        f"<a href='{project_root_text}/x.pdb'>x</a>\n", encoding="utf-8"
+    )
+    # Binary: must never be opened for rewriting.
+    (job / "HKLOUT.mtz").write_bytes(
+        b"MTZ \x00\x00\x00" + project_root_text.encode() + b"\x00padding"
+    )
+
+
+class RebaseHelpersTest(TestCase):
+    """The pure path-substitution helpers, no database involved."""
+
+    def test_path_variants_cover_windows_spellings(self):
+        variants = path_variants(r"C:\Users\me\Proj")
+        self.assertEqual(variants["windows"], r"C:\Users\me\Proj")
+        self.assertEqual(variants["posix"], "C:/Users/me/Proj")
+        self.assertEqual(variants["windows_escaped"], r"C:\\Users\\me\\Proj")
+
+    def test_trailing_separator_ignored(self):
+        self.assertEqual(path_variants("/a/b/"), path_variants("/a/b"))
+
+    def test_roots_of_different_shapes_pair_by_form_not_position(self):
+        """A POSIX source and a Windows destination must not cross-wire."""
+        pairs = dict(substitution_map("/mnt/data/Proj", r"D:\Projects\Proj"))
+        self.assertEqual(pairs["/mnt/data/Proj"], "D:/Projects/Proj")
+        self.assertEqual(pairs[r"\mnt\data\Proj"], r"D:\Projects\Proj")
+
+    def test_substitutions_apply_longest_first(self):
+        pairs = substitution_map(r"C:\old\proj", r"D:\new\proj")
+        lengths = [len(old) for old, _ in pairs]
+        self.assertEqual(lengths, sorted(lengths, reverse=True))
+
+    def test_doubled_backslash_form_survives_substitution(self):
+        old, new = r"C:\old\proj", r"D:\new\proj"
+        text = r"path = 'C:\\old\\proj\\CCP4_JOBS'"
+        for needle, replacement in substitution_map(old, new):
+            text = text.replace(needle, replacement)
+        self.assertEqual(text, r"path = 'D:\\new\\proj\\CCP4_JOBS'")
+
+
+class PlanRebaseTest(TestCase):
+    """Classification of a real-shaped project tree."""
+
+    def setUp(self):
+        self.root = Path(mkdtemp())
+        self.old_root = "/old/place/MyProject"
+        make_project_tree(self.root, self.old_root)
+
+    def tearDown(self):
+        rmtree(self.root, ignore_errors=True)
+
+    def test_plan_selects_functional_files_only(self):
+        plan = plan_rebase(self.root, self.old_root, "/new/place/MyProject")
+        rewritten = {candidate.path.name for candidate in plan.rewrites}
+        self.assertEqual(
+            rewritten,
+            {"params.xml", "program.xml", "script.py", "scene_1.scene.xml"},
+        )
+
+    def test_provenance_is_skipped(self):
+        plan = plan_rebase(self.root, self.old_root, "/new/place/MyProject")
+        skipped = {path.name for path in plan.skipped_provenance}
+        self.assertIn("log.txt", skipped)
+        self.assertIn("stdout.txt", skipped)
+
+    def test_caches_are_listed_for_deletion(self):
+        plan = plan_rebase(self.root, self.old_root, "/new/place/MyProject")
+        caches = {path.name for path in plan.caches}
+        self.assertEqual(caches, {"report_xml.xml", "report.html"})
+
+    def test_binary_is_skipped(self):
+        plan = plan_rebase(self.root, self.old_root, "/new/place/MyProject")
+        self.assertIn("HKLOUT.mtz", {path.name for path in plan.skipped_binary})
+
+    def test_apply_rewrites_and_deletes(self):
+        new_root = "/new/place/MyProject"
+        plan = plan_rebase(self.root, self.old_root, new_root)
+        rewritten = apply_rebase(plan)
+
+        self.assertEqual(len(rewritten), 4)
+        job = self.root / "CCP4_JOBS" / "job_1"
+
+        params = (job / "params.xml").read_text()
+        self.assertIn(f"{new_root}/CCP4_JOBS/job_1/INTERRUPT", params)
+        self.assertNotIn(self.old_root, params)
+        # The portable half is untouched.
+        self.assertIn("<relPath>CCP4_JOBS/job_1</relPath>", params)
+
+        self.assertIn(new_root, (job / "script.py").read_text())
+        self.assertIn(new_root, (job / "scene_1.scene.xml").read_text())
+
+        # Provenance preserved verbatim.
+        self.assertIn(self.old_root, (job / "log.txt").read_text())
+        self.assertIn(self.old_root, (job / "stdout.txt").read_text())
+
+        # Caches gone, binary untouched.
+        self.assertFalse((job / "report_xml.xml").exists())
+        self.assertFalse((job / "report.html").exists())
+        self.assertIn(
+            self.old_root.encode(), (job / "HKLOUT.mtz").read_bytes()
+        )
+
+
+class StaleRootTest(TestCase):
+    """Detection of roots left behind by an earlier move or import."""
+
+    def setUp(self):
+        self.root = Path(mkdtemp())
+        self.old_root = "/Volumes/OldDrive/MyProject"
+        make_project_tree(self.root, self.old_root)
+
+    def tearDown(self):
+        rmtree(self.root, ignore_errors=True)
+
+    def test_finds_the_root_the_files_point_at(self):
+        found = find_stale_roots(self.root, str(self.root))
+        self.assertIn(self.old_root, found)
+        self.assertGreater(found[self.old_root], 0)
+
+    def test_current_root_is_not_reported(self):
+        make_project_tree(self.root / "nested", str(self.root / "nested"))
+        found = find_stale_roots(self.root / "nested", str(self.root / "nested"))
+        self.assertNotIn(str(self.root / "nested"), found)
+
+    def test_windows_root_is_recovered(self):
+        root = Path(mkdtemp())
+        try:
+            (root / "CCP4_JOBS").mkdir()
+            (root / "CCP4_JOBS" / "params.xml").write_text(
+                r"<p>C:\Data\Projects\Foo\CCP4_JOBS\job_1\XYZOUT.pdb</p>",
+                encoding="utf-8",
+            )
+            found = find_stale_roots(root, str(root))
+            self.assertIn(r"C:\Data\Projects\Foo", found)
+        finally:
+            rmtree(root, ignore_errors=True)
+
+    def test_nothing_reported_when_everything_is_relative(self):
+        root = Path(mkdtemp())
+        try:
+            (root / "CCP4_JOBS").mkdir()
+            (root / "CCP4_JOBS" / "params.xml").write_text(
+                "<p><relPath>CCP4_JOBS/job_1</relPath></p>", encoding="utf-8"
+            )
+            self.assertEqual(find_stale_roots(root, str(root)), {})
+        finally:
+            rmtree(root, ignore_errors=True)
+
+
+@override_settings(
+    CCP4I2_PROJECTS_DIR=Path(__file__).parent.parent / "CCP4I2_MOVE_TEST_DIR"
+)
+class MoveProjectTest(TestCase):
+    def setUp(self):
+        self.projects_dir = Path(settings.CCP4I2_PROJECTS_DIR)
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+        self.source = self.projects_dir / "MyProject"
+        self.source.mkdir()
+        make_project_tree(self.source, str(self.source))
+        self.project = Project.objects.create(
+            name="MyProject", directory=str(self.source)
+        )
+
+    def tearDown(self):
+        rmtree(self.projects_dir, ignore_errors=True)
+
+    def test_dry_run_changes_nothing(self):
+        destination = self.projects_dir / "Moved"
+        summary = dry_run_move(self.project, destination)
+
+        self.assertEqual(summary["destination"], str(destination))
+        self.assertEqual(len(summary["rewrites"]), 4)
+        self.assertTrue(self.source.is_dir())
+        self.assertFalse(destination.exists())
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.directory, str(self.source))
+
+    def test_move_relocates_and_rebases(self):
+        destination = self.projects_dir / "Moved"
+        summary = move_project(self.project, destination)
+
+        self.assertFalse(self.source.exists())
+        self.assertTrue(destination.is_dir())
+        self.assertEqual(summary["rewritten"], 4)
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.directory, str(destination))
+
+        params = (destination / "CCP4_JOBS" / "job_1" / "params.xml").read_text()
+        self.assertIn(str(destination), params)
+        self.assertNotIn(str(self.source), params)
+
+        # No journal left behind on success.
+        self.assertFalse((destination / JOURNAL_NAME).exists())
+
+    def test_move_refuses_existing_destination(self):
+        destination = self.projects_dir / "Occupied"
+        destination.mkdir()
+        with self.assertRaises(MoveProjectError):
+            move_project(self.project, destination)
+        self.assertTrue(self.source.is_dir())
+
+    def test_move_refuses_destination_inside_project(self):
+        with self.assertRaises(MoveProjectError):
+            move_project(self.project, self.source / "CCP4_JOBS" / "inner")
+
+    def test_move_refuses_while_a_job_is_running(self):
+        for number, status in (
+            ("1", Job.Status.RUNNING),
+            ("2", Job.Status.QUEUED),
+            ("3", Job.Status.RUNNING_REMOTELY),
+        ):
+            with self.subTest(status=status):
+                job = Job.objects.create(
+                    project=self.project,
+                    number=number,
+                    status=status,
+                    task_name="aimless",
+                )
+                with self.assertRaises(MoveProjectError) as caught:
+                    move_project(self.project, self.projects_dir / "Moved")
+                self.assertIn("running", str(caught.exception).lower())
+                self.assertTrue(self.source.is_dir())
+                job.delete()
+
+    def test_unrun_tasks_do_not_block_a_move(self):
+        """PENDING is a task being edited, not one that is doing anything."""
+        for number in ("12", "13", "14", "15", "17"):
+            Job.objects.create(
+                project=self.project,
+                number=number,
+                status=Job.Status.PENDING,
+                task_name="aimless",
+            )
+        destination = self.projects_dir / "Moved"
+
+        move_project(self.project, destination)
+
+        self.assertTrue(destination.is_dir())
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.directory, str(destination))
+
+    def test_finished_and_failed_jobs_do_not_block_a_move(self):
+        for number, status in (
+            ("1", Job.Status.FINISHED),
+            ("2", Job.Status.FAILED),
+            ("3", Job.Status.INTERRUPTED),
+            ("4", Job.Status.UNKNOWN),
+        ):
+            Job.objects.create(
+                project=self.project,
+                number=number,
+                status=status,
+                task_name="aimless",
+            )
+
+        move_project(self.project, self.projects_dir / "Moved")
+
+        self.assertTrue((self.projects_dir / "Moved").is_dir())
+
+    def test_repair_rewrites_without_moving(self):
+        """The renamed-mount case: directory intact, its old path stale."""
+        stale_root = "/Volumes/OldDriveName/MyProject"
+        params = self.source / "CCP4_JOBS" / "job_1" / "params.xml"
+        params.write_text(
+            f"<params><KILLFILEPATH>{stale_root}/INTERRUPT</KILLFILEPATH></params>\n",
+            encoding="utf-8",
+        )
+
+        summary = repair_project_paths(self.project, stale_root)
+
+        self.assertEqual(summary["rewritten"], 1)
+        self.assertIn(str(self.source), params.read_text())
+        self.assertNotIn(stale_root, params.read_text())
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.directory, str(self.source))
+
+    def test_move_reports_roots_it_could_not_know_about(self):
+        """A project moved twice still points at its first home; say so."""
+        params = self.source / "CCP4_JOBS" / "job_1" / "params.xml"
+        params.write_text(
+            "<params><f>/Volumes/FirstHome/MyProject/CCP4_JOBS/job_1/X.pdb</f></params>",
+            encoding="utf-8",
+        )
+        summary = move_project(self.project, self.projects_dir / "Moved")
+        self.assertIn("/Volumes/FirstHome/MyProject", summary["stale_roots"])
+
+    def test_directory_cannot_be_changed_through_the_serializer(self):
+        from ...api.serializers import ProjectSerializer
+
+        serializer = ProjectSerializer(
+            self.project,
+            data={"directory": str(self.projects_dir / "Elsewhere")},
+            partial=True,
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("directory", serializer.errors)
+
+    def test_serializer_still_accepts_an_unchanged_directory(self):
+        from ...api.serializers import ProjectSerializer
+
+        serializer = ProjectSerializer(
+            self.project,
+            data={"directory": self.project.directory, "description": "hello"},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_endpoints_plan_then_move(self):
+        """The REST surface, end to end: preview, move, then repair."""
+        from django.contrib.auth import get_user_model
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(get_user_model().objects.create(username="tester"))
+        destination = self.projects_dir / "Moved"
+
+        preview = client.post(
+            f"/api/ccp4i2/projects/{self.project.id}/move/",
+            {"directory": str(destination), "dry_run": True},
+            format="json",
+        )
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(len(preview.data["data"]["rewrites"]), 4)
+        self.assertTrue(self.source.is_dir())
+
+        moved = client.post(
+            f"/api/ccp4i2/projects/{self.project.id}/move/",
+            {"directory": str(destination)},
+            format="json",
+        )
+        self.assertEqual(moved.status_code, 200, moved.data)
+        self.assertEqual(moved.data["data"]["rewritten"], 4)
+        self.assertTrue(destination.is_dir())
+        self.assertFalse(self.source.exists())
+
+    def test_move_endpoint_reports_a_refusal_as_a_400(self):
+        from django.contrib.auth import get_user_model
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(get_user_model().objects.create(username="tester"))
+        occupied = self.projects_dir / "Occupied"
+        occupied.mkdir()
+
+        response = client.post(
+            f"/api/ccp4i2/projects/{self.project.id}/move/",
+            {"directory": str(occupied)},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue(self.source.is_dir())
+
+    def test_stale_roots_endpoint(self):
+        from django.contrib.auth import get_user_model
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(get_user_model().objects.create(username="tester"))
+        params = self.source / "CCP4_JOBS" / "job_1" / "params.xml"
+        params.write_text(
+            "<params><f>/Volumes/Gone/MyProject/CCP4_JOBS/job_1/X.pdb</f></params>",
+            encoding="utf-8",
+        )
+
+        response = client.get(
+            f"/api/ccp4i2/projects/{self.project.id}/stale_roots/"
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIn("/Volumes/Gone/MyProject", response.data["data"]["stale_roots"])
+
+    def test_repair_dry_run_changes_nothing(self):
+        stale_root = "/Volumes/OldDriveName/MyProject"
+        params = self.source / "CCP4_JOBS" / "job_1" / "params.xml"
+        params.write_text(
+            f"<params><KILLFILEPATH>{stale_root}/INTERRUPT</KILLFILEPATH></params>\n",
+            encoding="utf-8",
+        )
+
+        summary = repair_project_paths(self.project, stale_root, dry_run=True)
+
+        self.assertEqual(len(summary["rewrites"]), 1)
+        self.assertEqual(summary["rewritten"], 0)
+        self.assertIn(stale_root, params.read_text())

--- a/server/ccp4i2/tests/db/test_move_project.py
+++ b/server/ccp4i2/tests/db/test_move_project.py
@@ -12,11 +12,16 @@ from ...db.move_project import (
     JOURNAL_NAME,
     MoveProjectError,
     apply_rebase,
+    directory_is_missing,
     dry_run_move,
     find_stale_roots,
+    looks_like_a_project,
     move_project,
     path_variants,
     plan_rebase,
+    plan_root_rebase,
+    rebase_projects_root,
+    relocate_project,
     repair_project_paths,
     substitution_map,
 )
@@ -450,3 +455,213 @@ class MoveProjectTest(TestCase):
         self.assertEqual(len(summary["rewrites"]), 1)
         self.assertEqual(summary["rewritten"], 0)
         self.assertIn(stale_root, params.read_text())
+
+
+@override_settings(
+    CCP4I2_PROJECTS_DIR=Path(__file__).parent.parent / "CCP4I2_RELOCATE_TEST_DIR"
+)
+class RelocateProjectTest(TestCase):
+    """The database is intact; the directory is not where it says it is.
+
+    A renamed drive or a projects folder moved outside CCP4i2. Nothing needs
+    moving - the record needs correcting, and the paths inside rebasing.
+    """
+
+    def setUp(self):
+        self.projects_dir = Path(settings.CCP4I2_PROJECTS_DIR)
+        self.projects_dir.mkdir(parents=True, exist_ok=True)
+
+        # Where the project really is.
+        self.actual = self.projects_dir / "NewDriveName" / "MyProject"
+        self.actual.mkdir(parents=True)
+        self.stale = "/Volumes/OldDriveName/MyProject"
+        make_project_tree(self.actual, self.stale)
+
+        # What the database still believes.
+        self.project = Project.objects.create(
+            name="MyProject", directory=self.stale
+        )
+
+    def tearDown(self):
+        rmtree(self.projects_dir, ignore_errors=True)
+
+    def test_missing_directory_is_detected(self):
+        self.assertTrue(directory_is_missing(self.project))
+
+    def test_relocate_repoints_and_rebases(self):
+        summary = relocate_project(self.project, self.actual)
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.directory, str(self.actual))
+        self.assertTrue(summary["directory_was_missing"])
+        self.assertEqual(summary["rewritten"], 4)
+
+        params = (self.actual / "CCP4_JOBS" / "job_1" / "params.xml").read_text()
+        self.assertIn(str(self.actual), params)
+        self.assertNotIn(self.stale, params)
+        self.assertEqual(summary["stale_roots"], {})
+
+    def test_relocate_moves_nothing(self):
+        relocate_project(self.project, self.actual)
+        self.assertTrue((self.actual / "CCP4_JOBS" / "job_1").is_dir())
+
+    def test_dry_run_changes_nothing(self):
+        summary = relocate_project(self.project, self.actual, dry_run=True)
+
+        self.assertEqual(len(summary["rewrites"]), 4)
+        self.assertEqual(summary["rewritten"], 0)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.directory, self.stale)
+
+    def test_refuses_a_folder_that_is_not_a_project(self):
+        elsewhere = self.projects_dir / "Downloads"
+        elsewhere.mkdir()
+        with self.assertRaises(MoveProjectError) as caught:
+            relocate_project(self.project, elsewhere)
+        self.assertIn("does not look like", str(caught.exception))
+
+    def test_refuses_a_directory_another_project_claims(self):
+        Project.objects.create(name="Other", directory=str(self.actual))
+        with self.assertRaises(MoveProjectError):
+            relocate_project(self.project, self.actual)
+
+    def test_looks_like_a_project(self):
+        self.assertTrue(looks_like_a_project(self.actual))
+        self.assertFalse(looks_like_a_project(self.projects_dir))
+
+    def test_repair_points_at_relocate_when_the_directory_is_gone(self):
+        """The message must not send the user somewhere they cannot go."""
+        with self.assertRaises(MoveProjectError) as caught:
+            repair_project_paths(self.project, "/somewhere/else")
+        self.assertIn("re-point", str(caught.exception).lower())
+
+
+@override_settings(
+    CCP4I2_PROJECTS_DIR=Path(__file__).parent.parent / "CCP4I2_ROOT_REBASE_TEST_DIR"
+)
+class RebaseProjectsRootTest(TestCase):
+    """One drive rename, every project stale at once."""
+
+    def setUp(self):
+        self.base = Path(settings.CCP4I2_PROJECTS_DIR)
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.old_root = "/Volumes/OldName/CCP4I2_PROJECTS"
+        self.new_root = self.base / "NewName" / "CCP4I2_PROJECTS"
+        self.new_root.mkdir(parents=True)
+
+        self.projects = []
+        for name in ("Alpha", "Beta", "Gamma"):
+            directory = self.new_root / name
+            directory.mkdir()
+            make_project_tree(directory, f"{self.old_root}/{name}")
+            self.projects.append(
+                Project.objects.create(
+                    name=name, directory=f"{self.old_root}/{name}"
+                )
+            )
+        # One project that was never on the renamed drive.
+        self.untouched_dir = self.base / "Local" / "Delta"
+        self.untouched_dir.mkdir(parents=True)
+        make_project_tree(self.untouched_dir, str(self.untouched_dir))
+        self.untouched = Project.objects.create(
+            name="Delta", directory=str(self.untouched_dir)
+        )
+
+    def tearDown(self):
+        rmtree(self.base, ignore_errors=True)
+
+    def test_plan_maps_projects_onto_the_new_root(self):
+        plan = plan_root_rebase(self.old_root, str(self.new_root))
+
+        self.assertEqual({e["name"] for e in plan["matched"]}, {"Alpha", "Beta", "Gamma"})
+        self.assertEqual(plan["missing"], [])
+        self.assertEqual({e["name"] for e in plan["unaffected"]}, {"Delta"})
+
+    def test_plan_reports_projects_it_cannot_find(self):
+        rmtree(self.new_root / "Beta")
+        plan = plan_root_rebase(self.old_root, str(self.new_root))
+
+        self.assertEqual({e["name"] for e in plan["matched"]}, {"Alpha", "Gamma"})
+        self.assertEqual([e["name"] for e in plan["missing"]], ["Beta"])
+        self.assertEqual(plan["missing"][0]["reason"], "not found")
+
+    def test_dry_run_changes_nothing(self):
+        summary = rebase_projects_root(
+            self.old_root, str(self.new_root), dry_run=True
+        )
+        self.assertEqual(summary["relocated"], [])
+        for project in self.projects:
+            project.refresh_from_db()
+            self.assertTrue(project.directory.startswith(self.old_root))
+
+    def test_all_three_projects_are_repointed(self):
+        summary = rebase_projects_root(self.old_root, str(self.new_root))
+
+        self.assertEqual(len(summary["relocated"]), 3)
+        self.assertEqual(summary["failed"], [])
+        for project in self.projects:
+            project.refresh_from_db()
+            self.assertEqual(
+                project.directory, str(self.new_root / project.name)
+            )
+            self.assertFalse(directory_is_missing(project))
+
+    def test_unrelated_project_is_left_alone(self):
+        rebase_projects_root(self.old_root, str(self.new_root))
+        self.untouched.refresh_from_db()
+        self.assertEqual(self.untouched.directory, str(self.untouched_dir))
+
+    def test_a_missing_project_does_not_abandon_the_others(self):
+        rmtree(self.new_root / "Beta")
+        summary = rebase_projects_root(self.old_root, str(self.new_root))
+
+        self.assertEqual(len(summary["relocated"]), 2)
+        self.assertEqual([e["name"] for e in summary["missing"]], ["Beta"])
+        beta = Project.objects.get(name="Beta")
+        self.assertTrue(directory_is_missing(beta))
+
+    def test_paths_inside_the_files_are_rebased_too(self):
+        rebase_projects_root(self.old_root, str(self.new_root))
+        params = (
+            self.new_root / "Alpha" / "CCP4_JOBS" / "job_1" / "params.xml"
+        ).read_text()
+        self.assertIn(str(self.new_root / "Alpha"), params)
+        self.assertNotIn(self.old_root, params)
+
+    def test_endpoints(self):
+        from django.contrib.auth import get_user_model
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        client.force_authenticate(get_user_model().objects.create(username="tester"))
+
+        broken = client.get("/api/ccp4i2/projects/missing_directories/")
+        self.assertEqual(broken.status_code, 200, broken.data)
+        self.assertEqual(broken.data["data"]["count"], 3)
+
+        preview = client.post(
+            "/api/ccp4i2/projects/rebase_root/",
+            {
+                "old_root": self.old_root,
+                "new_root": str(self.new_root),
+                "dry_run": True,
+            },
+            format="json",
+        )
+        self.assertEqual(preview.status_code, 200, preview.data)
+        self.assertEqual(len(preview.data["data"]["matched"]), 3)
+
+        applied = client.post(
+            "/api/ccp4i2/projects/rebase_root/",
+            {
+                "old_root": self.old_root,
+                "new_root": str(self.new_root),
+                "update_preference": False,
+            },
+            format="json",
+        )
+        self.assertEqual(applied.status_code, 200, applied.data)
+        self.assertEqual(len(applied.data["data"]["relocated"]), 3)
+
+        after = client.get("/api/ccp4i2/projects/missing_directories/")
+        self.assertEqual(after.data["data"]["count"], 0)

--- a/server/ccp4i2/wrappers/aimless/script/aimless.py
+++ b/server/ccp4i2/wrappers/aimless/script/aimless.py
@@ -406,8 +406,16 @@ class aimless(CPluginScript):
 
         print("outputOptions:", self.container.outputData.HKLOUT_BASENAME)        
 
+        # HKLOUT_BASENAME is stored as a bare basename, never an absolute path, so
+        # that params.xml stays portable when the project is moved on disk. Values
+        # inherited from older jobs may be absolute - strip them back to a basename.
         if not self.container.outputData.HKLOUT_BASENAME.isSet():
-            self.container.outputData.HKLOUT_BASENAME = os.path.join(self.getWorkDirectory(),"HKLOUT")
+            self.container.outputData.HKLOUT_BASENAME = "HKLOUT"
+        else:
+            self.container.outputData.HKLOUT_BASENAME = os.path.basename(
+                str(self.container.outputData.HKLOUT_BASENAME))
+        hkloutBase = os.path.join(self.getWorkDirectory(),
+                                  str(self.container.outputData.HKLOUT_BASENAME))
         par = self.container.controlParameters
 
         # par.OUTPUT_MODE is a CList of CStrings, each type only occurs once
@@ -422,22 +430,22 @@ class aimless(CPluginScript):
         for mode in par.OUTPUT_MODE:
             if mode == 'MERGED':
                 self.appendCommandScript("OUTPUT MTZ MERGED")
-                self.appendCommandLine(['HKLOUT',self.container.outputData.HKLOUT_BASENAME + '.mtz'])
+                self.appendCommandLine(['HKLOUT', hkloutBase + '.mtz'])
                 commandlinehklout = True
             elif mode == 'UNMERGED':
                 self.appendCommandScript("OUTPUT MTZ UNMERGED")
                 if not commandlinehklout:  # not needed if already done
-                    self.appendCommandLine(['HKLOUT',self.container.outputData.HKLOUT_BASENAME + '.mtz'])
+                    self.appendCommandLine(['HKLOUT', hkloutBase + '.mtz'])
                 unmergedout = True
             elif mode == 'ORIGINAL':
                 if unmergedout:  # only relevant for unmerged output
                     self.appendCommandScript("OUTPUT ORIGINAL")
             elif mode == 'SP_MERGED':
                 self.appendCommandScript("OUTPUT SCALEPACK MERGED")
-                self.appendCommandLine(['HKLOUT',self.container.outputData.HKLOUT_BASENAME + '.sca'])
+                self.appendCommandLine(['HKLOUT', hkloutBase + '.sca'])
             elif mode == 'SP_UNMERGED':
                 self.appendCommandScript("OUTPUT SCALEPACK UNMERGED")
-                self.appendCommandLine(['HKLOUT',self.container.outputData.HKLOUT_BASENAME + '.sca'])
+                self.appendCommandLine(['HKLOUT', hkloutBase + '.sca'])
             elif mode == 'NONE':
                 self.appendCommandScript("OUTPUT NONE")
         


### PR DESCRIPTION
Addresses a user observation:

> Missing feature to move projects on disk. This feature is in Qt-i2, which will move your project but leave it in a state where some jobs will be broken due to the use of absolute paths. Having the ability to move projects would be useful. There was a user case where a mounted drive name got changed outside of the user's control and absolute paths in the project had to be updated.

## Where the absolute paths come from

The data model is nearly location-independent already. `CDataFile` serialises as project UUID + `relPath` + `baseName` + `dbFileId`, and `Project.directory` is the only absolute path in the database — `Job.directory` and `File.path` are both derived from it. So a move is, to a first approximation, `mv` plus one `UPDATE`.

The breakage is leakage into files *inside* the project. Measured across twelve real projects:

| File | Written by | Re-read? |
|---|---|---|
| `program.xml` | the CCP4 program itself (aimless writes `<MTZmergedfilename>`) | by report classes |
| `params.xml`, `input_params.xml` | base serialiser — but only plugin-set scalars are absolute | clone, re-run |
| `*.scene.xml` | ccp4mg | yes — breaks the 3D view |
| `script.py`, `state*.py`, `*.scm` | Coot wrappers | yes — breaks Coot relaunch |
| `job.ccp4db.xml`, `DATABASE.db.xml` | legacy Qt-i2 | on import |
| `report.html`, `report_xml.xml` | report generator | cached, regenerable |
| `log.txt`, `stdout.txt`, `com.txt`, `*.log` | provenance | no |

## Plugin-level emitters, fixed at source

Three places wrote absolute paths into `params.xml`, from where they propagated into every downstream job that inherited the parameter:

- **`phaser_pipeline`** no longer sets `KILLFILEPATH`. Each phaser wrapper already defaults to `<its own work directory>/INTERRUPT`, which is what `CPluginScript.isInterrupted()` watches — so the two mechanisms now agree, where before the pipeline pointed phaser at a different directory from the base class.
- **`aimless`** stores `HKLOUT_BASENAME` as a bare basename and joins it with the work directory at point of use. This also fixes a real bug: a cloned aimless job inherited the absolute value and wrote its output into the *original* job's directory.
- **`phaser_EP_AUTO`** built its `- original hand` annotation from `str(MAPOUT[0])` — the file object, whose `__str__` is its full path — instead of `str(MAPOUT[0].annotation)`.

Nothing can be done at source about `program.xml`: the program writes it.

## `db/move_project.py`

- **Same filesystem → `os.rename`.** Atomic, instant, and no second copy of what can be a multi-gigabyte project (there is a 4.1 GB project on the machine this was developed on). **Cross-device → `copytree`**, with the source removed only after the database commit, so an interrupted move always leaves one complete tree.
- **Rebase** every text file that is not provenance, not a regenerable cache and not binary. Binaries are identified by sniffing for a NUL byte, not by trusting the extension.
- **Delete** `report_xml.xml` / `report.html` — cached by `get_job_report_xml` and regenerated on demand, so deleting is cheaper and safer than rewriting.
- **Leave** logs, stdout/stderr and command scripts alone. They are the record of what actually ran; rewriting them would falsify it.
- Any failure after the bytes move rolls back — rewrites inverted from a manifest, directory renamed back, or the partial cross-device copy discarded. A `.ccp4i2-move.json` journal marks a tree left half-rebased by a crash.

`find_stale_roots` reports locations that an earlier move or import left behind, which a single old→new substitution cannot know about. That is also the renamed-mount case from the user report, and `repair_project_paths` rewrites any one of them onto the current directory in place, moving nothing.

## Surface

| Endpoint | Purpose |
|---|---|
| `POST /projects/{id}/move/` | `{directory, dry_run?}` |
| `POST /projects/{id}/repair_paths/` | `{old_directory, dry_run?}` |
| `GET /projects/{id}/stale_roots/` | roots the project still refers to |

`PATCH`ing `Project.directory` is now rejected by the serializer — it would leave the record pointing at a directory still sitting somewhere else.

The desktop dialog takes a parent folder and a folder name with a live preview of the resulting path, runs the dry run automatically, and offers a Repair button per stale root. It is gated on Electron: neither the directory being moved nor a native folder picker exists in the browser build.

## Testing

- 29 new tests in `tests/db/test_move_project.py`, all passing. Wider suites match their pre-change baselines exactly (`tests/db`: 6 failures / 24 errors before and after, all pre-existing in this environment; `tests/unit`: 17 failed / 735 passed both ways). `tsc` clean; the Electron main bundle builds.
- Exercised on a real 26 MB `BetaBlip`: move → repair round trip rewrote 29 files / 169 references, with binary checksums bit-identical before and after.

## Not done

- **`aimless` and `phaser` were not exercised end-to-end.** The CCP4 tree used here has no generated `ccp4.setup-sh`, so the i2run tests could not run. The aimless change is contained (`HKLOUT_BASENAME` is a `CString` read only within `aimless.py`) but is worth a run against a real CCP4 setup before merge.
- **Zip import has the same bug and is not fixed.** `import_ccp4_project_zip` takes a `relocate_path` and updates `Project.directory` but does not rebase the paths inside the extracted files. Wiring the rebase in is complicated by job renumbering — an imported `job_3` may land as `job_7` — so the substitution list would have to be built from `import_i2xml_result["job_map"]` as well as the root. Noted in `docs/MOVING_PROJECTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
