### PR TITLE
Report grid items inherit the parent's xmlnode

### DIFF
--- a/server/ccp4i2/report/core.py
+++ b/server/ccp4i2/report/core.py
@@ -204,6 +204,14 @@ class Container(ReportClass):
         if getattr(self, 'errReport', None) is None:
             self.errReport = CException()
         self.children: list[ReportClass] = []
+        # Elements constructed directly with parent= (rather than through the
+        # addX() helpers, which fill these in) inherit the parent's xml context.
+        # Without this a container such as a GridItem has xmlnode None, and any
+        # select= passed to a child graph/table silently selects nothing.
+        if not jobInfo and self.parent is not None:
+            jobInfo = getattr(self.parent, 'jobInfo', None) or {}
+        if xmlnode is None and self.parent is not None:
+            xmlnode = getattr(self.parent, 'xmlnode', None)
         self.jobInfo: dict[str, Any] = {}
         self.jobInfo.update(jobInfo)
         self.xmlnode = xmlnode

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/arcimboldo_lite_test_0__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/arcimboldo_lite_test_0__import_merged_1/expected_report.xml
@@ -690,21 +690,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 42 21 2</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.981</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/arcimboldo_lite_test_0__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/arcimboldo_lite_test_0__pointless_1_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 42 21 2</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.981</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__aimless_pipe_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__aimless_pipe_1/expected_report.xml
@@ -114,21 +114,27 @@ Completeness test shows good data.
                   <tbody>
                     <tr>
                       <th>Group name</th>
+                      <td>P 21 21 21</td>
                     </tr>
                     <tr>
                       <th>Reindex</th>
+                      <td>[h,k,l]</td>
                     </tr>
                     <tr>
                       <th>Space group confidence</th>
+                      <td>0.625</td>
                     </tr>
                     <tr>
                       <th>Laue group confidence</th>
+                      <td>0.977</td>
                     </tr>
                     <tr>
                       <th>Laue group probability</th>
+                      <td>0.981</td>
                     </tr>
                     <tr>
                       <th>Systematic absence probability</th>
+                      <td>0.714</td>
                     </tr>
                   </tbody>
                 </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__import_merged_3/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__import_merged_3/expected_report.xml
@@ -713,21 +713,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 21 21 21</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.992</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__pointless_1_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__pointless_1_1/expected_report.xml
@@ -24,21 +24,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>0.625</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>0.977</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>0.981</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.714</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__pointless_3_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/auspex_test_0__pointless_3_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.992</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/crank2_test_0__aimless_pipe_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/crank2_test_0__aimless_pipe_1/expected_report.xml
@@ -114,21 +114,27 @@ Completeness test shows good data.
                   <tbody>
                     <tr>
                       <th>Group name</th>
+                      <td>P 21 21 21</td>
                     </tr>
                     <tr>
                       <th>Reindex</th>
+                      <td>[h,k,l]</td>
                     </tr>
                     <tr>
                       <th>Space group confidence</th>
+                      <td>0.625</td>
                     </tr>
                     <tr>
                       <th>Laue group confidence</th>
+                      <td>0.977</td>
                     </tr>
                     <tr>
                       <th>Laue group probability</th>
+                      <td>0.981</td>
                     </tr>
                     <tr>
                       <th>Systematic absence probability</th>
+                      <td>0.714</td>
                     </tr>
                   </tbody>
                 </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/crank2_test_0__pointless_1_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/crank2_test_0__pointless_1_1/expected_report.xml
@@ -24,21 +24,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>0.625</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>0.977</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>0.981</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.714</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/freer_test_0__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/freer_test_0__import_merged_1/expected_report.xml
@@ -730,21 +730,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 21 21 21</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.992</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/freer_test_0__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/freer_test_0__pointless_1_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.992</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/import_merged_test_0__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/import_merged_test_0__import_merged_1/expected_report.xml
@@ -544,21 +544,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 21 21 21</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>0.990</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.992</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/import_merged_test_0__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/import_merged_test_0__pointless_1_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>0.990</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.992</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/makelink_test0__prosmart_refmac_2/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/makelink_test0__prosmart_refmac_2/expected_report.xml
@@ -75,8 +75,8 @@
         <CCP4i2ReportFlotGraph class="" style="height:250px; width:100%;">
           <ns0:ccp4_data title="Running refmac" id="data_SummaryGraph" style="display:none;">
             <headers>Cycle R_Factor R_Free rmsBonds </headers>
-            <data>- - - 0.021 
-- - - 0.016 
+            <data>0 0.1794 0.1746 0.021 
+1 0.1709 0.1739 0.016 
 </data>
             <plot>
               <title>Running refmac R-factors</title>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/mrbump_gamma_test_0__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/mrbump_gamma_test_0__import_merged_1/expected_report.xml
@@ -731,21 +731,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 21 21 21</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.992</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/mrbump_gamma_test_0__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/mrbump_gamma_test_0__pointless_1_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.992</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_asu_test_0__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_asu_test_0__import_merged_1/expected_report.xml
@@ -463,21 +463,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 32 2 1</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>0.951</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>0.932</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>0.955</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.997</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_asu_test_0__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_asu_test_0__pointless_1_3_1/expected_report.xml
@@ -41,21 +41,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 32 2 1</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>0.951</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>0.932</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>0.955</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.997</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_test_0__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_test_0__import_merged_1/expected_report.xml
@@ -463,21 +463,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 32 2 1</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>0.951</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>0.932</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>0.955</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.997</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_test_0__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_test_0__pointless_1_3_1/expected_report.xml
@@ -41,21 +41,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 32 2 1</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>0.951</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>0.932</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>0.955</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.997</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_tncs_test_3__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_tncs_test_3__import_merged_1/expected_report.xml
@@ -649,21 +649,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 21 21 21</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.994</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_tncs_test_3__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_expert_tncs_test_3__pointless_1_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.994</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_simple_refmac_test_0__prosmart_refmac_2/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/phaser_simple_refmac_test_0__prosmart_refmac_2/expected_report.xml
@@ -63,16 +63,17 @@
         <CCP4i2ReportFlotGraph class="" style="height:250px; width:100%;">
           <ns0:ccp4_data title="Running refmac" id="data_SummaryGraph" style="display:none;">
             <headers>Cycle R_Factor R_Free rmsBonds </headers>
-            <data>- - - 0.022 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
+            <data>1 0.2694 - 0.022 
+2 0.2648 - 0.012 
+3 0.2624 - 0.012 
+4 0.2614 - 0.012 
+5 0.2608 - 0.012 
+6 0.2604 - 0.012 
+7 0.2601 - 0.012 
+8 0.2602 - 0.012 
+9 0.2601 - 0.012 
+10 0.2601 - 0.012 
+- 0.2601 - - 
 </data>
             <plot>
               <title>Running refmac R-factors</title>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/refmac_gamma_test_0__prosmart_refmac_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/refmac_gamma_test_0__prosmart_refmac_1/expected_report.xml
@@ -63,16 +63,17 @@
         <CCP4i2ReportFlotGraph class="" style="height:250px; width:100%;">
           <ns0:ccp4_data title="Running refmac" id="data_SummaryGraph" style="display:none;">
             <headers>Cycle R_Factor R_Free rmsBonds </headers>
-            <data>- - - 0.023 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
-- - - 0.012 
+            <data>1 0.2695 - 0.023 
+2 0.2635 - 0.012 
+3 0.2619 - 0.012 
+4 0.2611 - 0.012 
+5 0.2607 - 0.012 
+6 0.2604 - 0.012 
+7 0.2604 - 0.012 
+8 0.2602 - 0.012 
+9 0.2602 - 0.012 
+10 0.2603 - 0.012 
+- 0.2603 - - 
 </data>
             <plot>
               <title>Running refmac R-factors</title>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/shelxSAD_test_1__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/shelxSAD_test_1__import_merged_1/expected_report.xml
@@ -731,21 +731,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 21 21 21</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.992</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/shelxSAD_test_1__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/shelxSAD_test_1__pointless_1_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.992</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/shelxe_mr_test_1__import_merged_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/shelxe_mr_test_1__import_merged_1/expected_report.xml
@@ -731,21 +731,27 @@ AnomFrc is the % of measured acentric reflections for which an anomalous differe
                 <tbody>
                   <tr>
                     <th>Group name</th>
+                    <td>P 21 21 21</td>
                   </tr>
                   <tr>
                     <th>Reindex</th>
+                    <td>[h,k,l]</td>
                   </tr>
                   <tr>
                     <th>Space group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group confidence</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Laue group probability</th>
+                    <td>1.000</td>
                   </tr>
                   <tr>
                     <th>Systematic absence probability</th>
+                    <td>0.992</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/shelxe_mr_test_1__pointless_1_3_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/shelxe_mr_test_1__pointless_1_3_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.992</td>
               </tr>
             </tbody>
           </table>

--- a/server/ccp4i2/tests/unit/lib/report_fixtures/single_atom_test_0__pointless_1_4_1/expected_report.xml
+++ b/server/ccp4i2/tests/unit/lib/report_fixtures/single_atom_test_0__pointless_1_4_1/expected_report.xml
@@ -29,21 +29,27 @@
             <tbody>
               <tr>
                 <th>Group name</th>
+                <td>P 21 21 21</td>
               </tr>
               <tr>
                 <th>Reindex</th>
+                <td>[h,k,l]</td>
               </tr>
               <tr>
                 <th>Space group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group confidence</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Laue group probability</th>
+                <td>1.000</td>
               </tr>
               <tr>
                 <th>Systematic absence probability</th>
+                <td>0.837</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
## Problem

The **Running refmac** plot in the `prosmart_refmac` report renders with a legend but no data — no R-factor, R-free or bond-RMSD curve — even though `program.xml` holds a full `<Cycle>` record for every refinement cycle.

Reported against a real job (11 cycles in `program.xml`, empty plot in the report).

## Root cause

Not a Refmac or XML problem — a report-framework one.

`prosmart_refmac_report.drawContents()` lays the table and graph out side by side with `summaryFold.addTwoColumnLayout(...)`, then builds the graph with `parent.addFlotGraph(..., select="RefmacInProgress/Cycle")`.

But `addTwoColumnLayout` (and `addGrid`/`addGridItem`) construct their items as `GridItem(span=..., parent=grid)` — with no `xmlnode`. `Container.__init__` stored `xmlnode` verbatim, so the grid item's `xmlnode` was `None`. `addObjectOfClass()` then defaults a child's `xmlnode` to that `None`, and `FlotGraph.__init__` has:

```python
if 'select' in kw and xmlnode is not None:
```

so `self.xmldata` stayed empty and every `select=`-driven column came back blank. `rmsBonds` survived only because it is passed explicitly as `data=`, computed off `self.xmlnode`.

Before the fix, on the reported job:

```
Cycle R_Factor R_Free rmsBonds
- - - 0.015
- - - 0.013
...                     (x11)
```

## Fix

`Container.__init__` now inherits `xmlnode` and `jobInfo` from `self.parent` when they are not supplied, so containers built directly with `parent=` behave like ones built through the `addX()` helpers.

After the fix, same job:

```
Cycle R_Factor R_Free rmsBonds
0 0.2334 0.2548 0.015
1 0.2213 0.2468 0.013
...
10 0.2137 0.2413 0.013
```

## Blast radius

The bug hit anything placed in a grid column, not just `prosmart_refmac`. The report fixtures gain previously-blank cells in `pointless`, `import_merged`, `aimless_pipe` and `refmac` — space group, reindex operator, probabilities — as well as the refmac per-cycle series. 28 fixture baselines re-recorded; all changes are additive (blank cells becoming populated), with no content removed.

## Testing

`ccp4i2/tests/unit/` failure set is byte-identical before and after: 18 pre-existing failures, all unrelated (stale `ProvideAsuContents`/`validate_protein`/`xia2` baselines).

## Not changed

The table beside the plot is `addProgressTable`, which deliberately shows only cycles `[0, n-2, n-1]`. That compaction of the live-progress view is legacy behaviour, not part of this bug, and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)