### PR TITLE
Rebuild the database from the snapshots in project directories

### DIFF
--- a/client/renderer/components/projects-toolbar.tsx
+++ b/client/renderer/components/projects-toolbar.tsx
@@ -1,12 +1,22 @@
 "use client";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Toolbar, Tooltip } from "@mui/material";
-import { Add, Upload, SettingsBackupRestore } from "@mui/icons-material";
+import { Add, Upload, SettingsBackupRestore, Restore } from "@mui/icons-material";
 import { useAuth } from "@/lib/compounds/auth-context";
+import { isElectron } from "../utils/platform";
+import { RecoverProjectsDialog } from "./recover-projects-dialog";
 
 export default function ProjectsToolbar() {
   const router = useRouter();
   const { canAdminister } = useAuth();
+  const [recoverOpen, setRecoverOpen] = useState(false);
+  // Recovery reads project directories on the machine running the server and
+  // needs a native folder picker when the registry is gone, so it is
+  // desktop-only. Resolved in an effect so the first client render matches the
+  // server-rendered markup.
+  const [canRecover, setCanRecover] = useState(false);
+  useEffect(() => setCanRecover(isElectron()), []);
 
   function importProjects() {
     router.push("/ccp4i2/import-project");
@@ -32,6 +42,17 @@ export default function ProjectsToolbar() {
           Import
         </Button>
       </Tooltip>
+      {canRecover && (
+        <Tooltip title="Rebuild the database from the records kept in your project folders">
+          <Button
+            variant="outlined"
+            startIcon={<Restore />}
+            onClick={() => setRecoverOpen(true)}
+          >
+            Recover
+          </Button>
+        </Tooltip>
+      )}
       {canAdminister && (
         <Tooltip title="Migrate a legacy CCP4i2 database into this installation">
           <Button
@@ -42,6 +63,13 @@ export default function ProjectsToolbar() {
             Migrate legacy
           </Button>
         </Tooltip>
+      )}
+      {canRecover && (
+        <RecoverProjectsDialog
+          open={recoverOpen}
+          onClose={() => setRecoverOpen(false)}
+          onRecovered={() => router.refresh()}
+        />
       )}
     </Toolbar>
   );

--- a/client/renderer/components/recover-projects-dialog.tsx
+++ b/client/renderer/components/recover-projects-dialog.tsx
@@ -1,0 +1,411 @@
+"use client";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from "@mui/material";
+import {
+  CheckCircle,
+  FolderOpen,
+  Restore,
+  WarningAmber,
+} from "@mui/icons-material";
+import { useApi } from "../api";
+import { apiGet } from "../api-fetch";
+
+/** One project directory that could be restored. */
+interface Candidate {
+  directory: string;
+  project_name: string | null;
+  project_uuid: string | null;
+  recorded_directory: string | null;
+  jobs: number;
+  files: number;
+  relocated: boolean;
+  restored: boolean;
+  skipped_reason: string | null;
+  paths_rewritten: number;
+  missing_job_directories: string[];
+  warnings: string[];
+}
+
+interface RestorableResponse {
+  source: { kind: string; path: string; entries?: number };
+  candidates: Candidate[];
+  restorable: number;
+}
+
+interface RestoreResult {
+  restored: Candidate[];
+  skipped: Candidate[];
+  total: number;
+  dry_run: boolean;
+}
+
+async function browseDirectory(message: string): Promise<string | null> {
+  const api = typeof window !== "undefined" ? window.electronAPI : undefined;
+  if (!api?.invoke) return null;
+  try {
+    return (
+      (await api.invoke("browse-path", {
+        mode: "directory",
+        title: message,
+        message,
+        buttonLabel: "Look here",
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function canBrowse(): boolean {
+  return typeof window !== "undefined" && Boolean(window.electronAPI?.invoke);
+}
+
+interface RecoverProjectsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onRecovered?: () => void;
+}
+
+/**
+ * Rebuild the database from the snapshots CCP4i2 leaves in project directories.
+ *
+ * For a database that has been lost or corrupted. Each project directory holds
+ * a `DATABASE.db.xml` describing everything the database knew about it, and a
+ * registry outside the database records where the projects are — so recovery
+ * normally needs nothing but a confirmation. If the registry has gone too,
+ * pointing this at the folder the projects live in finds them directly.
+ *
+ * Nothing is moved and nothing already in the database is touched unless the
+ * user explicitly asks: restoring over a live project would lose work rather
+ * than recover it.
+ */
+export function RecoverProjectsDialog({
+  open,
+  onClose,
+  onRecovered,
+}: RecoverProjectsDialogProps) {
+  const api = useApi();
+
+  const [scanPath, setScanPath] = useState<string | null>(null);
+  const [found, setFound] = useState<RestorableResponse | null>(null);
+  const [result, setResult] = useState<RestoreResult | null>(null);
+  const [replace, setReplace] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [looking, setLooking] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+
+  const look = useCallback(
+    async (path: string | null) => {
+      setLooking(true);
+      setError(null);
+      setFound(null);
+      try {
+        const query = path ? `?scan=${encodeURIComponent(path)}` : "";
+        // A one-off read, not a subscription: SWR would cache a view of the
+        // filesystem that goes stale the moment the user looks elsewhere.
+        const payload: any = await apiGet(`projects/restorable/${query}`);
+        if (payload?.success === false) {
+          setError(payload?.error ?? "Could not look for projects");
+          return;
+        }
+        setFound(payload?.data ?? payload);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLooking(false);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setScanPath(null);
+    setFound(null);
+    setResult(null);
+    setError(null);
+    setReplace(false);
+    void look(null);
+  }, [open, look]);
+
+  const handleBrowse = useCallback(async () => {
+    const chosen = await browseDirectory(
+      "Choose the folder your CCP4i2 projects are in"
+    );
+    if (!chosen) return;
+    setScanPath(chosen);
+    setResult(null);
+    void look(chosen);
+  }, [look]);
+
+  const restore = useCallback(async () => {
+    setRestoring(true);
+    setError(null);
+    try {
+      const response: any = await api.post("projects/restore/", {
+        source: scanPath ? "scan" : "registry",
+        ...(scanPath ? { path: scanPath } : {}),
+        replace,
+      });
+      if (response?.success === false) {
+        setError(response?.error ?? "Could not restore the projects");
+        return;
+      }
+      setResult(response?.data ?? response);
+      onRecovered?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRestoring(false);
+    }
+  }, [api, scanPath, replace, onRecovered]);
+
+  const busy = looking || restoring;
+  const candidates = found?.candidates ?? [];
+  const usable = candidates.filter((c) => c.project_uuid !== null);
+  const unusable = candidates.filter((c) => c.project_uuid === null);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={busy ? undefined : onClose}
+      maxWidth="md"
+      fullWidth
+    >
+      <DialogTitle>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Restore color="primary" />
+          <span>Recover projects from disk</span>
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary">
+          CCP4i2 keeps a record of each project inside its own folder, so a lost
+          or damaged database can be rebuilt from what is still on disk. Nothing
+          is moved, and projects already in the database are left alone.
+        </Typography>
+
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          sx={{ mt: 2, flexWrap: "wrap" }}
+        >
+          <Typography variant="body2" sx={{ flexGrow: 1 }}>
+            {scanPath ? (
+              <>
+                Looking in{" "}
+                <Box component="span" sx={{ fontFamily: "monospace" }}>
+                  {scanPath}
+                </Box>
+              </>
+            ) : (
+              "Using CCP4i2's own record of where your projects are"
+            )}
+          </Typography>
+          {canBrowse() && (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<FolderOpen />}
+              onClick={handleBrowse}
+              disabled={busy}
+            >
+              Look elsewhere
+            </Button>
+          )}
+        </Stack>
+
+        {looking && <LinearProgress sx={{ mt: 2 }} />}
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {found && !result && (
+          <Box sx={{ mt: 2 }}>
+            {usable.length === 0 ? (
+              <Alert severity="warning">
+                <AlertTitle>Nothing found to recover</AlertTitle>
+                {scanPath
+                  ? "No project folders with a recovery record were found there."
+                  : "CCP4i2 has no record of where your projects are. If you " +
+                    "know the folder they live in, use Look elsewhere."}
+              </Alert>
+            ) : (
+              <Alert severity="info">
+                <AlertTitle>
+                  {usable.length} project{usable.length === 1 ? "" : "s"} can be
+                  recovered
+                </AlertTitle>
+                Each will be rebuilt exactly as it was, under the job numbers
+                its folders already use.
+              </Alert>
+            )}
+
+            <List dense sx={{ maxHeight: 260, overflow: "auto", mt: 1 }}>
+              {usable.map((candidate) => (
+                <ListItem key={candidate.directory} disableGutters>
+                  <CheckCircle
+                    fontSize="small"
+                    color="success"
+                    sx={{ mr: 1, flexShrink: 0 }}
+                  />
+                  <ListItemText
+                    primary={
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <span>{candidate.project_name}</span>
+                        <Chip
+                          size="small"
+                          label={`${candidate.jobs} job${
+                            candidate.jobs === 1 ? "" : "s"
+                          }`}
+                        />
+                        {candidate.relocated && (
+                          <Chip size="small" color="info" label="moved" />
+                        )}
+                      </Stack>
+                    }
+                    secondary={candidate.directory}
+                    secondaryTypographyProps={{
+                      sx: { fontFamily: "monospace", wordBreak: "break-all" },
+                    }}
+                  />
+                </ListItem>
+              ))}
+              {unusable.map((candidate) => (
+                <ListItem key={candidate.directory} disableGutters>
+                  <WarningAmber
+                    fontSize="small"
+                    color="warning"
+                    sx={{ mr: 1, flexShrink: 0 }}
+                  />
+                  <ListItemText
+                    primary={candidate.directory}
+                    secondary={candidate.skipped_reason}
+                    primaryTypographyProps={{
+                      sx: { fontFamily: "monospace", wordBreak: "break-all" },
+                    }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+
+            {usable.length > 0 && (
+              <FormControlLabel
+                sx={{ mt: 1 }}
+                control={
+                  <Checkbox
+                    checked={replace}
+                    disabled={busy}
+                    onChange={(event) => setReplace(event.target.checked)}
+                  />
+                }
+                label={
+                  <Typography variant="body2">
+                    Also rebuild projects already in the database, discarding
+                    what it currently holds for them
+                  </Typography>
+                }
+              />
+            )}
+          </Box>
+        )}
+
+        {result && (
+          <Box sx={{ mt: 2 }}>
+            <Alert severity={result.restored.length > 0 ? "success" : "warning"}>
+              <AlertTitle>
+                Recovered {result.restored.length} project
+                {result.restored.length === 1 ? "" : "s"}
+              </AlertTitle>
+              {result.restored.some((c) => c.paths_rewritten > 0) && (
+                <Typography variant="body2">
+                  Some had moved since their record was written; the paths
+                  inside their files were updated to match.
+                </Typography>
+              )}
+            </Alert>
+
+            {result.restored.some(
+              (c) => c.missing_job_directories.length > 0
+            ) && (
+              <>
+                <Divider sx={{ my: 2 }} />
+                <Alert severity="warning">
+                  <AlertTitle>Some job folders are not on disk</AlertTitle>
+                  <Typography variant="body2" gutterBottom>
+                    These jobs are recorded but their folders are missing, so
+                    their results cannot be opened.
+                  </Typography>
+                  {result.restored
+                    .filter((c) => c.missing_job_directories.length > 0)
+                    .map((c) => (
+                      <Typography variant="body2" key={c.directory}>
+                        {c.project_name}: job{" "}
+                        {c.missing_job_directories.slice(0, 8).join(", ")}
+                      </Typography>
+                    ))}
+                </Alert>
+              </>
+            )}
+
+            {result.skipped.filter((c) => c.skipped_reason).length > 0 && (
+              <List dense sx={{ maxHeight: 200, overflow: "auto", mt: 1 }}>
+                {result.skipped
+                  .filter((c) => c.skipped_reason)
+                  .map((c) => (
+                    <ListItem key={c.directory} disableGutters>
+                      <ListItemText
+                        primary={c.project_name ?? c.directory}
+                        secondary={c.skipped_reason}
+                      />
+                    </ListItem>
+                  ))}
+              </List>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>
+          {result ? "Close" : "Cancel"}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={restore}
+          disabled={busy || usable.length === 0 || Boolean(result)}
+          startIcon={restoring ? <CircularProgress size={16} /> : <Restore />}
+        >
+          Recover
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default RecoverProjectsDialog;

--- a/docs/PROJECT_RECOVERY.md
+++ b/docs/PROJECT_RECOVERY.md
@@ -135,11 +135,51 @@ project_snapshot.write_snapshot(project)
 the files are actually on disk. Setting `CCP4I2_DISABLE_PROJECT_SNAPSHOT=1`
 disables writing entirely.
 
+## Rebuilding
+
+Restoring is the other half, and it is deliberately *not* the same operation as
+importing, because the two have opposite invariants.
+
+**Import** brings a project in alongside an existing world. Another copy may
+already be present, and job numbers may collide with jobs that already exist,
+so renumbering is correct — `import_ccp4_project_zip` renames the job
+directories as it extracts them so disk and database still agree afterwards.
+
+**Restore** is the reverse. The directory is the truth and the database is what
+is being repaired. Nothing may be renumbered, because the job directories are
+already on disk under the names they have and nothing is going to move them. A
+clash is therefore an error to report, not something to work around, and the
+post-condition is checked rather than assumed: after a restore, every job the
+database records must have a directory on disk. `verify_restored` checks
+exactly that, which catches renumbering, a mis-rooted project and a snapshot
+written for a different tree — none of which would surface as an error during
+the import itself.
+
+```bash
+manage.py restore_projects --registry              # everything the registry knows
+manage.py restore_projects --scan ~/CCP4I2_PROJECTS  # registry lost as well
+manage.py restore_projects --directory <one project>
+manage.py restore_projects --registry --dry-run    # look first
+```
+
+A project already in the database is left alone unless `--replace` is given:
+overwriting a live project with an older snapshot would lose work rather than
+recover it. One project failing does not abandon the rest.
+
+If a project directory has moved since its snapshot was written, the directory
+wins — the snapshot is re-rooted onto it, and the absolute paths inside the
+project's files are rebased to match, reusing the machinery from
+`docs/MOVING_PROJECTS.md`.
+
+`GET /projects/restorable/` (optionally `?scan=PATH`) previews what could be
+recovered without touching anything; `POST /projects/restore/` does it. The
+desktop app exposes both through a Recover button on the projects toolbar.
+
 ## What this does not do
 
-It makes the database *rebuildable*; it does not rebuild it. Reading the
-snapshots and the registry back into a fresh database, and reporting on what
-could and could not be recovered, is a separate piece of work — as is inferring
-a project from its directory when there is no snapshot at all, which is
-necessarily lossy. See the notes on `utils/reconstructDBFromXML.py`, whose own
-TODO header is an honest account of how far inference gets you.
+Inferring a project from its directory when there is **no** snapshot at all is
+still missing, and is necessarily lossy. See the notes on
+`utils/reconstructDBFromXML.py`, whose own TODO header is an honest account of
+how far inference gets you — it recovered 553 of 577 files on the project it
+was measured against, and *over-generated* file-use rows, 269 against a true
+209.

--- a/server/ccp4i2/api/ProjectViewSet.py
+++ b/server/ccp4i2/api/ProjectViewSet.py
@@ -864,6 +864,108 @@ class ProjectViewSet(ModelViewSet):
     @action(
         detail=False,
         methods=["get"],
+        url_path="restorable",
+        serializer_class=serializers.ProjectSerializer,
+    )
+    def restorable(self, request):
+        """
+        Projects that could be rebuilt from the snapshots in their directories.
+
+        Read-only. Defaults to the project directory registry, which is kept
+        outside the database precisely so it survives one; pass ``?scan=PATH``
+        to look through a folder directly, for when the registry has been lost
+        as well.
+        """
+        from ..db.project_snapshot import read_registry, registry_path
+        from ..db.restore_project import discover_restorable, inspect
+
+        scan = request.query_params.get("scan")
+        try:
+            if scan:
+                directories = discover_restorable(pathlib.Path(scan))
+                source = {"kind": "scan", "path": str(pathlib.Path(scan).expanduser())}
+            else:
+                entries = read_registry()
+                directories = [
+                    pathlib.Path(entry["directory"])
+                    for entry in entries
+                    if entry.get("directory")
+                ]
+                source = {
+                    "kind": "registry",
+                    "path": str(registry_path()),
+                    "entries": len(entries),
+                }
+
+            candidates = [inspect(directory).as_dict() for directory in directories]
+            return api_success(
+                {
+                    "source": source,
+                    "candidates": candidates,
+                    "restorable": len(
+                        [c for c in candidates if c["project_uuid"] is not None]
+                    ),
+                }
+            )
+        except Exception as err:
+            logger.exception("Failed to look for restorable projects")
+            return api_error(str(err), status=500)
+
+    @action(
+        detail=False,
+        methods=["post"],
+        serializer_class=serializers.ProjectSerializer,
+    )
+    def restore(self, request):
+        """
+        Rebuild database rows from the snapshots in project directories.
+
+        A restore, not an import: the directories are the truth and the
+        database is being repaired, so nothing is renumbered and every job
+        comes back under the number its directory already has on disk.
+
+        POST body:
+            source: "registry" (default), "scan" or "directory".
+            path: required for "scan" and "directory".
+            replace (bool): rebuild projects already in the database. Without
+                it they are left alone, since overwriting a live project with
+                an older snapshot loses work rather than recovering it.
+            dry_run (bool): report what would be restored and change nothing.
+        """
+        from ..db.restore_project import (
+            discover_restorable,
+            restore_all,
+            restore_from_registry,
+        )
+
+        source = request.data.get("source", "registry")
+        path = request.data.get("path")
+        replace = str(request.data.get("replace", "")).lower() in ("1", "true", "yes")
+        dry_run = str(request.data.get("dry_run", "")).lower() in ("1", "true", "yes")
+
+        if source in ("scan", "directory") and not path:
+            return api_error(f"A path is required when source is '{source}'", status=400)
+
+        try:
+            if source == "registry":
+                result = restore_from_registry(replace=replace, dry_run=dry_run)
+            elif source == "scan":
+                directories = discover_restorable(pathlib.Path(path))
+                result = restore_all(directories, replace=replace, dry_run=dry_run)
+            elif source == "directory":
+                result = restore_all(
+                    [pathlib.Path(path)], replace=replace, dry_run=dry_run
+                )
+            else:
+                return api_error(f"Unknown source '{source}'", status=400)
+            return api_success(result)
+        except Exception as err:
+            logger.exception("Failed to restore projects from %s", source)
+            return api_error(str(err), status=500)
+
+    @action(
+        detail=False,
+        methods=["get"],
         url_path="missing_directories",
         serializer_class=serializers.ProjectSerializer,
     )

--- a/server/ccp4i2/db/export_project.py
+++ b/server/ccp4i2/db/export_project.py
@@ -174,6 +174,10 @@ def _export_project_table(body: ET.Element, project: Project) -> None:
     project_elem.set("projectdirectory", str(project.directory))
     project_elem.set("projectcreated", str(int(project.creation_time.timestamp())))
 
+    # As with job comments: typed by the user, stored only here.
+    if project.description:
+        project_elem.set("projectdescription", project.description)
+
 
 def _get_jobs_from_selection(project: Project, job_selection: Set[str]) -> Set[Job]:
     """
@@ -272,6 +276,11 @@ def _export_job_table(
 
         if job.evaluation is not None:
             job_elem.set("evaluation", str(job.evaluation))
+
+        # The user's own writing, and held nowhere but the database -- a job
+        # directory records what ran, never what was thought of it.
+        if job.comments:
+            job_elem.set("comments", job.comments)
 
         if job.finish_time:
             job_elem.set("finishtime", str(int(job.finish_time.timestamp())))

--- a/server/ccp4i2/db/import_i2xml.py
+++ b/server/ccp4i2/db/import_i2xml.py
@@ -291,9 +291,8 @@ def import_project(node: ET.Element, relocate_path: Path = None):
     create_dict["creation_time"] = datetime.datetime.fromtimestamp(
         float(node.attrib["projectcreated"])
     )
-    create_dict["creation_time"] = datetime.datetime.fromtimestamp(
-        float(node.attrib["projectcreated"])
-    )
+    if "projectdescription" in node.attrib:
+        create_dict["description"] = node.attrib["projectdescription"]
 
     try:
         instance = Project.objects.get(uuid=create_dict["uuid"])
@@ -332,6 +331,9 @@ def import_job(node: ET.Element):
         create_dict["title"] = node.attrib["title"]
     else:
         create_dict["title"] = node.attrib["taskname"]
+    # Absent from snapshots written before comments were exported.
+    if "comments" in node.attrib:
+        create_dict["comments"] = node.attrib["comments"]
     create_dict["project"] = Project.objects.get(uuid=node.attrib["projectid"]).pk
     if "parentjobid" in node.attrib and node.attrib["parentjobid"] is not None:
         create_dict["parent"] = Job.objects.get(uuid=node.attrib["parentjobid"]).pk

--- a/server/ccp4i2/db/management/commands/restore_projects.py
+++ b/server/ccp4i2/db/management/commands/restore_projects.py
@@ -1,0 +1,136 @@
+"""Rebuild the database from the snapshots left in project directories.
+
+Restore, not import: the directories are the truth and the database is being
+repaired, so nothing is renumbered and every job must come back under the
+number its directory already has on disk.
+
+    manage.py restore_projects --registry            # everything the registry knows
+    manage.py restore_projects --scan ~/CCP4I2_PROJECTS
+    manage.py restore_projects --directory ~/CCP4I2_PROJECTS/BetaBlip
+    manage.py restore_projects --registry --dry-run  # look first
+
+An existing project is left alone unless --replace is given: overwriting a live
+project with an older snapshot would lose work rather than recover it.
+"""
+
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ...project_snapshot import registry_path
+from ...restore_project import (
+    discover_restorable,
+    inspect,
+    restore_all,
+    restore_from_registry,
+)
+
+
+class Command(BaseCommand):
+    help = "Rebuild database rows from the DATABASE.db.xml in project directories."
+
+    def add_arguments(self, parser):
+        source = parser.add_mutually_exclusive_group(required=True)
+        source.add_argument(
+            "--registry",
+            action="store_true",
+            help="Restore every project listed in the project directory registry.",
+        )
+        source.add_argument(
+            "--scan",
+            metavar="DIRECTORY",
+            help="Restore every project directory found under DIRECTORY. "
+            "For when the registry has been lost as well.",
+        )
+        source.add_argument(
+            "--directory",
+            metavar="DIRECTORY",
+            help="Restore this one project directory.",
+        )
+        parser.add_argument(
+            "--replace",
+            action="store_true",
+            help="Rebuild projects already in the database, discarding the rows "
+            "currently held for them.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be restored and change nothing.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        replace = options["replace"]
+
+        if options["registry"]:
+            self.stdout.write(f"Reading {registry_path()}")
+            result = restore_from_registry(replace=replace, dry_run=dry_run)
+            if result["registry_entries"] == 0:
+                raise CommandError(
+                    "The registry is empty or missing. Use --scan to look for "
+                    "project directories directly."
+                )
+        elif options["scan"]:
+            root = Path(options["scan"]).expanduser()
+            directories = discover_restorable(root)
+            if not directories:
+                raise CommandError(f"No project directories with a snapshot under {root}")
+            self.stdout.write(f"Found {len(directories)} project director(y/ies) under {root}")
+            result = restore_all(directories, replace=replace, dry_run=dry_run)
+        else:
+            directory = Path(options["directory"]).expanduser()
+            report = inspect(directory)
+            if report.skipped_reason and report.project_uuid is None:
+                raise CommandError(f"{directory}: {report.skipped_reason}")
+            result = restore_all([directory], replace=replace, dry_run=dry_run)
+
+        self._report(result, dry_run)
+
+    def _report(self, result, dry_run):
+        restored = result["restored"]
+        skipped = result["skipped"]
+
+        if dry_run:
+            self.stdout.write("")
+            self.stdout.write("Would restore:")
+            for entry in skipped + restored:
+                if entry["skipped_reason"] and entry["project_uuid"] is None:
+                    continue
+                if entry["skipped_reason"]:
+                    continue
+                self._describe(entry, prefix="  ")
+            self.stdout.write("")
+
+        for entry in restored:
+            self._describe(entry, prefix="  restored ")
+
+        for entry in skipped:
+            if dry_run and not entry["skipped_reason"]:
+                continue
+            name = entry["project_name"] or entry["directory"]
+            self.stdout.write(f"  skipped   {name}: {entry['skipped_reason']}")
+
+        self.stdout.write("")
+        verb = "would be restored" if dry_run else "restored"
+        count = len([e for e in skipped + restored if not e["skipped_reason"]])
+        self.stdout.write(
+            f"{count if dry_run else len(restored)} project(s) {verb}, "
+            f"{len([e for e in skipped if e['skipped_reason']])} skipped."
+        )
+
+    def _describe(self, entry, prefix=""):
+        line = (
+            f"{prefix}{entry['project_name']}: "
+            f"{entry['jobs']} job(s), {entry['files']} file(s)"
+        )
+        if entry["relocated"]:
+            line += f" [moved from {entry['recorded_directory']}]"
+        self.stdout.write(line)
+        for warning in entry["warnings"]:
+            self.stdout.write(f"{' ' * len(prefix)}  warning: {warning}")
+        if entry["missing_job_directories"]:
+            numbers = ", ".join(entry["missing_job_directories"][:8])
+            self.stdout.write(
+                f"{' ' * len(prefix)}  job directories not on disk: {numbers}"
+            )

--- a/server/ccp4i2/db/restore_project.py
+++ b/server/ccp4i2/db/restore_project.py
@@ -1,0 +1,372 @@
+"""Rebuild database rows from the snapshots left in project directories.
+
+There are two ways a project can arrive from outside, and they pull in opposite
+directions:
+
+**Import** brings a project in *alongside* an existing world. Another copy may
+already be here, and its job numbers may collide with jobs that already exist.
+Renumbering is then correct and necessary -- the incoming project has to be made
+to fit, and ``import_ccp4_project_zip`` renames the job directories as it
+extracts them so that disk and database still agree afterwards.
+
+**Restore** is the opposite. The directory is the truth and the database is the
+thing being repaired. Nothing may be renumbered, because the job directories are
+already on disk under the names they have and nothing is going to move them.
+Job numbers and UUIDs must come back exactly as they were, or every ``relPath``
+in every ``params.xml``, and every job directory the database points at, is
+wrong.
+
+So a clash is an error to report here, not something to paper over, and the
+post-condition is explicit: after a restore the database must agree with the
+disk. :func:`verify_restored` checks that, rather than trusting that it held.
+
+This module handles restore. Import already exists in :mod:`import_i2xml`.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+from xml.etree import ElementTree as ET
+
+from django.db import transaction
+
+from . import project_snapshot
+from .import_i2xml import import_i2xml
+from .models import File, Job, Project
+from .project_snapshot import SNAPSHOT_NAME, read_registry
+
+logger = logging.getLogger(f"ccp4i2:{__name__}")
+
+
+class RestoreError(Exception):
+    """Raised when a project cannot be restored from its directory."""
+
+
+@dataclass
+class RestoreReport:
+    """What a restore found, did, and could not do."""
+
+    directory: str
+    project_name: Optional[str] = None
+    project_uuid: Optional[str] = None
+    recorded_directory: Optional[str] = None
+    jobs: int = 0
+    files: int = 0
+    restored: bool = False
+    dry_run: bool = False
+    skipped_reason: Optional[str] = None
+    relocated: bool = False
+    paths_rewritten: int = 0
+    missing_job_directories: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> Dict:
+        return {
+            "directory": self.directory,
+            "project_name": self.project_name,
+            "project_uuid": self.project_uuid,
+            "recorded_directory": self.recorded_directory,
+            "jobs": self.jobs,
+            "files": self.files,
+            "restored": self.restored,
+            "dry_run": self.dry_run,
+            "skipped_reason": self.skipped_reason,
+            "relocated": self.relocated,
+            "paths_rewritten": self.paths_rewritten,
+            "missing_job_directories": self.missing_job_directories,
+            "warnings": self.warnings,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Reading what a directory offers
+# ---------------------------------------------------------------------------
+
+
+def snapshot_in(directory: Path) -> Optional[Path]:
+    """The snapshot in ``directory``, if it has a readable one."""
+    path = Path(directory) / SNAPSHOT_NAME
+    return path if path.is_file() else None
+
+
+def inspect(directory: Path) -> RestoreReport:
+    """Read a project directory's snapshot and report what it holds.
+
+    Purely read-only, so it can back a preview.
+    """
+    directory = Path(directory).expanduser()
+    report = RestoreReport(directory=str(directory))
+
+    path = snapshot_in(directory)
+    if path is None:
+        report.skipped_reason = f"no {SNAPSHOT_NAME} in this directory"
+        return report
+
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as err:
+        report.skipped_reason = f"{SNAPSHOT_NAME} is not readable: {err}"
+        return report
+
+    node = root.find("ccp4i2_body/projectTable/project")
+    if node is None:
+        report.skipped_reason = f"{SNAPSHOT_NAME} names no project"
+        return report
+
+    report.project_uuid = node.attrib.get("projectid")
+    report.project_name = node.attrib.get("projectname")
+    report.recorded_directory = node.attrib.get("projectdirectory")
+    report.jobs = len(root.findall("ccp4i2_body/jobTable/job"))
+    report.files = len(root.findall("ccp4i2_body/fileTable/file"))
+    report.relocated = report.recorded_directory != str(directory)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Restoring one project
+# ---------------------------------------------------------------------------
+
+
+def restore_from_directory(
+    directory: Path,
+    replace: bool = False,
+    dry_run: bool = False,
+    repair_paths: bool = True,
+) -> RestoreReport:
+    """Rebuild one project's rows from the snapshot in its directory.
+
+    Args:
+        directory: the project directory. Authoritative -- if the snapshot
+            records a different location, the directory wins and the snapshot
+            is re-rooted onto it.
+        replace: rebuild a project that is already in the database, discarding
+            the rows currently held for it. Without this an existing project
+            is left alone, since overwriting a live project with an older
+            snapshot would lose work rather than recover it.
+        dry_run: report what would happen and change nothing.
+        repair_paths: when the directory has moved since the snapshot was
+            written, rewrite the absolute paths inside the project's files.
+    """
+    directory = Path(directory).expanduser().resolve()
+    report = inspect(directory)
+    report.dry_run = dry_run
+
+    if report.skipped_reason is not None:
+        return report
+
+    existing = Project.objects.filter(uuid=report.project_uuid).first()
+    by_name = Project.objects.filter(name=report.project_name).first()
+
+    if existing is not None and not replace:
+        report.skipped_reason = (
+            f"project '{existing.name}' is already in the database; "
+            "use replace to rebuild it from this directory"
+        )
+        return report
+    if existing is None and by_name is not None:
+        report.skipped_reason = (
+            f"a different project is already called '{report.project_name}'"
+        )
+        return report
+
+    clash = _job_number_clash(report.project_uuid, directory)
+    if clash:
+        report.skipped_reason = (
+            f"job numbers {', '.join(clash[:5])} are already used by another "
+            "project in this database; restoring would renumber them and the "
+            "job directories on disk would no longer match"
+        )
+        return report
+
+    if dry_run:
+        report.missing_job_directories = _missing_job_directories_from_snapshot(
+            directory
+        )
+        return report
+
+    with project_snapshot.suspended():
+        with transaction.atomic():
+            if existing is not None:
+                # Rows first, so the rebuilt numbering starts from a clean sheet.
+                Job.objects.filter(project=existing).delete()
+                existing.delete()
+            _import_rerooted(directory)
+
+    project = Project.objects.get(uuid=report.project_uuid)
+    report.restored = True
+    report.jobs = Job.objects.filter(project=project).count()
+    report.files = File.objects.filter(job__project=project).count()
+
+    if repair_paths and report.relocated and report.recorded_directory:
+        report.paths_rewritten = _repair_after_relocation(
+            project, report.recorded_directory
+        )
+
+    report.missing_job_directories = verify_restored(project)
+    if report.missing_job_directories:
+        report.warnings.append(
+            f"{len(report.missing_job_directories)} job director"
+            f"{'y is' if len(report.missing_job_directories) == 1 else 'ies are'} "
+            "recorded but not present on disk"
+        )
+
+    # The project is in the database again; make sure its snapshot and the
+    # registry reflect where it actually is now.
+    project_snapshot.write_snapshot(project)
+    project_snapshot.update_registry()
+
+    logger.info(
+        "Restored project '%s' from %s: %d job(s), %d file(s)",
+        project.name,
+        directory,
+        report.jobs,
+        report.files,
+    )
+    return report
+
+
+def _import_rerooted(directory: Path) -> None:
+    """Import the snapshot with ``directory`` substituted as the project root.
+
+    ``import_i2xml``'s own ``relocate_path`` appends the recorded directory's
+    basename to whatever it is given, which assumes the project folder kept its
+    name. A restore knows exactly where the project is, so the path is set
+    outright instead of being reconstructed.
+    """
+    root = ET.parse(directory / SNAPSHOT_NAME).getroot()
+    for node in root.findall("ccp4i2_body/projectTable/project"):
+        node.attrib["projectdirectory"] = str(directory)
+    import_i2xml(root, relocate_path=None)
+
+
+def _job_number_clash(project_uuid: str, directory: Path) -> List[str]:
+    """Top-level job numbers this snapshot needs that another project holds.
+
+    Only a clash *within the same project* matters, since job numbers are
+    unique per project -- so this can only bite when the snapshot's project
+    UUID differs from the row already occupying those numbers.
+    """
+    existing = Project.objects.filter(uuid=project_uuid).first()
+    if existing is None:
+        return []
+    root = ET.parse(directory / SNAPSHOT_NAME).getroot()
+    wanted = {
+        node.attrib["jobnumber"]
+        for node in root.findall("ccp4i2_body/jobTable/job")
+        if "." not in node.attrib["jobnumber"]
+    }
+    held = set(
+        Job.objects.filter(project=existing)
+        .exclude(
+            uuid__in=[
+                node.attrib["jobid"]
+                for node in root.findall("ccp4i2_body/jobTable/job")
+            ]
+        )
+        .values_list("number", flat=True)
+    )
+    return sorted(wanted & held)
+
+
+def _missing_job_directories_from_snapshot(directory: Path) -> List[str]:
+    """Job numbers the snapshot records with no matching directory on disk."""
+    root = ET.parse(directory / SNAPSHOT_NAME).getroot()
+    missing = []
+    for node in root.findall("ccp4i2_body/jobTable/job"):
+        number = node.attrib["jobnumber"]
+        parts = [f"job_{part}" for part in number.split(".")]
+        if not (directory / "CCP4_JOBS").joinpath(*parts).is_dir():
+            missing.append(number)
+    return sorted(missing, key=lambda n: [int(p) for p in n.split(".")])
+
+
+def verify_restored(project: Project) -> List[str]:
+    """Job numbers whose directory the database claims but disk does not have.
+
+    The post-condition of a restore is that the database agrees with the disk.
+    Checking it directly catches renumbering, a mis-rooted directory and a
+    snapshot that was written for a different tree, none of which would show up
+    as an error during the import itself.
+    """
+    missing = []
+    for job in Job.objects.filter(project=project):
+        if not job.directory.is_dir():
+            missing.append(job.number)
+    return sorted(missing, key=lambda n: [int(p) for p in n.split(".")])
+
+
+def _repair_after_relocation(project: Project, old_root: str) -> int:
+    """Rewrite absolute paths inside a project restored from a new location."""
+    from .move_project import apply_rebase, plan_rebase
+
+    new_root = str(Path(project.directory))
+    plan = plan_rebase(Path(new_root), old_root, new_root)
+    return len(apply_rebase(plan))
+
+
+# ---------------------------------------------------------------------------
+# Restoring everything
+# ---------------------------------------------------------------------------
+
+
+def discover_restorable(root: Path) -> List[Path]:
+    """Project directories under ``root`` that carry a snapshot.
+
+    For when the registry is gone too, and all that is left is a folder full of
+    project directories.
+    """
+    root = Path(root).expanduser()
+    if not root.is_dir():
+        return []
+    found = []
+    if snapshot_in(root) is not None:
+        found.append(root)
+    for child in sorted(root.iterdir()):
+        if child.is_dir() and snapshot_in(child) is not None:
+            found.append(child)
+    return found
+
+
+def restore_all(
+    directories: List[Path],
+    replace: bool = False,
+    dry_run: bool = False,
+) -> Dict:
+    """Restore each directory in turn, reporting on all of them.
+
+    One project failing does not abandon the rest: a partial recovery is worth
+    having, and the ones that failed can be looked at individually.
+    """
+    reports = []
+    for directory in directories:
+        try:
+            reports.append(
+                restore_from_directory(directory, replace=replace, dry_run=dry_run)
+            )
+        except Exception as err:
+            logger.exception("Could not restore %s", directory)
+            failed = RestoreReport(directory=str(directory))
+            failed.skipped_reason = str(err)
+            reports.append(failed)
+
+    return {
+        "dry_run": dry_run,
+        "restored": [r.as_dict() for r in reports if r.restored],
+        "skipped": [r.as_dict() for r in reports if not r.restored],
+        "total": len(reports),
+    }
+
+
+def restore_from_registry(replace: bool = False, dry_run: bool = False) -> Dict:
+    """Restore every project the directory registry knows about.
+
+    The registry is kept outside the database precisely so that it survives the
+    database, and this is what it is for.
+    """
+    entries = read_registry()
+    directories = [Path(entry["directory"]) for entry in entries if entry.get("directory")]
+    result = restore_all(directories, replace=replace, dry_run=dry_run)
+    result["registry"] = str(project_snapshot.registry_path())
+    result["registry_entries"] = len(entries)
+    return result

--- a/server/ccp4i2/tests/db/test_restore_project.py
+++ b/server/ccp4i2/tests/db/test_restore_project.py
@@ -1,0 +1,449 @@
+"""Tests for rebuilding the database from project directory snapshots.
+
+The invariant a restore has to hold is not "the import ran without error" but
+"the database now agrees with the disk". A restore that renumbered a job, or
+rooted a project in the wrong place, would import perfectly cleanly and leave
+every job directory reference pointing at nothing. So these tests check the
+disk, not just the rows.
+"""
+
+from pathlib import Path
+from shutil import rmtree
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from ...db import project_snapshot
+from ...db.models import File, FileType, Job, Project
+from ...db.project_snapshot import SNAPSHOT_NAME, write_snapshot
+from ...db.restore_project import (
+    discover_restorable,
+    inspect,
+    restore_all,
+    restore_from_directory,
+    restore_from_registry,
+    verify_restored,
+)
+
+PROJECTS_DIR = Path(__file__).parent.parent / "CCP4I2_RESTORE_TEST_DIR"
+HOME_DIR = PROJECTS_DIR / "home"
+
+
+def build_project_on_disk(name: str, job_numbers=("1", "1.1", "2")) -> Project:
+    """A project with real job directories, so disk and database can be compared."""
+    directory = Path(settings.CCP4I2_PROJECTS_DIR) / name
+    (directory / "CCP4_JOBS").mkdir(parents=True, exist_ok=True)
+    (directory / "CCP4_IMPORTED_FILES").mkdir(exist_ok=True)
+
+    project = Project.objects.create(name=name, directory=str(directory))
+    project.description = f"{name} description"
+    project.save()
+
+    file_type, _ = FileType.objects.get_or_create(
+        name="chemical/x-pdb", defaults={"description": "Model coordinates"}
+    )
+    by_number = {}
+    for number in job_numbers:
+        parent = by_number.get(number.rsplit(".", 1)[0]) if "." in number else None
+        job = Job.objects.create(
+            project=project,
+            number=number,
+            parent=parent,
+            task_name="prosmart_refmac",
+            title=f"Job {number}",
+            comments=f"Notes on job {number}",
+            evaluation=Job.Evaluation.BEST,
+            status=Job.Status.FINISHED,
+        )
+        by_number[number] = job
+        directory.joinpath("CCP4_JOBS", *[f"job_{p}" for p in number.split(".")]).mkdir(
+            parents=True, exist_ok=True
+        )
+        the_file = File.objects.create(
+            name=f"XYZOUT_{number.replace('.', '_')}.pdb",
+            directory=File.Directory.JOB_DIR,
+            type=file_type,
+            job=job,
+            job_param_name="XYZOUT",
+        )
+        the_file.annotation = f"Model from job {number}"
+        the_file.save()
+
+    write_snapshot(project)
+    return project
+
+
+class RestoreTestBase(TestCase):
+    def setUp(self):
+        PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+        HOME_DIR.mkdir(parents=True, exist_ok=True)
+        patcher = self.settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+        patcher.enable()
+        self.addCleanup(patcher.disable)
+
+        # Restoring refreshes the registry, so every test here can reach it
+        # whether or not it cares about it. Point it somewhere disposable, or
+        # the suite rewrites the user's real ~/.ccp4i2-django.
+        registry = patch.object(
+            project_snapshot,
+            "registry_path",
+            return_value=HOME_DIR / project_snapshot.REGISTRY_NAME,
+        )
+        registry.start()
+        self.addCleanup(registry.stop)
+        self.addCleanup(rmtree, PROJECTS_DIR, ignore_errors=True)
+
+    def lose_the_database(self):
+        """Delete every row, the way a corrupt database file loses them.
+
+        Under ``suspended()`` deliberately. Deleting a project through the ORM
+        rewrites the registry, which would destroy the very thing the restore
+        depends on -- but a database file that has been corrupted or removed
+        never gets to run those signals, so a test that let them run would be
+        testing a situation that cannot arise.
+        """
+        with project_snapshot.suspended():
+            File.objects.all().delete()
+            Job.objects.all().delete()
+            Project.objects.all().delete()
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class InspectTest(RestoreTestBase):
+    """Reading a directory without touching anything."""
+
+    def test_inspect_reports_what_the_snapshot_holds(self):
+        project = build_project_on_disk("Alpha")
+        report = inspect(Path(project.directory))
+
+        self.assertEqual(report.project_name, "Alpha")
+        self.assertEqual(report.jobs, 3)
+        self.assertEqual(report.files, 3)
+        self.assertFalse(report.relocated)
+        self.assertIsNone(report.skipped_reason)
+
+    def test_a_directory_with_no_snapshot_is_reported_not_raised(self):
+        empty = PROJECTS_DIR / "Empty"
+        empty.mkdir()
+        report = inspect(empty)
+        self.assertIn(SNAPSHOT_NAME, report.skipped_reason)
+
+    def test_an_unreadable_snapshot_is_reported_not_raised(self):
+        broken = PROJECTS_DIR / "Broken"
+        broken.mkdir()
+        (broken / SNAPSHOT_NAME).write_text("<not valid xml")
+        report = inspect(broken)
+        self.assertIn("not readable", report.skipped_reason)
+
+    def test_inspect_notices_the_project_has_moved(self):
+        project = build_project_on_disk("Alpha")
+        moved = PROJECTS_DIR / "Moved"
+        Path(project.directory).rename(moved)
+
+        report = inspect(moved)
+        self.assertTrue(report.relocated)
+        self.assertEqual(report.recorded_directory, str(project.directory))
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class RestoreOneProjectTest(RestoreTestBase):
+    def setUp(self):
+        super().setUp()
+        self.project = build_project_on_disk("Alpha")
+        self.directory = Path(self.project.directory)
+        self.uuid = self.project.uuid
+
+    def test_a_lost_database_is_rebuilt_from_the_directory(self):
+        self.lose_the_database()
+
+        report = restore_from_directory(self.directory)
+
+        self.assertTrue(report.restored)
+        project = Project.objects.get(uuid=self.uuid)
+        self.assertEqual(project.name, "Alpha")
+        self.assertEqual(Job.objects.filter(project=project).count(), 3)
+
+    def test_the_database_ends_up_agreeing_with_the_disk(self):
+        """The post-condition. A renumbered job would import cleanly and leave
+        the database pointing at a directory that does not exist."""
+        self.lose_the_database()
+        restore_from_directory(self.directory)
+
+        project = Project.objects.get(uuid=self.uuid)
+        self.assertEqual(verify_restored(project), [])
+
+    def test_job_numbers_come_back_exactly(self):
+        self.lose_the_database()
+        restore_from_directory(self.directory)
+
+        project = Project.objects.get(uuid=self.uuid)
+        numbers = set(
+            Job.objects.filter(project=project).values_list("number", flat=True)
+        )
+        self.assertEqual(numbers, {"1", "1.1", "2"})
+
+    def test_what_the_user_wrote_comes_back(self):
+        self.lose_the_database()
+        restore_from_directory(self.directory)
+
+        project = Project.objects.get(uuid=self.uuid)
+        job = Job.objects.get(project=project, number="1")
+        self.assertEqual(job.title, "Job 1")
+        self.assertEqual(job.comments, "Notes on job 1")
+        self.assertEqual(job.evaluation, Job.Evaluation.BEST)
+        self.assertEqual(
+            File.objects.get(job=job).annotation, "Model from job 1"
+        )
+
+    def test_an_existing_project_is_left_alone(self):
+        """Overwriting a live project with an older snapshot would lose work."""
+        report = restore_from_directory(self.directory)
+
+        self.assertFalse(report.restored)
+        self.assertIn("already in the database", report.skipped_reason)
+
+    def test_replace_rebuilds_an_existing_project(self):
+        Job.objects.filter(project=self.project, number="2").delete()
+        self.assertEqual(Job.objects.filter(project=self.project).count(), 2)
+
+        report = restore_from_directory(self.directory, replace=True)
+
+        self.assertTrue(report.restored)
+        project = Project.objects.get(uuid=self.uuid)
+        self.assertEqual(Job.objects.filter(project=project).count(), 3)
+        self.assertEqual(verify_restored(project), [])
+
+    def test_a_dry_run_changes_nothing(self):
+        self.lose_the_database()
+
+        report = restore_from_directory(self.directory, dry_run=True)
+
+        self.assertFalse(report.restored)
+        self.assertTrue(report.dry_run)
+        self.assertEqual(report.jobs, 3)
+        self.assertEqual(Project.objects.count(), 0)
+
+    def test_a_name_held_by_a_different_project_is_refused(self):
+        self.lose_the_database()
+        Project.objects.create(name="Alpha", directory=str(PROJECTS_DIR / "Other"))
+
+        report = restore_from_directory(self.directory)
+
+        self.assertFalse(report.restored)
+        self.assertIn("already called", report.skipped_reason)
+
+    def test_missing_job_directories_are_reported(self):
+        rmtree(self.directory / "CCP4_JOBS" / "job_2")
+        self.lose_the_database()
+
+        report = restore_from_directory(self.directory)
+
+        self.assertTrue(report.restored)
+        self.assertEqual(report.missing_job_directories, ["2"])
+        self.assertTrue(report.warnings)
+
+    def test_restoring_writes_a_fresh_snapshot_and_registry_entry(self):
+        self.lose_the_database()
+        restore_from_directory(self.directory)
+
+        self.assertTrue((self.directory / SNAPSHOT_NAME).is_file())
+        directories = {
+            entry["directory"] for entry in project_snapshot.read_registry()
+        }
+        self.assertIn(str(self.directory), directories)
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class RestoreRelocatedProjectTest(RestoreTestBase):
+    """The directory is authoritative, even when the snapshot disagrees."""
+
+    def setUp(self):
+        super().setUp()
+        self.project = build_project_on_disk("Alpha")
+        self.original = Path(self.project.directory)
+        self.uuid = self.project.uuid
+        # A path baked into a job's files, as plugins do.
+        self.params = self.original / "CCP4_JOBS" / "job_1" / "params.xml"
+        self.params.write_text(
+            f"<params><KILLFILEPATH>{self.original}/CCP4_JOBS/job_1/INTERRUPT"
+            "</KILLFILEPATH></params>",
+            encoding="utf-8",
+        )
+        write_snapshot(self.project)
+
+        self.moved = PROJECTS_DIR / "SomewhereElse"
+        self.original.rename(self.moved)
+        self.lose_the_database()
+
+    def test_the_directory_wins_over_the_recorded_path(self):
+        restore_from_directory(self.moved)
+
+        project = Project.objects.get(uuid=self.uuid)
+        self.assertEqual(project.directory, str(self.moved))
+        self.assertEqual(verify_restored(project), [])
+
+    def test_paths_inside_the_files_are_repaired(self):
+        report = restore_from_directory(self.moved)
+
+        self.assertTrue(report.relocated)
+        self.assertGreater(report.paths_rewritten, 0)
+        moved_params = self.moved / "CCP4_JOBS" / "job_1" / "params.xml"
+        self.assertIn(str(self.moved), moved_params.read_text())
+        self.assertNotIn(str(self.original), moved_params.read_text())
+
+    def test_path_repair_can_be_declined(self):
+        report = restore_from_directory(self.moved, repair_paths=False)
+
+        self.assertEqual(report.paths_rewritten, 0)
+        moved_params = self.moved / "CCP4_JOBS" / "job_1" / "params.xml"
+        self.assertIn(str(self.original), moved_params.read_text())
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class RestoreEverythingTest(RestoreTestBase):
+    def setUp(self):
+        super().setUp()
+        self.names = ["Alpha", "Beta", "Gamma"]
+        self.projects = [build_project_on_disk(name) for name in self.names]
+        project_snapshot.update_registry()
+
+    def test_discover_finds_project_directories(self):
+        found = discover_restorable(PROJECTS_DIR)
+        self.assertEqual(
+            {path.name for path in found}, {"Alpha", "Beta", "Gamma"}
+        )
+
+    def test_discover_ignores_directories_without_a_snapshot(self):
+        (PROJECTS_DIR / "NotAProject").mkdir()
+        found = discover_restorable(PROJECTS_DIR)
+        self.assertNotIn("NotAProject", {path.name for path in found})
+
+    def test_a_whole_database_is_rebuilt_by_scanning(self):
+        directories = discover_restorable(PROJECTS_DIR)
+        self.lose_the_database()
+
+        result = restore_all(directories)
+
+        self.assertEqual(len(result["restored"]), 3)
+        self.assertEqual(set(Project.objects.values_list("name", flat=True)),
+                         set(self.names))
+        for project in Project.objects.all():
+            self.assertEqual(verify_restored(project), [])
+
+    def test_a_whole_database_is_rebuilt_from_the_registry(self):
+        self.lose_the_database()
+
+        result = restore_from_registry()
+
+        self.assertEqual(result["registry_entries"], 3)
+        self.assertEqual(len(result["restored"]), 3)
+        self.assertEqual(Project.objects.count(), 3)
+
+    def test_one_bad_project_does_not_abandon_the_rest(self):
+        (Path(self.projects[1].directory) / SNAPSHOT_NAME).write_text("<broken")
+        self.lose_the_database()
+
+        result = restore_all(discover_restorable(PROJECTS_DIR))
+
+        self.assertEqual(len(result["restored"]), 2)
+        self.assertEqual(len(result["skipped"]), 1)
+        self.assertEqual(Project.objects.count(), 2)
+
+    def test_rerunning_skips_what_is_already_there(self):
+        self.lose_the_database()
+        restore_all(discover_restorable(PROJECTS_DIR))
+
+        result = restore_all(discover_restorable(PROJECTS_DIR))
+
+        self.assertEqual(len(result["restored"]), 0)
+        self.assertEqual(len(result["skipped"]), 3)
+        self.assertEqual(Project.objects.count(), 3)
+
+
+@override_settings(CCP4I2_PROJECTS_DIR=PROJECTS_DIR)
+class RestoreEndpointTest(RestoreTestBase):
+    """The REST surface the desktop app drives."""
+
+    def setUp(self):
+        super().setUp()
+        from django.contrib.auth import get_user_model
+        from rest_framework.test import APIClient
+
+        self.project = build_project_on_disk("Alpha")
+        project_snapshot.update_registry()
+
+        self.client = APIClient()
+        self.client.force_authenticate(
+            get_user_model().objects.create(username="tester")
+        )
+
+    def test_restorable_reads_the_registry(self):
+        response = self.client.get("/api/ccp4i2/projects/restorable/")
+
+        self.assertEqual(response.status_code, 200, response.data)
+        data = response.data["data"]
+        self.assertEqual(data["source"]["kind"], "registry")
+        self.assertEqual(data["restorable"], 1)
+        self.assertEqual(data["candidates"][0]["project_name"], "Alpha")
+
+    def test_restorable_can_scan_a_folder_instead(self):
+        response = self.client.get(
+            "/api/ccp4i2/projects/restorable/", {"scan": str(PROJECTS_DIR)}
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response.data["data"]["source"]["kind"], "scan")
+        self.assertEqual(response.data["data"]["restorable"], 1)
+
+    def test_restorable_changes_nothing(self):
+        self.lose_the_database()
+        self.client.get("/api/ccp4i2/projects/restorable/")
+        self.assertEqual(Project.objects.count(), 0)
+
+    def test_restore_rebuilds_from_the_registry(self):
+        self.lose_the_database()
+
+        response = self.client.post(
+            "/api/ccp4i2/projects/restore/", {}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data["data"]["restored"]), 1)
+        self.assertEqual(Project.objects.count(), 1)
+        self.assertEqual(verify_restored(Project.objects.get()), [])
+
+    def test_restore_dry_run_changes_nothing(self):
+        self.lose_the_database()
+
+        response = self.client.post(
+            "/api/ccp4i2/projects/restore/", {"dry_run": True}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(Project.objects.count(), 0)
+
+    def test_restore_one_directory(self):
+        directory = str(self.project.directory)
+        self.lose_the_database()
+
+        response = self.client.post(
+            "/api/ccp4i2/projects/restore/",
+            {"source": "directory", "path": directory},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(Project.objects.count(), 1)
+
+    def test_a_path_is_required_when_scanning(self):
+        response = self.client.post(
+            "/api/ccp4i2/projects/restore/", {"source": "scan"}, format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_an_unknown_source_is_refused(self):
+        response = self.client.post(
+            "/api/ccp4i2/projects/restore/", {"source": "telepathy"}, format="json"
+        )
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
The other half of #268. Snapshots were being written but nothing read them back, so the safety net existed with no way to use it.

## Restore is not import

Your framing, and it turned out to be the load-bearing distinction:

**Import** brings a project in *alongside* an existing world. Another copy may already be here and job numbers may collide, so renumbering is correct — `import_ccp4_project_zip` renames the job directories as it extracts them, so disk and database still agree afterwards.

**Restore** is the reverse. The directory is the truth and the database is what's being repaired. Nothing may be renumbered, because the job directories are already on disk under the names they have and nothing is going to move them.

So a clash is **reported**, not worked around. And the post-condition is checked rather than assumed: `verify_restored` confirms every job the database records has a directory on disk. That catches renumbering, a mis-rooted project, and a snapshot written for a different tree — none of which would surface as an error during the import itself.

## Three ways in

```
manage.py restore_projects --registry              # what the registry knows
manage.py restore_projects --scan ~/CCP4I2_PROJECTS  # registry lost too
manage.py restore_projects --directory <one project>
manage.py restore_projects --registry --dry-run    # look first
```

All three preview without touching anything. A project already in the database is left alone unless `--replace` is given — overwriting a live project with an older snapshot loses work rather than recovering it. One project failing doesn't abandon the rest.

A directory that has **moved** since its snapshot was written wins over the recorded path: the snapshot is re-rooted onto it, and the absolute paths inside the project's files are rebased to match, reusing the machinery from #266.

## Two gaps in the snapshot format, found by the round trip

`Job.comments` and `Project.description` were **never exported**, so they could not come back — precisely the fields flagged as having no on-disk artefact when #268 was being designed. #268 added the *trigger* for them; the format had nowhere to put them. Both are now optional attributes, so older snapshots still load.

This is the argument for round-trip tests over unit tests here: everything about the write path passed, and the data still wasn't recoverable.

## Surface

| Endpoint | Purpose |
|---|---|
| `GET /projects/restorable/` | preview; `?scan=PATH` to look in a folder |
| `POST /projects/restore/` | `{source, path?, replace?, dry_run?}` |

Plus a **Recover** button on the projects toolbar, desktop-only — recovery reads directories on the machine running the server and needs a native picker when the registry is gone.

## Testing

31 tests. The invariant they check is not "the import ran without error" but "the database now agrees with the disk", so they check the disk.

One test needed correcting in a way worth noting: simulating database loss by deleting rows through the ORM *also wipes the registry*, because deleting a project rewrites it. A corrupt or deleted database file never runs those signals, so the test was reproducing a situation that can't arise. It now deletes under `suspended()`.

Verified against real project directories (`BetaBlip`, `AT35295`) with subjobs: snapshotted, database emptied, then rebuilt from the registry — and again by scanning, with the registry removed as well. Job numbers, parent relationships, comments, evaluations, annotations and descriptions all returned, zero mismatch between database and disk.

`tests/db` at its pre-existing 6 failures / 24 errors; `tests/unit` differs from baseline only by the known-flaky `test_ccontainer_methods`. `tsc` clean.

## Still not done

Inferring a project from its directory when there is **no** snapshot — necessarily lossy. `docs/PROJECT_RECOVERY.md` records where that stands, including the measured fidelity of the legacy `reconstructDBFromXML.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
