### PR TITLE
Write an on-disk record of each project, so the database can be rebuilt

### DIFF
--- a/client/main/ccp4i2-django-server.ts
+++ b/client/main/ccp4i2-django-server.ts
@@ -174,6 +174,25 @@ export async function startDjangoServer(
     }
   }
 
+  // Write the on-disk recovery snapshot for any project that lacks one.
+  //
+  // Snapshots are normally kept current by database signals, but a project
+  // that predates the mechanism never triggers one -- and a finished, dormant
+  // project is both the kind most worth protecting and the kind nothing will
+  // ever touch again. --missing-only makes this a no-op once every project is
+  // covered, so it is cheap to run on every launch.
+  //
+  // Never fatal: failing to write a safety net must not stop the app starting.
+  try {
+    execSync(`"${PYTHON_PATH}" -m django snapshot_projects`, {
+      env: pythonEnv,
+      stdio: "inherit",
+      ...(serverCwd && { cwd: serverCwd }),
+    });
+  } catch (error) {
+    console.error(`🐍 Could not write project recovery snapshots:`, error);
+  }
+
   // Setup logging for production
   let logStream: fs.WriteStream | null = null;
   if (!isDev) {

--- a/docs/PROJECT_RECOVERY.md
+++ b/docs/PROJECT_RECOVERY.md
@@ -1,0 +1,145 @@
+# Rebuilding the database from what is on disk
+
+Everything CCP4i2 knows about a project's *files* can be recovered from the
+project directory: the job directories are there, `params.xml` records what each
+job ran with, the outputs are where they were written.
+
+Everything the *user* wrote cannot. Annotations, job titles, comments, the
+evaluation of one run as best and another as rejected, tags, the project
+description — none of it has an on-disk artefact. It lives only in
+`db.sqlite3`, and if that is lost or corrupted it is gone, with no way to
+reconstruct it from anything.
+
+Qt-era CCP4i2 knew this and wrote a per-project `DATABASE.db.xml` as jobs
+started and finished, plus a list of known project directories outside the
+database. The Django app had neither. This is that, restored.
+
+## What gets written, and where
+
+| File | Where | Holds |
+|---|---|---|
+| `DATABASE.db.xml` | project directory | everything the database knows about that project |
+| `project_directories.json` | `~/.ccp4i2-django/` | where every known project is |
+
+The registry matters as much as the snapshots. A snapshot inside a project
+directory is only useful if something can find the project directory in the
+first place, and with the database gone nothing else knows where the projects
+are.
+
+`DATABASE.db.xml` is the format the project export already produces and the
+project import already reads — the one project zips carry and legacy project
+directories already contain. Reusing it means one recovery path rather than
+two. It also keys on UUIDs rather than on primary keys or on the current shape
+of the models, which is what a file written to be read back *after something
+went wrong* needs: primary keys are meaningless once the database has been
+rebuilt, and a Django fixture would refuse to load after a migration changed
+the models it was written against.
+
+## When it gets written
+
+Driven by database signals rather than by calls at each endpoint, so every
+write path is covered — REST, `i2run`, management commands, the job runner —
+including ones that do not exist yet.
+
+The rule is: anything user-authored that exists only in the database.
+
+| Model | Watched |
+|---|---|
+| `Job` | `status`, `title`, `comments`, `evaluation` |
+| `File` | `annotation`, `sub_type`, `content` |
+| `Project` | `name`, `description`, `directory`, `last_job_number` |
+| `ProjectTag` | tag text and which projects carry it |
+
+Two deliberate exclusions:
+
+- **Subjob status changes.** A pipeline runs dozens of subjobs; the top-level
+  job reaching a terminal state writes a snapshot covering them all. A comment
+  or evaluation on a subjob *is* captured — status churn is noise, what the
+  user wrote is not.
+- **File creation.** The gleaner drops many files as a job finishes, and that
+  job's own transition covers them. A later edit — someone annotating a result
+  — is what triggers a write.
+
+DRF's `partial_update` saves without `update_fields`, so which fields actually
+changed is worked out by comparing against the stored row in `pre_save`.
+
+## Coalescing, and why there is no timer
+
+One request can touch many rows. Snapshots are registered with
+`transaction.on_commit` and de-duplicated per transaction, so a request that
+changes thirty files still writes once.
+
+That is coalescing **by transaction, not by wall-clock**. There is deliberately
+no timer anywhere here, because there is nowhere for one to live: the desktop
+app runs uvicorn with two workers, and `i2run` and the job runner are processes
+that exit as soon as they are done. An in-process timer would be duplicated
+across the workers and would never fire at all in the CLI.
+
+The de-duplication set is Django's own `run_on_commit` list rather than one
+kept alongside it, because Django clears that list on rollback as well as on
+commit. A separate set would keep an entry for a transaction that rolled back,
+and the next change to that project would be silently skipped — a safety net
+with a hole in it that nothing would ever report.
+
+Writes are atomic (temp file, `os.replace`), so two workers writing at once
+cannot produce a partial file. Both read the same database, so last-writer-wins
+is harmless.
+
+Failing to write a snapshot never propagates. A job must not be reported as
+failed because its directory was read-only: a safety net that breaks the thing
+it protects is worse than no safety net.
+
+## Retrofitting projects that predate this
+
+Signals only fire when something changes, and a finished, dormant project is
+both the kind most worth protecting and the kind nothing will ever touch again.
+So there has to be a way to write them all out:
+
+```bash
+ccp4-python manage.py snapshot_projects --status   # who is protected
+ccp4-python manage.py snapshot_projects            # write the missing ones
+ccp4-python manage.py snapshot_projects --all      # rewrite everything
+```
+
+The desktop app runs `snapshot_projects` at launch, just after `migrate`. In
+its default missing-only mode it is a no-op once every project is covered, so
+it is cheap to run every time, and it is never fatal.
+
+### Legacy snapshots are preserved, not overwritten
+
+A project directory carried over from Qt-era CCP4i2 already has a
+`DATABASE.db.xml`, and it may describe jobs or annotations that were never
+imported into this database. The first time one is about to be overwritten, the
+original is copied to `DATABASE.db.xml.pre-ccp4i2-django` — once, so our own
+output can never creep over the real backup.
+
+Snapshots we wrote are recognised by a `<generator>ccp4i2-django</generator>`
+element in the header. Recognition matches the whole element, not the marker on
+its own: the first real project this was tried on referenced a directory called
+`ccp4i2-djangodbapi`, and a substring search mistook it for one of ours.
+
+## Suspending
+
+Bulk work — importing a project zip, migrating a legacy database — would
+otherwise snapshot after every row:
+
+```python
+from ccp4i2.db import project_snapshot
+
+with project_snapshot.suspended():
+    ...  # hundreds of rows
+project_snapshot.write_snapshot(project)
+```
+
+`import_ccp4_project_zip` already does this, snapshotting once at the end when
+the files are actually on disk. Setting `CCP4I2_DISABLE_PROJECT_SNAPSHOT=1`
+disables writing entirely.
+
+## What this does not do
+
+It makes the database *rebuildable*; it does not rebuild it. Reading the
+snapshots and the registry back into a fresh database, and reporting on what
+could and could not be recovered, is a separate piece of work — as is inferring
+a project from its directory when there is no snapshot at all, which is
+necessarily lossy. See the notes on `utils/reconstructDBFromXML.py`, whose own
+TODO header is an honest account of how far inference gets you.

--- a/server/ccp4i2/db/import_i2xml.py
+++ b/server/ccp4i2/db/import_i2xml.py
@@ -61,6 +61,7 @@ from ..api.serializers import (
     JobFloatValueSerializer,
     ProjectTagSerializer,
 )
+from . import project_snapshot
 from .models import (
     Project,
     Job,
@@ -103,7 +104,13 @@ def import_ccp4_project_zip(zip_path: Path, relocate_path: Path = None):
     with zipfile.ZipFile(zip_path, "r") as zip_archive:
         with zip_archive.open("DATABASE.db.xml", "r") as database_file:
             root_node = ET.parse(database_file).getroot()
-            import_i2xml_result = import_i2xml(root_node, relocate_path=relocate_path)
+            # An import creates hundreds of rows; snapshotting after each one
+            # would be pointless churn, and the project directory does not even
+            # exist yet. One snapshot at the end covers the lot.
+            with project_snapshot.suspended():
+                import_i2xml_result = import_i2xml(
+                    root_node, relocate_path=relocate_path
+                )
             # print(import_i2xml_result)
             all_archive_files = zip_archive.namelist()
             this_project_node = root_node.findall("ccp4i2_header/projectId")
@@ -153,6 +160,11 @@ def import_ccp4_project_zip(zip_path: Path, relocate_path: Path = None):
                         with zip_archive.open(src, "r") as src_file:
                             with open(destination, "wb") as destination_file:
                                 destination_file.write(src_file.read())
+
+            # Now the files are on disk, record the project so a lost database
+            # can be rebuilt from what was just imported.
+            project_snapshot.write_snapshot(this_project)
+            project_snapshot.update_registry()
 
 
 def renumber_top_job(job_node: ET.Element, root_node: ET.Element):

--- a/server/ccp4i2/db/management/commands/snapshot_projects.py
+++ b/server/ccp4i2/db/management/commands/snapshot_projects.py
@@ -1,0 +1,70 @@
+"""Write the on-disk recovery snapshot for projects that have none.
+
+Projects created before snapshots existed never trigger one: a finished,
+dormant project is both the kind you most want protected and the kind nothing
+will touch again. This retrofits them.
+
+Cheap enough to run on every start-up in its default ``--missing-only`` mode,
+which skips projects already covered.
+"""
+
+from django.core.management.base import BaseCommand
+
+from ...project_snapshot import snapshot_all_projects, snapshot_status
+
+
+class Command(BaseCommand):
+    help = "Write DATABASE.db.xml recovery snapshots for projects on disk."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Rewrite every project's snapshot, not just the missing ones.",
+        )
+        parser.add_argument(
+            "--status",
+            action="store_true",
+            help="Report which projects are protected, and write nothing.",
+        )
+
+    def handle(self, *args, **options):
+        if options["status"]:
+            self._report_status()
+            return
+
+        result = snapshot_all_projects(missing_only=not options["all"])
+
+        self.stdout.write(
+            f"Wrote {result['written']} snapshot(s); "
+            f"{result['already_current']} already current, "
+            f"{result['skipped']} could not be written."
+        )
+
+    def _report_status(self):
+        rows = snapshot_status()
+        if not rows:
+            self.stdout.write("No projects.")
+            return
+
+        width = max(len(row["name"]) for row in rows)
+        for row in rows:
+            if not row["directory_exists"]:
+                state = "directory missing"
+            elif row["has_snapshot"]:
+                state = "protected"
+            elif row["foreign_snapshot"]:
+                state = "has a snapshot from another installation"
+            else:
+                state = "NOT PROTECTED"
+            self.stdout.write(f"  {row['name']:<{width}}  {state}")
+
+        unprotected = sum(
+            1 for row in rows if row["directory_exists"] and not row["has_snapshot"]
+        )
+        self.stdout.write("")
+        self.stdout.write(
+            f"{len(rows) - unprotected} of {len(rows)} project(s) protected."
+        )
+        if unprotected:
+            self.stdout.write("Run without --status to write the missing snapshots.")

--- a/server/ccp4i2/db/project_snapshot.py
+++ b/server/ccp4i2/db/project_snapshot.py
@@ -1,0 +1,369 @@
+"""Keep an on-disk record of each project, so the database can be rebuilt.
+
+Everything CCP4i2 knows about a project's *files* is recoverable from the
+project directory: job directories, ``params.xml``, the files themselves. What
+is not recoverable is everything the user typed. Annotations, job titles and
+comments, evaluations of good and rejected, tags, the project description --
+none of that has an on-disk artefact. It lives only in ``db.sqlite3``, and if
+that is lost or corrupted it is gone.
+
+The Qt-era CCP4i2 wrote a per-project ``DATABASE.db.xml`` as jobs started and
+finished, and kept a list of known project directories outside the database, so
+a lost database could be reconstructed. The Django app has had neither. This
+module restores both.
+
+The snapshot is the same format the project export already produces and the
+project import already reads -- the interchange format that project zips carry
+and that legacy project directories on disk already contain. Reusing it means
+one recovery path rather than two, and it keys on UUIDs rather than on primary
+keys or on the current shape of the models, which is what a file written to be
+read back after something went wrong needs.
+
+Writing is driven by signals rather than by calls at each endpoint, so it
+catches every write path -- REST, i2run, management commands, the job runner --
+including ones that do not exist yet.
+
+**On coalescing.** A single request can touch many rows: saving a task writes a
+dozen files, a finishing job writes its outputs. Snapshots are therefore
+registered with ``transaction.on_commit`` and de-duplicated per transaction, so
+one request produces one write however much it changed. That is coalescing by
+transaction, not by wall-clock: there is deliberately no timer anywhere here.
+The desktop app runs uvicorn with two workers and the CLI runs in processes that
+exit immediately, so there is no long-lived process for a timer to live in, and
+an in-process one would be either duplicated or never fire.
+"""
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, List, Optional
+from xml.etree import ElementTree as ET
+
+from django.db import transaction
+
+from .export_project import generate_project_xml_tree
+from .models import Project
+
+logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+
+#: Written at the root of each project directory. The name the export and the
+#: import already agree on, and the one legacy project directories carry.
+SNAPSHOT_NAME = "DATABASE.db.xml"
+
+#: Where a snapshot we did not write is set aside before being replaced.
+PRESERVED_NAME = "DATABASE.db.xml.pre-ccp4i2-django"
+
+#: Stamped into the header, so a later run can tell our snapshots from one a
+#: Qt-era CCP4i2 left in the project directory.
+GENERATOR_MARK = "ccp4i2-django"
+
+#: The element as it appears in the file. Recognition matches this rather than
+#: the marker alone, which occurs in ordinary directory paths.
+GENERATOR_ELEMENT = f"<generator>{GENERATOR_MARK}</generator>"
+
+#: The header is the first thing in the file; no need to read further.
+GENERATOR_SEARCH_BYTES = 8192
+
+#: A list of every project directory known to this installation, kept outside
+#: the database so that a lost database can be told where to look.
+REGISTRY_NAME = "project_directories.json"
+
+#: Set to disable snapshot writing entirely -- for bulk imports, migrations and
+#: tests that would otherwise snapshot after every row.
+DISABLE_ENV = "CCP4I2_DISABLE_PROJECT_SNAPSHOT"
+
+
+_state = threading.local()
+
+
+@contextmanager
+def suspended():
+    """Suspend snapshot writing for the duration of the block.
+
+    For bulk work -- importing a project zip, migrating a legacy database --
+    where the caller will snapshot once at the end rather than after every row.
+    """
+    previous = getattr(_state, "suspended", False)
+    _state.suspended = True
+    try:
+        yield
+    finally:
+        _state.suspended = previous
+
+
+def is_enabled() -> bool:
+    if getattr(_state, "suspended", False):
+        return False
+    return os.environ.get(DISABLE_ENV, "").lower() not in ("1", "true", "yes")
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+def snapshot_path(project: Project) -> Path:
+    return Path(project.directory) / SNAPSHOT_NAME
+
+
+def write_snapshot(project: Project) -> Optional[Path]:
+    """Write ``project``'s snapshot, atomically. Returns the path, or None.
+
+    Never raises. A snapshot is a safety net: failing to write one must not
+    fail the operation that triggered it, and a job that has just finished
+    should not be reported as failed because its directory is read-only.
+    """
+    directory = Path(project.directory)
+    if not directory.is_dir():
+        logger.debug(
+            "Not snapshotting project '%s': %s does not exist", project.name, directory
+        )
+        return None
+
+    _preserve_foreign_snapshot(directory)
+
+    try:
+        root = generate_project_xml_tree(project)
+        header = root.find("ccp4i2_header")
+        if header is not None:
+            ET.SubElement(header, "generator").text = GENERATOR_MARK
+        ET.indent(root, space="  ")
+        payload = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+        path = _atomic_write_bytes(directory, SNAPSHOT_NAME, payload)
+        logger.debug("Wrote project snapshot %s (%d bytes)", path, len(payload))
+        return path
+    except Exception as err:
+        logger.warning(
+            "Could not write snapshot for project '%s': %s", project.name, err
+        )
+        return None
+
+
+def _preserve_foreign_snapshot(directory: Path) -> None:
+    """Keep a one-time copy of a snapshot this installation did not write.
+
+    A project directory carried over from Qt-era CCP4i2 already has a
+    ``DATABASE.db.xml``, and it may describe jobs or annotations that were
+    never imported into this database. Overwriting it would destroy the only
+    remaining record of them. So the first time we are about to write over a
+    snapshot we did not author, the original is set aside.
+
+    One-time by construction: once the backup exists it is never touched again,
+    so this cannot creep over the real backup with our own output.
+    """
+    existing = directory / SNAPSHOT_NAME
+    backup = directory / PRESERVED_NAME
+    if not existing.is_file() or backup.exists():
+        return
+    try:
+        if _was_written_here(existing):
+            return
+        shutil.copy2(existing, backup)
+        logger.info("Preserved the pre-existing %s as %s", existing, backup.name)
+    except OSError as err:
+        logger.warning("Could not preserve %s: %s", existing, err)
+
+
+def _was_written_here(path: Path) -> bool:
+    """True if this module wrote ``path`` (it stamps a generator element).
+
+    Matches the whole element, not the marker on its own. A bare substring
+    search finds the marker inside any path that happens to contain it -- and
+    real project directories do: the first project this was tried on referenced
+    ``/Users/.../ccp4i2-djangodbapi/demo_data``, and was consequently mistaken
+    for one of ours and would have been overwritten without being preserved.
+    """
+    try:
+        with open(path, "rb") as stream:
+            head = stream.read(GENERATOR_SEARCH_BYTES)
+    except OSError:
+        return False
+    return GENERATOR_ELEMENT.encode("utf-8") in head
+
+
+def _atomic_write_bytes(directory: Path, name: str, payload: bytes) -> Path:
+    """Write via a temp file and os.replace, so a reader never sees a partial.
+
+    The desktop app runs two uvicorn workers, so two processes can write the
+    same snapshot at once. Both read the same database, so their content agrees
+    and last-writer-wins is harmless -- but a half-written file would not be.
+    """
+    target = directory / name
+    handle, temp_name = tempfile.mkstemp(dir=str(directory), prefix=f".{name}-")
+    try:
+        with os.fdopen(handle, "wb") as stream:
+            stream.write(payload)
+        os.replace(temp_name, target)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+    return target
+
+
+def _already_scheduled(project_pk) -> bool:
+    """True when this transaction has a snapshot pending for ``project_pk``.
+
+    The pending set is Django's own ``run_on_commit`` list rather than one kept
+    alongside it. That matters: Django clears that list on rollback as well as
+    on commit, so the de-duplication state lives exactly as long as the
+    transaction does. A separate set would keep an entry for a transaction that
+    rolled back, and the next change to that project would be silently skipped
+    -- a safety net with a hole in it that nothing would ever report.
+
+    In autocommit there is no pending list, so every call schedules its own
+    write, which is correct: each save is its own transaction.
+    """
+    for entry in transaction.get_connection().run_on_commit:
+        callback = entry[1]
+        if getattr(callback, "snapshot_project_pk", None) == project_pk:
+            return True
+    return False
+
+
+def schedule_snapshot(project: Optional[Project]) -> None:
+    """Arrange for ``project`` to be snapshotted when this transaction commits.
+
+    Repeated calls within one transaction collapse to a single write, so a
+    request that touches thirty files still writes once.
+    """
+    if project is None or not is_enabled():
+        return
+
+    project_pk = project.pk
+    if _already_scheduled(project_pk):
+        return
+
+    def run():
+        # Re-read: the instance that triggered this may be stale by commit time,
+        # and may have been deleted altogether.
+        current = Project.objects.filter(pk=project_pk).first()
+        if current is not None:
+            write_snapshot(current)
+        update_registry()
+
+    run.snapshot_project_pk = project_pk
+    transaction.on_commit(run)
+
+
+# ---------------------------------------------------------------------------
+# The registry of known project directories
+# ---------------------------------------------------------------------------
+
+
+def registry_path() -> Path:
+    from ..config.preferences import ccp4i2_home
+
+    return ccp4i2_home() / REGISTRY_NAME
+
+
+def update_registry() -> Optional[Path]:
+    """Rewrite the list of known project directories. Never raises.
+
+    A snapshot inside a project directory is only useful if something can find
+    the project directory in the first place. With the database gone, this file
+    is the only thing that knows where the projects are.
+    """
+    if not is_enabled():
+        return None
+    try:
+        entries = [
+            {
+                "uuid": str(project.uuid),
+                "name": project.name,
+                "directory": str(project.directory),
+            }
+            for project in Project.objects.all().order_by("name")
+        ]
+        home = registry_path().parent
+        home.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({"projects": entries}, indent=2).encode("utf-8")
+        return _atomic_write_bytes(home, REGISTRY_NAME, payload)
+    except Exception as err:
+        logger.warning("Could not update the project directory registry: %s", err)
+        return None
+
+
+def read_registry() -> List[Dict[str, str]]:
+    """The known project directories, or an empty list if there is no registry."""
+    try:
+        with open(registry_path(), encoding="utf-8") as stream:
+            data = json.load(stream)
+    except (OSError, json.JSONDecodeError):
+        return []
+    projects = data.get("projects") if isinstance(data, dict) else None
+    return projects if isinstance(projects, list) else []
+
+
+# ---------------------------------------------------------------------------
+# Rebuilding everything at once
+# ---------------------------------------------------------------------------
+
+
+def has_snapshot(project: Project) -> bool:
+    """True when this installation has written a snapshot for ``project``.
+
+    A Qt-era ``DATABASE.db.xml`` sitting in the directory does not count: it
+    describes whatever that installation knew, which is not necessarily what
+    this database holds.
+    """
+    path = snapshot_path(project)
+    return path.is_file() and _was_written_here(path)
+
+
+def snapshot_status() -> List[Dict]:
+    """Per project, whether it is protected and when it was last written."""
+    status = []
+    for project in Project.objects.all().order_by("name"):
+        path = snapshot_path(project)
+        exists = path.is_file()
+        status.append(
+            {
+                "id": project.pk,
+                "name": project.name,
+                "directory": str(project.directory),
+                "directory_exists": Path(project.directory).is_dir(),
+                "has_snapshot": exists and _was_written_here(path),
+                "foreign_snapshot": exists and not _was_written_here(path),
+                "written": (
+                    int(path.stat().st_mtime) if exists else None
+                ),
+            }
+        )
+    return status
+
+
+def snapshot_all_projects(missing_only: bool = False) -> Dict[str, int]:
+    """Snapshot every project, and refresh the registry.
+
+    Projects that predate this mechanism never trigger a signal -- a finished,
+    dormant project is exactly the kind you most want protected and exactly the
+    kind that nothing will touch again -- so there has to be a way to write
+    them all out on demand.
+
+    Args:
+        missing_only: skip projects this installation has already snapshotted.
+            Cheap enough to run on every start-up; use False to refresh all.
+    """
+    written, skipped, already = 0, 0, 0
+    for project in Project.objects.all().order_by("name"):
+        if missing_only and has_snapshot(project):
+            already += 1
+            continue
+        if write_snapshot(project) is not None:
+            written += 1
+        else:
+            skipped += 1
+    update_registry()
+    logger.info(
+        "Snapshotted %d project(s); %d already current, %d could not be written",
+        written,
+        already,
+        skipped,
+    )
+    return {"written": written, "skipped": skipped, "already_current": already}

--- a/server/ccp4i2/db/signals.py
+++ b/server/ccp4i2/db/signals.py
@@ -1,20 +1,160 @@
-from django.db.models.signals import pre_save
+"""Decide when a project's on-disk snapshot needs rewriting.
+
+The rule is: anything the *user* authored that exists only in the database.
+Everything about a project's files can be recovered from the project directory
+itself; nothing about the user's judgement can. Job titles and comments,
+evaluations of good and rejected, file annotations, tags and the project
+description all vanish with the database unless they have been written out.
+
+Driving this from signals rather than from calls at each endpoint means every
+write path is covered -- REST, i2run, management commands, the job runner --
+including paths that do not exist yet. DRF's ``partial_update`` saves without
+``update_fields``, so which fields actually changed is worked out by comparing
+against the stored row in ``pre_save``.
+
+See :mod:`ccp4i2.db.project_snapshot` for how the writes are coalesced.
+"""
+
+import logging
+
+from django.db.models.signals import m2m_changed, post_delete, post_save, pre_save
 from django.dispatch import receiver
-from .models import Job
+
+from .models import File, Job, Project, ProjectTag
+from .project_snapshot import schedule_snapshot, update_registry
+
+logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+
+#: Fields whose change means the snapshot is out of date. Everything here is
+#: either user-authored or the job lifecycle, and none of it is reconstructible
+#: from the project directory.
+WATCHED_FIELDS = {
+    Job: ("status", "title", "comments", "evaluation"),
+    File: ("annotation", "sub_type", "content"),
+    Project: ("name", "description", "directory", "last_job_number"),
+}
+
+#: Attribute used to carry the result of the pre_save comparison through to
+#: post_save on the same instance.
+_CHANGED = "_snapshot_changed_fields"
+
+
+def _is_top_level(job: Job) -> bool:
+    """Subjob transitions are frequent and their parent's snapshot covers them.
+
+    A pipeline can run dozens of subjobs; snapshotting each time one starts or
+    finishes would be constant churn for no gain, because the top-level job
+    reaching a terminal state writes a snapshot that includes them all.
+
+    ``parent`` is the truth here -- both create paths set it -- with the dotted
+    job number as a fallback for rows that predate it or arrived by import.
+    """
+    if job.parent_id is not None:
+        return False
+    return "." not in str(job.number)
 
 
 @receiver(pre_save, sender=Job)
-def job_status_change_handler(sender, instance, **kwargs):
-    if not instance.pk:
-        # New Job, not an update
+@receiver(pre_save, sender=File)
+@receiver(pre_save, sender=Project)
+def record_changed_fields(sender, instance, **kwargs):
+    """Note which watched fields differ from the stored row.
+
+    Only for updates: on creation there is nothing to compare against, and the
+    extra query would be paid on every row of a bulk import.
+    """
+    setattr(instance, _CHANGED, ())
+    if instance.pk is None:
         return
+    watched = WATCHED_FIELDS.get(sender)
+    if not watched:
+        return
+    stored = sender.objects.filter(pk=instance.pk).only(*watched).first()
+    if stored is None:
+        return
+    setattr(
+        instance,
+        _CHANGED,
+        tuple(
+            field
+            for field in watched
+            if getattr(stored, field, None) != getattr(instance, field, None)
+        ),
+    )
+
+
+@receiver(post_save, sender=Job)
+def job_saved(sender, instance, created, **kwargs):
+    if created:
+        # A new top-level job is a new piece of project history. Subjobs arrive
+        # in bursts as a pipeline builds them and are covered by their parent.
+        if _is_top_level(instance):
+            schedule_snapshot(instance.project)
+        return
+    changed = getattr(instance, _CHANGED, ())
+    if not changed:
+        return
+    # status is the lifecycle; the rest is the user's own writing, and worth
+    # capturing on a subjob as well as a top-level one.
+    if changed == ("status",) and not _is_top_level(instance):
+        return
+    schedule_snapshot(instance.project)
+
+
+@receiver(post_save, sender=File)
+def file_saved(sender, instance, created, **kwargs):
+    # Files are created in bulk by the gleaner as a job finishes; that job's
+    # own transition to a terminal state writes the snapshot that covers them.
+    # What matters here is a later edit -- someone annotating a result.
+    if created or not getattr(instance, _CHANGED, ()):
+        return
+    schedule_snapshot(instance.job.project if instance.job else None)
+
+
+@receiver(post_save, sender=Project)
+def project_saved(sender, instance, created, **kwargs):
+    if created or getattr(instance, _CHANGED, ()):
+        schedule_snapshot(instance)
+
+
+@receiver(post_delete, sender=Job)
+@receiver(post_delete, sender=File)
+def row_deleted(sender, instance, **kwargs):
+    # Deleting a project cascades to every job and file it owns, so by the time
+    # these fire the project row may already be gone. Reaching for it then
+    # raises; the project's own post_delete handles that case.
     try:
-        old_instance = Job.objects.get(pk=instance.pk)
-    except Job.DoesNotExist:
-        return
-    if old_instance.status != instance.status:
-        # Status has changed
-        print(
-            f"Job {instance.pk} status changed from {old_instance.status} to {instance.status}"
+        project = (
+            instance.project
+            if isinstance(instance, Job)
+            else (instance.job.project if instance.job_id else None)
         )
-        # Place your custom logic here
+    except (Job.DoesNotExist, Project.DoesNotExist):
+        return
+    schedule_snapshot(project)
+
+
+@receiver(post_delete, sender=Project)
+def project_deleted(sender, instance, **kwargs):
+    # The project's own snapshot goes with its directory; what needs correcting
+    # is the registry that lists where projects are.
+    update_registry()
+
+
+@receiver(m2m_changed, sender=ProjectTag.projects.through)
+def project_tags_changed(sender, instance, action, pk_set, **kwargs):
+    if action not in ("post_add", "post_remove", "post_clear"):
+        return
+    if isinstance(instance, Project):
+        schedule_snapshot(instance)
+        return
+    # instance is the tag; pk_set holds the projects it was applied to.
+    for project in Project.objects.filter(pk__in=pk_set or []):
+        schedule_snapshot(project)
+
+
+@receiver(post_save, sender=ProjectTag)
+def project_tag_saved(sender, instance, **kwargs):
+    for project in instance.projects.all():
+        schedule_snapshot(project)

--- a/server/ccp4i2/tests/db/test_project_snapshot.py
+++ b/server/ccp4i2/tests/db/test_project_snapshot.py
@@ -1,0 +1,597 @@
+"""Tests for the on-disk project snapshot and the project directory registry.
+
+Two things matter here and they pull against each other: the snapshot must be
+written whenever the user changes something that exists nowhere else, and it
+must not be written once per row when a job finishes and drops thirty files
+into the database. Most of these tests therefore count writes, not just check
+content.
+"""
+
+from pathlib import Path
+from shutil import rmtree
+from unittest.mock import patch
+from xml.etree import ElementTree as ET
+
+from django.conf import settings
+from django.db import transaction
+from django.test import TestCase, TransactionTestCase, override_settings
+
+from ...db import project_snapshot
+from ...db.import_i2xml import import_i2xml_from_file
+from ...db.models import File, FileType, Job, Project, ProjectTag
+from ...db.project_snapshot import (
+    GENERATOR_ELEMENT,
+    GENERATOR_MARK,
+    PRESERVED_NAME,
+    SNAPSHOT_NAME,
+    has_snapshot,
+    read_registry,
+    snapshot_all_projects,
+    snapshot_path,
+    snapshot_status,
+    suspended,
+    write_snapshot,
+)
+
+PROJECTS_DIR = Path(__file__).parent.parent / "CCP4I2_SNAPSHOT_TEST_DIR"
+HOME_DIR = PROJECTS_DIR / "home"
+
+
+class IsolatedHomeMixin:
+    """Keep the registry out of the user's real ~/.ccp4i2-django.
+
+    ``update_registry`` runs from the on-commit callback whether or not a test
+    cares about the registry, so pointing it somewhere disposable has to be
+    done for every test here, not only the ones that assert on it.
+    """
+
+    def setUp(self):
+        PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+        HOME_DIR.mkdir(parents=True, exist_ok=True)
+        self._home_patcher = patch.object(
+            project_snapshot,
+            "registry_path",
+            return_value=HOME_DIR / project_snapshot.REGISTRY_NAME,
+        )
+        self._home_patcher.start()
+        self.addCleanup(self._home_patcher.stop)
+        self.addCleanup(rmtree, PROJECTS_DIR, ignore_errors=True)
+        super().setUp()
+
+
+def make_project(name: str = "Snap") -> Project:
+    directory = Path(settings.CCP4I2_PROJECTS_DIR) / name
+    directory.mkdir(parents=True, exist_ok=True)
+    return Project.objects.create(name=name, directory=str(directory))
+
+
+def make_file(job: Job, name: str = "XYZOUT.pdb") -> File:
+    file_type, _ = FileType.objects.get_or_create(
+        name="chemical/x-pdb", defaults={"description": "Model coordinates"}
+    )
+    return File.objects.create(
+        name=name,
+        directory=File.Directory.JOB_DIR,
+        type=file_type,
+        job=job,
+        job_param_name="XYZOUT",
+    )
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class SnapshotContentTest(IsolatedHomeMixin, TestCase):
+    """What ends up in the file."""
+
+    def setUp(self):
+        super().setUp()
+        self.project = make_project()
+
+    def test_snapshot_is_written_into_the_project_directory(self):
+        path = write_snapshot(self.project)
+        self.assertEqual(path, snapshot_path(self.project))
+        self.assertEqual(path.name, SNAPSHOT_NAME)
+        self.assertTrue(path.is_file())
+
+    def test_snapshot_captures_what_the_database_alone_holds(self):
+        job = Job.objects.create(
+            project=self.project,
+            number="1",
+            task_name="prosmart_refmac",
+            title="Refinement against native",
+            comments="Looks better than job 3",
+            evaluation=Job.Evaluation.BEST,
+            status=Job.Status.FINISHED,
+        )
+        the_file = make_file(job)
+        the_file.annotation = "Final model, deposit this one"
+        the_file.save()
+
+        root = ET.parse(write_snapshot(self.project)).getroot()
+
+        job_elem = root.find(".//jobTable/job")
+        self.assertEqual(job_elem.get("title"), "Refinement against native")
+        self.assertEqual(job_elem.get("evaluation"), str(Job.Evaluation.BEST))
+        file_elem = root.find(".//fileTable/file")
+        self.assertEqual(
+            file_elem.get("annotation"), "Final model, deposit this one"
+        )
+
+    def test_snapshot_is_written_atomically(self):
+        """A reader must never see a half-written snapshot."""
+        write_snapshot(self.project)
+        original = snapshot_path(self.project).read_bytes()
+
+        with patch("os.replace", side_effect=OSError("disk full")):
+            write_snapshot(self.project)
+
+        self.assertEqual(snapshot_path(self.project).read_bytes(), original)
+        leftovers = list(Path(self.project.directory).glob(f".{SNAPSHOT_NAME}-*"))
+        self.assertEqual(leftovers, [])
+
+    def test_a_missing_project_directory_is_not_an_error(self):
+        rmtree(self.project.directory)
+        self.assertIsNone(write_snapshot(self.project))
+
+    def test_a_failure_to_write_never_propagates(self):
+        """A job must not be reported as failed because a snapshot could not
+        be written -- a safety net that breaks the thing it protects is worse
+        than no safety net."""
+        with patch(
+            "ccp4i2.db.project_snapshot.generate_project_xml_tree",
+            side_effect=RuntimeError("boom"),
+        ):
+            self.assertIsNone(write_snapshot(self.project))
+
+    def test_snapshot_all_projects(self):
+        make_project("Second")
+        result = snapshot_all_projects()
+        self.assertEqual(result["written"], 2)
+        self.assertEqual(result["skipped"], 0)
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class RetrofitTest(IsolatedHomeMixin, TestCase):
+    """Projects that grew up without a snapshot have to be able to get one.
+
+    Nothing will ever touch a finished, dormant project again, so signals alone
+    would leave exactly the projects most worth protecting unprotected.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.first = make_project("Alpha")
+        self.second = make_project("Beta")
+
+    def test_a_project_starts_unprotected(self):
+        self.assertFalse(has_snapshot(self.first))
+
+    def test_retrofit_protects_every_project(self):
+        result = snapshot_all_projects(missing_only=True)
+
+        self.assertEqual(result["written"], 2)
+        self.assertTrue(has_snapshot(self.first))
+        self.assertTrue(has_snapshot(self.second))
+
+    def test_retrofit_is_cheap_to_repeat(self):
+        snapshot_all_projects(missing_only=True)
+        result = snapshot_all_projects(missing_only=True)
+
+        self.assertEqual(result["written"], 0)
+        self.assertEqual(result["already_current"], 2)
+
+    def test_all_rewrites_even_current_snapshots(self):
+        snapshot_all_projects(missing_only=True)
+        result = snapshot_all_projects(missing_only=False)
+        self.assertEqual(result["written"], 2)
+
+    def test_status_reports_what_is_protected(self):
+        write_snapshot(self.first)
+        by_name = {row["name"]: row for row in snapshot_status()}
+
+        self.assertTrue(by_name["Alpha"]["has_snapshot"])
+        self.assertFalse(by_name["Beta"]["has_snapshot"])
+        self.assertIsNotNone(by_name["Alpha"]["written"])
+
+    def test_status_notices_a_missing_directory(self):
+        rmtree(self.second.directory)
+        by_name = {row["name"]: row for row in snapshot_status()}
+        self.assertFalse(by_name["Beta"]["directory_exists"])
+
+    def test_a_legacy_snapshot_is_preserved_before_being_replaced(self):
+        """A Qt-era DATABASE.db.xml may describe jobs this database never
+        imported. Overwriting it blind would destroy the only record of them."""
+        legacy = snapshot_path(self.first)
+        legacy.write_text("<database><legacy>irreplaceable</legacy></database>")
+
+        write_snapshot(self.first)
+
+        preserved = Path(self.first.directory) / PRESERVED_NAME
+        self.assertTrue(preserved.is_file())
+        self.assertIn("irreplaceable", preserved.read_text())
+        self.assertIn(GENERATOR_ELEMENT, legacy.read_text())
+
+    def test_a_legacy_snapshot_is_only_preserved_once(self):
+        """The backup must never be overwritten by one of our own snapshots."""
+        legacy = snapshot_path(self.first)
+        legacy.write_text("<database><legacy>the original</legacy></database>")
+
+        write_snapshot(self.first)
+        write_snapshot(self.first)
+        write_snapshot(self.first)
+
+        preserved = Path(self.first.directory) / PRESERVED_NAME
+        self.assertIn("the original", preserved.read_text())
+
+    def test_our_own_snapshot_is_not_treated_as_foreign(self):
+        write_snapshot(self.first)
+        write_snapshot(self.first)
+        self.assertFalse((Path(self.first.directory) / PRESERVED_NAME).exists())
+
+    def test_a_legacy_snapshot_mentioning_the_marker_is_still_foreign(self):
+        """Found on the first real project this was tried on.
+
+        Its legacy DATABASE.db.xml referenced a directory called
+        ``ccp4i2-djangodbapi``, so a substring search for the marker matched
+        and the file was taken for one of ours -- meaning it would have been
+        overwritten without being preserved.
+        """
+        legacy = snapshot_path(self.first)
+        legacy.write_text(
+            "<database><file filename='/Users/me/ccp4i2-djangodbapi/x.pdb'/>"
+            "</database>"
+        )
+        self.assertFalse(has_snapshot(self.first))
+
+        write_snapshot(self.first)
+
+        preserved = Path(self.first.directory) / PRESERVED_NAME
+        self.assertTrue(preserved.is_file())
+        self.assertIn("ccp4i2-djangodbapi", preserved.read_text())
+
+    def test_status_flags_a_foreign_snapshot(self):
+        snapshot_path(self.second).write_text("<database/>")
+        by_name = {row["name"]: row for row in snapshot_status()}
+
+        self.assertTrue(by_name["Beta"]["foreign_snapshot"])
+        self.assertFalse(by_name["Beta"]["has_snapshot"])
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class SnapshotTriggerTest(IsolatedHomeMixin, TransactionTestCase):
+    """When it gets written.
+
+    TransactionTestCase, not TestCase: on_commit callbacks never run inside the
+    transaction TestCase wraps each test in, so a snapshot scheduled for commit
+    would silently never happen.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.writes = []
+        self.patcher = patch.object(
+            project_snapshot,
+            "write_snapshot",
+            side_effect=lambda project: self.writes.append(project.pk),
+        )
+        self.patcher.start()
+        self.project = make_project()
+        self.writes.clear()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_creating_a_top_level_job_writes_one_snapshot(self):
+        Job.objects.create(
+            project=self.project, number="1", task_name="aimless"
+        )
+        self.assertEqual(len(self.writes), 1)
+
+    def test_creating_a_subjob_writes_nothing(self):
+        parent = Job.objects.create(
+            project=self.project, number="1", task_name="phaser_pipeline"
+        )
+        self.writes.clear()
+
+        Job.objects.create(
+            project=self.project, number="1.1", task_name="phaser_MR_AUTO",
+            parent=parent,
+        )
+        self.assertEqual(self.writes, [])
+
+    def test_job_finishing_writes_a_snapshot(self):
+        job = Job.objects.create(
+            project=self.project, number="1", task_name="aimless"
+        )
+        self.writes.clear()
+
+        job.status = Job.Status.FINISHED
+        job.save()
+        self.assertEqual(len(self.writes), 1)
+
+    def test_a_subjob_changing_status_writes_nothing(self):
+        parent = Job.objects.create(
+            project=self.project, number="1", task_name="phaser_pipeline"
+        )
+        subjob = Job.objects.create(
+            project=self.project, number="1.1", task_name="phaser_MR_AUTO",
+            parent=parent,
+        )
+        self.writes.clear()
+
+        subjob.status = Job.Status.FINISHED
+        subjob.save()
+        self.assertEqual(self.writes, [])
+
+    def test_a_comment_on_a_subjob_is_still_captured(self):
+        """Status churn is noise; what the user wrote is not."""
+        parent = Job.objects.create(
+            project=self.project, number="1", task_name="phaser_pipeline"
+        )
+        subjob = Job.objects.create(
+            project=self.project, number="1.1", task_name="phaser_MR_AUTO",
+            parent=parent,
+        )
+        self.writes.clear()
+
+        subjob.comments = "This is the run that worked"
+        subjob.save()
+        self.assertEqual(len(self.writes), 1)
+
+    def test_saving_a_job_unchanged_writes_nothing(self):
+        job = Job.objects.create(
+            project=self.project, number="1", task_name="aimless"
+        )
+        self.writes.clear()
+
+        job.save()
+        self.assertEqual(self.writes, [])
+
+    def test_job_evaluation_writes_a_snapshot(self):
+        job = Job.objects.create(
+            project=self.project, number="1", task_name="aimless"
+        )
+        self.writes.clear()
+
+        job.evaluation = Job.Evaluation.REJECTED
+        job.save()
+        self.assertEqual(len(self.writes), 1)
+
+    def test_creating_files_writes_nothing(self):
+        """The gleaner drops many files as a job finishes; the job's own
+        transition covers them."""
+        job = Job.objects.create(
+            project=self.project, number="1", task_name="aimless"
+        )
+        self.writes.clear()
+
+        for i in range(20):
+            make_file(job, f"out{i}.pdb")
+        self.assertEqual(self.writes, [])
+
+    def test_annotating_a_file_writes_a_snapshot(self):
+        job = Job.objects.create(
+            project=self.project, number="1", task_name="aimless"
+        )
+        the_file = make_file(job)
+        self.writes.clear()
+
+        the_file.annotation = "Best map so far"
+        the_file.save()
+        self.assertEqual(len(self.writes), 1)
+
+    def test_project_description_writes_a_snapshot(self):
+        self.project.description = "MDM2 fragment campaign"
+        self.project.save()
+        self.assertEqual(len(self.writes), 1)
+
+    def test_tagging_a_project_writes_a_snapshot(self):
+        tag = ProjectTag.objects.create(text="fragment")
+        self.writes.clear()
+
+        tag.projects.add(self.project)
+        self.assertEqual(len(self.writes), 1)
+
+    def test_many_changes_in_one_transaction_write_once(self):
+        """The point of coalescing: one request, one snapshot."""
+        job = Job.objects.create(
+            project=self.project, number="1", task_name="aimless"
+        )
+        files = [make_file(job, f"out{i}.pdb") for i in range(30)]
+        self.writes.clear()
+
+        with transaction.atomic():
+            job.status = Job.Status.FINISHED
+            job.save()
+            job.comments = "Done"
+            job.save()
+            for index, the_file in enumerate(files):
+                the_file.annotation = f"Output {index}"
+                the_file.save()
+            self.project.description = "Updated"
+            self.project.save()
+
+        self.assertEqual(len(self.writes), 1)
+
+    def test_suspended_writes_nothing(self):
+        with suspended():
+            job = Job.objects.create(
+                project=self.project, number="1", task_name="aimless"
+            )
+            job.status = Job.Status.FINISHED
+            job.save()
+        self.assertEqual(self.writes, [])
+
+    def test_a_rolled_back_transaction_does_not_block_the_next_write(self):
+        """De-duplication state must not outlive the transaction that set it.
+
+        If it does, a project touched inside a transaction that then rolls back
+        is skipped forever after -- a safety net with a hole nothing reports.
+        """
+        try:
+            with transaction.atomic():
+                self.project.description = "Doomed"
+                self.project.save()
+                raise RuntimeError("rolled back")
+        except RuntimeError:
+            pass
+        self.assertEqual(self.writes, [])
+
+        self.project.description = "This one sticks"
+        self.project.save()
+        self.assertEqual(len(self.writes), 1)
+
+    def test_writing_resumes_after_suspension(self):
+        with suspended():
+            Job.objects.create(
+                project=self.project, number="1", task_name="aimless"
+            )
+        Job.objects.create(project=self.project, number="2", task_name="aimless")
+        self.assertEqual(len(self.writes), 1)
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class RegistryTest(IsolatedHomeMixin, TransactionTestCase):
+    """The list of where the projects are, kept outside the database."""
+
+    def setUp(self):
+        super().setUp()
+        self.home = HOME_DIR
+
+    def test_registry_lists_every_project(self):
+        first = make_project("Alpha")
+        second = make_project("Beta")
+
+        entries = read_registry()
+        directories = {entry["directory"] for entry in entries}
+        self.assertEqual(
+            directories, {first.directory, second.directory}
+        )
+        self.assertEqual({e["name"] for e in entries}, {"Alpha", "Beta"})
+
+    def test_registry_records_the_uuid_so_a_rebuild_can_match_projects(self):
+        project = make_project("Alpha")
+        entry = read_registry()[0]
+        self.assertEqual(entry["uuid"], str(project.uuid))
+
+    def test_deleting_a_project_removes_it_from_the_registry(self):
+        make_project("Alpha")
+        second = make_project("Beta")
+        second.delete()
+
+        self.assertEqual([e["name"] for e in read_registry()], ["Alpha"])
+
+    def test_missing_registry_reads_as_empty(self):
+        self.assertEqual(read_registry(), [])
+
+    def test_a_corrupt_registry_reads_as_empty_rather_than_raising(self):
+        (self.home / project_snapshot.REGISTRY_NAME).write_text("{not json")
+        self.assertEqual(read_registry(), [])
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class RecoveryRoundTripTest(IsolatedHomeMixin, TestCase):
+    """The point of the whole exercise: a snapshot has to be able to restore.
+
+    Writing a file nobody can read back would be worse than writing nothing,
+    because it would look like protection. So this loses the database outright
+    and rebuilds from what was left on disk.
+
+    A TestCase rather than a TransactionTestCase: the import resolves file
+    types against the static rows a data migration installs, and a
+    TransactionTestCase truncates those along with everything else. The cost is
+    that on-commit callbacks do not fire, so the registry is written explicitly
+    below; ``RegistryTest`` covers the signal-driven path.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.project = make_project("Recoverable")
+        self.project.description = "MDM2 fragment campaign, autumn"
+        self.project.save()
+
+        self.job = Job.objects.create(
+            project=self.project,
+            number="1",
+            task_name="prosmart_refmac",
+            title="Refinement against native data",
+            comments="Better than job 3; use this for deposition",
+            evaluation=Job.Evaluation.BEST,
+            status=Job.Status.FINISHED,
+        )
+        self.rejected = Job.objects.create(
+            project=self.project,
+            number="2",
+            task_name="prosmart_refmac",
+            title="Refinement with TLS",
+            comments="TLS made it worse",
+            evaluation=Job.Evaluation.REJECTED,
+            status=Job.Status.FINISHED,
+        )
+        self.file = make_file(self.job)
+        self.file.annotation = "Final model, deposit this one"
+        self.file.sub_type = 1
+        self.file.save()
+
+        self.snapshot = write_snapshot(self.project)
+
+    def _lose_the_database(self):
+        """Everything the user typed lives here and nowhere else."""
+        File.objects.all().delete()
+        Job.objects.all().delete()
+        ProjectTag.objects.all().delete()
+        Project.objects.all().delete()
+
+    def test_the_database_really_is_the_only_copy(self):
+        """Guard the premise: if this data were recoverable anyway, the whole
+        mechanism would be unnecessary."""
+        self._lose_the_database()
+        self.assertEqual(Project.objects.count(), 0)
+        self.assertEqual(Job.objects.count(), 0)
+
+    def test_a_lost_database_is_rebuilt_from_the_snapshot(self):
+        self._lose_the_database()
+
+        with suspended():
+            import_i2xml_from_file(self.snapshot)
+
+        project = Project.objects.get(name="Recoverable")
+        self.assertEqual(project.directory, str(self.project.directory))
+        self.assertEqual(Job.objects.filter(project=project).count(), 2)
+
+    def test_what_the_user_wrote_survives(self):
+        self._lose_the_database()
+        with suspended():
+            import_i2xml_from_file(self.snapshot)
+
+        project = Project.objects.get(name="Recoverable")
+        jobs = {job.number: job for job in Job.objects.filter(project=project)}
+
+        self.assertEqual(jobs["1"].title, "Refinement against native data")
+        self.assertEqual(jobs["1"].evaluation, Job.Evaluation.BEST)
+        self.assertEqual(jobs["2"].title, "Refinement with TLS")
+        self.assertEqual(jobs["2"].evaluation, Job.Evaluation.REJECTED)
+
+        restored_file = File.objects.get(name="XYZOUT.pdb")
+        self.assertEqual(restored_file.annotation, "Final model, deposit this one")
+        self.assertEqual(restored_file.sub_type, 1)
+
+    def test_identity_survives_so_a_rebuild_can_be_matched_up(self):
+        """UUIDs, not primary keys: the file references inside every params.xml
+        in the project are keyed on these."""
+        original_project_uuid = self.project.uuid
+        original_job_uuid = self.job.uuid
+        original_file_uuid = self.file.uuid
+
+        self._lose_the_database()
+        with suspended():
+            import_i2xml_from_file(self.snapshot)
+
+        self.assertTrue(Project.objects.filter(uuid=original_project_uuid).exists())
+        self.assertTrue(Job.objects.filter(uuid=original_job_uuid).exists())
+        self.assertTrue(File.objects.filter(uuid=original_file_uuid).exists())
+
+    def test_the_registry_says_where_to_look(self):
+        """With the database gone, nothing else knows the project exists."""
+        project_snapshot.update_registry()
+        directories = {entry["directory"] for entry in read_registry()}
+        self.assertIn(str(self.project.directory), directories)


### PR DESCRIPTION
"Prevention first" from the recovery discussion. Makes the database *rebuildable*; rebuilding it is separate work.

## The problem

Everything CCP4i2 knows about a project's **files** can be recovered from the project directory — job directories, `params.xml`, the outputs themselves.

Everything the **user wrote** cannot. Annotations, job titles and comments, the evaluation of one run as best and another as rejected, tags, the project description: none of it has an on-disk artefact. It lives only in `db.sqlite3`, and if that is lost or corrupted it is gone, with nothing to reconstruct it from.

Qt-era CCP4i2 wrote a per-project `DATABASE.db.xml` as jobs started and finished, plus a list of known project directories outside the database (see the 2.4.3 changelog entry, "Improved checking/rebuilding of database and project-list XML files on startup"). The Django app has had neither.

## What gets written

| File | Where | Holds |
|---|---|---|
| `DATABASE.db.xml` | project directory | everything the database knows about that project |
| `project_directories.json` | `~/.ccp4i2-django/` | where every known project is |

The registry matters as much as the snapshots: a snapshot inside a project directory is only useful if something can find the directory, and with the database gone nothing else knows where the projects are.

`DATABASE.db.xml` is the format export already writes and import already reads — the one project zips carry and legacy directories already contain. One recovery path rather than two, and it keys on **UUIDs** rather than primary keys or the current shape of the models, which is what a file written to be read back after something went wrong needs. (A Django fixture would key on primary keys, meaningless after a rebuild, and would refuse to load after a migration changed the models it was written against.)

## When

Database signals, not calls at each endpoint, so every write path is covered — REST, `i2run`, management commands, the job runner — including ones that don't exist yet.

| Model | Watched |
|---|---|
| `Job` | `status`, `title`, `comments`, `evaluation` |
| `File` | `annotation`, `sub_type`, `content` |
| `Project` | `name`, `description`, `directory`, `last_job_number` |
| `ProjectTag` | text, and which projects carry it |

Two deliberate exclusions: **subjob status changes** (the top-level job's own transition writes a snapshot covering them) and **file creation** (the gleaner drops many files as a job finishes). A comment or evaluation on a *subjob* is still captured — status churn is noise, what the user wrote is not.

## Coalescing, and why there is no timer

One request can touch many rows, so snapshots register with `transaction.on_commit` and de-duplicate per transaction: thirty changed files, one write.

That is coalescing **by transaction, not wall-clock**. There is deliberately no timer, because there is nowhere for one to live — the desktop app runs uvicorn with `--workers 2`, and `i2run` and the job runner exit as soon as they're done. An in-process timer would be duplicated across workers and would never fire at all in the CLI.

The de-duplication set is **Django's own `run_on_commit` list** rather than one kept alongside it, because Django clears that list on rollback as well as commit. A separate set kept an entry for a rolled-back transaction and silently skipped that project's next change — a safety net with a hole nothing would report. Caught by a test, which now guards it.

Writes are atomic (temp + `os.replace`) so two workers can't produce a partial file, and a write failure never propagates: a job must not be reported as failed because its directory was read-only.

## Retrofit

Signals only fire when something changes, and a finished, dormant project is both the kind most worth protecting and the kind nothing will ever touch again.

```
manage.py snapshot_projects --status   # who is protected
manage.py snapshot_projects            # write the missing ones
manage.py snapshot_projects --all      # rewrite everything
```

The desktop app runs it at launch just after `migrate`; missing-only mode makes it a no-op once everything is covered, and it is never fatal.

**Legacy snapshots are preserved, not overwritten.** A Qt-era directory's `DATABASE.db.xml` may describe jobs never imported here, so the first time one is about to be replaced the original is copied to `DATABASE.db.xml.pre-ccp4i2-django` — once, so our own output can't creep over the real backup.

## Testing

42 tests. Most **count writes** rather than checking content, since the tension is between writing whenever the user changes something and not writing once per row when a job drops thirty files.

The one that matters is the round trip: build a project with titles, comments, evaluations and annotations; snapshot it; **delete every row**; import the snapshot; assert it all came back, UUIDs included.

Verified on real projects (`BetaBlip`, `Test`): both correctly reported as carrying a foreign snapshot, retrofitted, legacy files preserved byte-identical, repeat run a no-op.

Two bugs found during that and fixed:

1. The rollback leak above.
2. Marker recognition was a substring search for `ccp4i2-django`, which matched `BetaBlip`'s legacy snapshot because it referenced `/Users/.../ccp4i2-djangodbapi/demo_data`. It would have been overwritten without being preserved. Now matches the whole `<generator>` element. Both have regression tests.

`tests/db` is back at its pre-existing 6 failures / 24 errors (missing `test101` data); `tests/unit` differs from baseline only by the known-flaky `test_ccontainer_methods`.

## Not in scope

Reading the snapshots back into a fresh database and reporting what could and couldn't be recovered, and inferring a project with no snapshot at all. `docs/PROJECT_RECOVERY.md` records where that stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
