### PR TITLE
Make the project description visible, and keep it on import

### DIFF
--- a/client/renderer/components/menu-bar.tsx
+++ b/client/renderer/components/menu-bar.tsx
@@ -270,7 +270,11 @@ export default function MenuBar() {
           }}
         >
           {job && `Job ${job.number}: `}
-          {project && <span style={{ fontWeight: 500 }}>{project.name}</span>}
+          {project && (
+            <Tooltip title={project.description || ""}>
+              <span style={{ fontWeight: 500 }}>{project.name}</span>
+            </Tooltip>
+          )}
         </Typography>
       </HistoryToolbar>
     </AppBar>

--- a/client/renderer/components/new-project-content.tsx
+++ b/client/renderer/components/new-project-content.tsx
@@ -29,6 +29,7 @@ export const NewProjectContent: React.FC = () => {
   const api = useApi();
   const router = useRouter();
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [customDirectory, setCustomDirectory] = useState(false);
   const [ccp4i2ProjectDirectory, setCcp4i2ProjectDirectory] = useState<string>(
     "/home/user/CCP4X_PROJECTS"
@@ -79,6 +80,7 @@ export const NewProjectContent: React.FC = () => {
     try {
       const formData = new FormData();
       formData.append("name", name);
+      formData.append("description", description);
       formData.append("directory", customDirectory ? directory : "__default__");
       const project = await api.post<Project>("projects", formData);
 
@@ -241,6 +243,14 @@ export const NewProjectContent: React.FC = () => {
           error={nameError.length > 0}
           helperText={nameError}
           autoFocus
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          multiline
+          minRows={2}
+          helperText="Optional. What the project is for; shown wherever it is listed."
         />
         <ToggleButtonGroup
           exclusive

--- a/client/renderer/components/projects-table.tsx
+++ b/client/renderer/components/projects-table.tsx
@@ -187,6 +187,21 @@ const ProjectCard = React.memo(
               >
                 {project.name}
               </Typography>
+              {project.description && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{
+                    mt: 0.25,
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }}
+                >
+                  {project.description}
+                </Typography>
+              )}
             </Box>
           </Box>
 
@@ -553,6 +568,18 @@ export default function ProjectsTable() {
                     </Tooltip>
                   )}
                 </Stack>
+                {project.description && (
+                  <Tooltip title={project.description}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      noWrap
+                      sx={{ display: "block" }}
+                    >
+                      {project.description}
+                    </Typography>
+                  </Tooltip>
+                )}
                 <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
                   {new Date(project.last_access).getTime() >
                     Date.now() - 7 * 24 * 60 * 60 * 1000 && (

--- a/server/ccp4i2/db/import_i2xml.py
+++ b/server/ccp4i2/db/import_i2xml.py
@@ -22,6 +22,9 @@ Functions:
     import_project(node: ET.Element, relocate_path: Path = None):
         Imports a project from an XML node, creating or updating the project in the database.
 
+    import_project_comments(root_node: ET.Element):
+        Folds a Qt-era project's comments into the project description.
+
     import_job(node: ET.Element):
         Imports a job from an XML node, creating or updating the job in the database.
 
@@ -49,6 +52,7 @@ Functions:
 import datetime
 import zipfile
 
+from collections import defaultdict
 from pathlib import Path
 from xml.etree import ElementTree as ET
 from ..api.serializers import (
@@ -249,6 +253,7 @@ def import_i2xml(root_node: ET.Element, relocate_path: Path):
     job_map = {}
     for node in root_node.findall("ccp4i2_body/projectTable/project"):
         import_project(node, relocate_path)
+    import_project_comments(root_node)
     job_nodes = root_node.findall("ccp4i2_body/jobTable/job")
     job_nodes = sorted(
         job_nodes,
@@ -309,6 +314,51 @@ def import_project(node: ET.Element, relocate_path: Path = None):
     else:
         logging.error(f"Issues creating new project {item_form.errors}")
         return item_form.errors
+
+
+def import_project_comments(root_node: ET.Element):
+    """Carry a Qt-era project's comments into ``Project.description``.
+
+    A snapshot this app wrote records the description as a ``projectdescription``
+    attribute on the project element, which :func:`import_project` reads
+    directly. A ``DATABASE.db.xml`` left behind by the Qt-era CCP4i2 has no such
+    attribute: what it has is a ``projectcommentTable``, which is where that
+    interface kept the text it showed as the project description. The legacy
+    sqlite migration already folds those comments into the description (see
+    ``import_sqlite._import_project_comments``); without this, the same project
+    imported from its directory or its zip rather than from the old database
+    would silently lose it.
+
+    Comments are joined oldest-first, and an existing description always wins --
+    a ``projectdescription`` we read a moment ago is the newer of the two.
+    """
+    comments_by_project = defaultdict(list)
+
+    def time_of(node: ET.Element) -> float:
+        try:
+            return float(node.attrib.get("timeofcomment") or 0.0)
+        except ValueError:
+            return 0.0
+
+    comment_nodes = root_node.findall("ccp4i2_body/projectcommentTable/projectcomment")
+    for node in sorted(comment_nodes, key=time_of):
+        comment = node.attrib.get("comment")
+        if comment:
+            comments_by_project[node.attrib["projectid"]].append(comment)
+
+    for project_uuid, comments in comments_by_project.items():
+        try:
+            project = Project.objects.get(uuid=project_uuid)
+        except Project.DoesNotExist:
+            logger.warning(
+                f"Comments for unknown project {project_uuid} were not imported"
+            )
+            continue
+        if project.description:
+            continue
+        project.description = "\n".join(comments)
+        project.save(update_fields=["description"])
+        logger.info(f"Imported {len(comments)} comment(s) as description of {project}")
 
 
 def import_job(node: ET.Element):

--- a/server/ccp4i2/tests/db/test_import_i2xml.py
+++ b/server/ccp4i2/tests/db/test_import_i2xml.py
@@ -26,6 +26,21 @@ class CCP4i2TestCase(TestCase):
         )
         self.assertEqual(len(list(Project.objects.all())), 1)
 
+    def test_import_dbxml_takes_description_from_comments(self):
+        """A Qt-era file has no projectdescription, only a projectcommentTable.
+
+        That table is where the Qt interface kept what it showed as the project
+        description, so it has to land in Project.description here as it does in
+        the legacy sqlite migration -- otherwise importing a project directory
+        loses the text that migrating the old database would have kept.
+        """
+        import_i2xml_from_file(
+            Path(__file__).parent / "DATABASE.db.xml",
+            relocate_path=settings.CCP4I2_PROJECTS_DIR,
+        )
+        project = Project.objects.get(name="MDM2CCP4X")
+        self.assertEqual(project.description, "Description of this MDM2 project")
+
     def test_import_project_zip(self):
         import_ccp4_project_zip(
             Path(__file__).parent.parent.parent.parent.parent.parent


### PR DESCRIPTION
Project descriptions have been in the model, the REST API, the legacy-database
migration and the project search since the Django app began, and have never been
shown anywhere. The only use of the field in the client is as a hidden key the
project search matches on, so a migrated description changes nothing a user can
see — which reads, reasonably, as "descriptions were not migrated".

So: offer the field when a project is created, and show it in the two places a
project is listed and the one place it is named. Nothing here needs a server
change to support the edit side; the REST field is already writable, and the
edit page that uses it is the next PR.

The import gap is real, though. A snapshot this app writes carries the
description as a `projectdescription` attribute, which `import_i2xml` reads. A
`DATABASE.db.xml` written by the Qt-era CCP4i2 has no such attribute; it has a
`projectcommentTable`, which is where that interface kept the text it showed as
the project description. Importing a legacy project directory or zip therefore
dropped it, while migrating the same project from the old database kept it.
`import_project_comments` folds those comments in the way the sqlite migration
already does — oldest first, and never over a description that is already set.

## Testing

- New test in `tests/db/test_import_i2xml.py`, using the existing Qt-era
  fixture, whose sole comment is "Description of this MDM2 project".
- `tsc --noEmit` clean; `npm run build:web` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
