### PR TITLE
Give a project a page where it can be edited

### DIFF
--- a/client/renderer/app/ccp4i2/(authed)/edit-project/[id]/page.tsx
+++ b/client/renderer/app/ccp4i2/(authed)/edit-project/[id]/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { use } from "react";
+import { EditProjectContent } from "@/components/edit-project-content";
+import { NavigationShortcutsProvider } from "@/providers/navigation-shortcuts-provider";
+import CCP4i2TopBar from "@/components/ccp4i2-topbar";
+
+export default function EditProjectPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  return (
+    <NavigationShortcutsProvider>
+      <CCP4i2TopBar title="Edit Project" showBackButton backPath="/ccp4i2" />
+      <EditProjectContent projectId={parseInt(id)} />
+    </NavigationShortcutsProvider>
+  );
+}

--- a/client/renderer/components/edit-project-content.tsx
+++ b/client/renderer/components/edit-project-content.tsx
@@ -1,0 +1,172 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Container,
+  Divider,
+  LinearProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { DriveFileMove } from "@mui/icons-material";
+import { useApi } from "../api";
+import { Project } from "../types/models";
+import { usePopcorn } from "../providers/popcorn-provider";
+import { isElectron } from "../utils/platform";
+import { MoveProjectDialog } from "./move-project-dialog";
+import { TagsOfProject } from "./tags-of-project";
+
+/**
+ * View and change what a project is, as opposed to what is in it: its name,
+ * its description, its tags and where it lives on disk.
+ *
+ * The name and the description are a form, saved together. Tags and the
+ * directory are not: tags are applied as they are picked, and moving a project
+ * rewrites files as well as rows, so it keeps its own dialog and its own
+ * confirmation rather than being one unsaved edit among several.
+ */
+export const EditProjectContent: React.FC<{ projectId: number }> = ({
+  projectId,
+}) => {
+  const api = useApi();
+  const { setMessage } = usePopcorn();
+  const { data: project, mutate: mutateProject } = api.get<Project>(
+    `projects/${projectId}`
+  );
+  const { data: projects } = api.get<Project[]>("projects");
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
+  // Only the desktop build has a filesystem to move a project around in.
+  const [canMove, setCanMove] = useState(false);
+  useEffect(() => setCanMove(isElectron()), []);
+
+  // Seed the fields from the project once. Later revalidations -- a tag added,
+  // a move finished -- must not overwrite what is being typed.
+  const [seeded, setSeeded] = useState(false);
+  useEffect(() => {
+    if (project && !seeded) {
+      setName(project.name);
+      setDescription(project.description ?? "");
+      setSeeded(true);
+    }
+  }, [project, seeded]);
+
+  const nameError = useMemo(() => {
+    if (name.length === 0) return "Name is required";
+    if (!name.match("^[A-z0-9_-]+$"))
+      return "Name can only contain letters, numbers, underscores, and hyphens";
+    if (projects?.find((p) => p.name === name && p.id !== projectId))
+      return "Name is already taken";
+    return "";
+  }, [name, projects, projectId]);
+
+  const isDirty =
+    project !== undefined &&
+    (name !== project.name || description !== (project.description ?? ""));
+
+  function discard() {
+    if (!project) return;
+    setName(project.name);
+    setDescription(project.description ?? "");
+  }
+
+  async function save() {
+    if (!project) return;
+    setIsSaving(true);
+    try {
+      await api.patch(`projects/${project.id}`, { name, description });
+      await mutateProject();
+      setMessage("Project updated", "success");
+    } catch (err) {
+      setMessage(
+        `Error updating project: ${err instanceof Error ? err.message : String(err)}`,
+        "error"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (!project) return <LinearProgress />;
+
+  return (
+    <Container maxWidth="sm" sx={{ my: 3 }}>
+      <Stack spacing={2}>
+        <Typography variant="h4">Edit Project</Typography>
+
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          required
+          error={nameError.length > 0}
+          helperText={nameError}
+          autoFocus
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          multiline
+          minRows={3}
+          helperText="What the project is for; shown wherever it is listed."
+        />
+        <Stack direction="row" spacing={2} justifyContent="flex-end">
+          <Button variant="outlined" onClick={discard} disabled={!isDirty || isSaving}>
+            Discard changes
+          </Button>
+          <Button
+            variant="contained"
+            onClick={save}
+            disabled={nameError.length > 0 || !isDirty || isSaving}
+            startIcon={isSaving ? <CircularProgress size={16} /> : undefined}
+          >
+            {isSaving ? "Saving..." : "Save changes"}
+          </Button>
+        </Stack>
+
+        <Divider />
+
+        <Typography variant="h6">Tags</Typography>
+        <TagsOfProject projectId={project.id} />
+
+        <Divider />
+
+        <Typography variant="h6">Location</Typography>
+        <TextField
+          label="Project directory"
+          value={project.directory}
+          disabled
+          helperText={
+            canMove
+              ? "Renaming a project does not move it; use Move to relocate it on disk."
+              : "Moving a project on disk is available in the desktop app."
+          }
+        />
+        {canMove && (
+          <Stack direction="row" justifyContent="flex-end">
+            <Button
+              variant="outlined"
+              startIcon={<DriveFileMove />}
+              onClick={() => setMoveOpen(true)}
+            >
+              Move...
+            </Button>
+          </Stack>
+        )}
+
+        <MoveProjectDialog
+          project={moveOpen ? project : null}
+          open={moveOpen}
+          onClose={() => setMoveOpen(false)}
+          onMoved={() => mutateProject()}
+        />
+      </Stack>
+    </Container>
+  );
+};

--- a/client/renderer/components/file-menu.tsx
+++ b/client/renderer/components/file-menu.tsx
@@ -14,7 +14,7 @@ import {
   Typography,
   Box,
 } from "@mui/material";
-import { Add, Download, Menu as MenuIcon, Upload, PowerSettingsNew } from "@mui/icons-material";
+import { Add, Download, Edit, Menu as MenuIcon, Upload, PowerSettingsNew } from "@mui/icons-material";
 import { useApi } from "../api";
 import { Project } from "../types/models";
 import { useCCP4i2Window } from "../app-context";
@@ -113,6 +113,20 @@ export default function FileMenu() {
           </ListItemIcon>
           <ListItemText>New project</ListItemText>
         </MenuItem>
+        {projectId && (
+          <MenuItem
+            key="Edit"
+            onClick={() => {
+              handleClose();
+              window.open(`/ccp4i2/edit-project/${projectId}`);
+            }}
+          >
+            <ListItemIcon>
+              <Edit fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Edit project...</ListItemText>
+          </MenuItem>
+        )}
         <MenuItem key="Export" onClick={handleExportProject}>
           <ListItemIcon>
             <Download fontSize="small" />

--- a/client/renderer/components/projects-table.tsx
+++ b/client/renderer/components/projects-table.tsx
@@ -24,6 +24,7 @@ import {
   Clear,
   Delete,
   Download,
+  Edit,
   DriveFileMove,
   FolderOpen,
   LinkOff,
@@ -96,6 +97,7 @@ const ProjectCard = React.memo(
     isSelected,
     onToggleSelection,
     onNavigate,
+    onEdit,
     onExport,
     onMove,
     onDelete,
@@ -104,6 +106,7 @@ const ProjectCard = React.memo(
     isSelected: boolean;
     onToggleSelection: () => void;
     onNavigate: () => void;
+    onEdit: () => void;
     onExport: () => void;
     /** Omitted in the web build, where there is no local filesystem to move to. */
     onMove?: () => void;
@@ -229,6 +232,22 @@ const ProjectCard = React.memo(
             justifyContent="flex-end"
             sx={{ mt: 2 }}
           >
+            <Tooltip title="Edit project name, description and tags">
+              <IconButton
+                className="action-button"
+                size="small"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onEdit();
+                }}
+                sx={{
+                  color: "primary.main",
+                  "&:hover": { bgcolor: "primary.50" },
+                }}
+              >
+                <Edit fontSize="small" />
+              </IconButton>
+            </Tooltip>
             <Tooltip title="Export project">
               <IconButton
                 className="action-button"
@@ -659,7 +678,7 @@ export default function ProjectsTable() {
       {
         key: "actions",
         label: "",
-        width: canMoveProjects ? 140 : 100,
+        width: canMoveProjects ? 180 : 140,
         render: (_, project) => (
           <Stack
             direction="row"
@@ -667,6 +686,15 @@ export default function ProjectsTable() {
             justifyContent="flex-end"
             onClick={(e) => e.stopPropagation()}
           >
+            <Tooltip title="Edit project name, description and tags">
+              <IconButton
+                size="small"
+                onClick={() => router.push(`/ccp4i2/edit-project/${project.id}`)}
+                sx={{ color: "primary.main" }}
+              >
+                <Edit fontSize="small" />
+              </IconButton>
+            </Tooltip>
             <Tooltip title="Export project">
               <IconButton
                 size="small"
@@ -715,6 +743,7 @@ export default function ProjectsTable() {
             : selectedIds.add(project.id);
         }}
         onNavigate={() => router.push(`/ccp4i2/project/${project.id}`)}
+        onEdit={() => router.push(`/ccp4i2/edit-project/${project.id}`)}
         onExport={() => exportProject(project)}
         onMove={
           canMoveProjects && !brokenIds.has(project.id)

--- a/server/ccp4i2/api/serializers.py
+++ b/server/ccp4i2/api/serializers.py
@@ -130,12 +130,20 @@ class ProjectSerializer(ModelSerializer):
             raise ValidationError(
                 f"Your project name contains whitespace or special characters [{data}]"
             )
-        project_names = [
-            project.name.upper() for project in models.Project.objects.all()
-        ]
+        # An update has to be allowed to send back the name it already has: an
+        # edit form that PATCHes every field, changed or not, would otherwise
+        # collide with itself.
+        others = models.Project.objects.all()
+        if self.instance is not None:
+            others = others.exclude(pk=self.instance.pk)
+        project_names = [project.name.upper() for project in others]
         if "uuid" not in self.initial_data and data.upper() in project_names:
             raise ValidationError("A project with this name already exists!")
-        if "directory" not in self.initial_data:
+        # Only a project about to be created needs somewhere under
+        # CCP4I2_PROJECTS_DIR to be created in. One that already exists has a
+        # directory of its own, which need not be under that root at all, and
+        # renaming it does not move it.
+        if self.instance is None and "directory" not in self.initial_data:
             assert Path(settings.CCP4I2_PROJECTS_DIR).is_dir()
             try:
                 testWritePath = Path(settings.CCP4I2_PROJECTS_DIR) / "testWrite.txt"

--- a/server/ccp4i2/tests/db/test_project_serializer.py
+++ b/server/ccp4i2/tests/db/test_project_serializer.py
@@ -1,0 +1,77 @@
+"""How ProjectSerializer treats an update as opposed to a create.
+
+Everything a project's edit page can change goes through this serializer, and
+what it does on a create is not what it should do on an update: a create is
+about to have a directory made for it under CCP4I2_PROJECTS_DIR and must not
+take a name already in use, while an update already has a directory somewhere
+and its own name is not a name already in use as far as it is concerned.
+"""
+
+from pathlib import Path
+from shutil import rmtree
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from ...api.serializers import ProjectSerializer
+from ...db.models import Project
+
+
+@override_settings(
+    CCP4I2_PROJECTS_DIR=Path(__file__).parent.parent / "CCP4I2_TEST_PROJECT_DIRECTORY"
+)
+class ProjectSerializerTestCase(TestCase):
+    def setUp(self):
+        Path(settings.CCP4I2_PROJECTS_DIR).mkdir(exist_ok=True)
+        self.project = self.create_project("MDM2")
+        return super().setUp()
+
+    def tearDown(self):
+        rmtree(settings.CCP4I2_PROJECTS_DIR)
+        return super().tearDown()
+
+    def create_project(self, name: str) -> Project:
+        # "__default__" is what the client sends for "put it in the usual place".
+        serializer = ProjectSerializer(data={"name": name, "directory": "__default__"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        return serializer.save()
+
+    def test_update_may_send_back_its_own_name(self):
+        """An edit form sends every field, changed or not."""
+        serializer = ProjectSerializer(
+            instance=self.project,
+            data={"name": "MDM2", "description": "Ligand soaks, 2026 campaign"},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        project = serializer.save()
+        self.assertEqual(project.name, "MDM2")
+        self.assertEqual(project.description, "Ligand soaks, 2026 campaign")
+
+    def test_update_still_refuses_a_name_another_project_holds(self):
+        self.create_project("MDM4")
+        serializer = ProjectSerializer(
+            instance=self.project, data={"name": "MDM4"}, partial=True
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("name", serializer.errors)
+
+    def test_rename_leaves_the_project_where_it_is(self):
+        """The directory is named for the project it was created as.
+
+        Renaming does not move it -- relocating a project is what the move
+        endpoint is for, and it has files to rewrite as well as bytes to move.
+        """
+        directory = self.project.directory
+        serializer = ProjectSerializer(
+            instance=self.project, data={"name": "MDM2_2026"}, partial=True
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        project = serializer.save()
+        self.assertEqual(project.name, "MDM2_2026")
+        self.assertEqual(project.directory, directory)
+
+    def test_create_still_refuses_a_name_already_taken(self):
+        serializer = ProjectSerializer(data={"name": "MDM2", "directory": "__default__"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("name", serializer.errors)


### PR DESCRIPTION
Supersedes #272, which GitHub closed when its base branch `project-descriptions` was deleted on merging #271. Same commit, now rebased onto `django`.

What a project *is* — its name, what it is for, how it is filed, where it lives —
has had nowhere to be changed. The name could be edited in one place (inline on
the files page), tags could be set only at creation, the description could not be
set at all, and moving a project on disk was an icon on a row in the projects
list. This adds the page the Qt interface had: one place that shows what a
project is and lets it be changed, reachable from the projects list and from
File/Projects → Edit project… inside a project.

The name and description are a form, saved together. Tags are not part of that
form — they are applied as they are picked, by the component that already does
this elsewhere — and neither is the directory: moving a project rewrites files as
well as rows, so it keeps the dialog and the dry run it already has rather than
becoming one unsaved edit among several. The directory is shown read-only beside
the name, because renaming a project does not move it and that should not have to
be discovered. Move is offered only in the desktop build, which is the only one
with a filesystem to move within.

`ProjectSerializer` needed two things before an edit form could work. Uniqueness
of the name was checked against every project including the one being updated, so
a form that PATCHes every field, changed or not, failed against its own name —
which the inline rename on the files page could hit too, by editing a name back
to what it was. And the check that `CCP4I2_PROJECTS_DIR` exists and is writable
ran on updates as well as creates, though an existing project already has a
directory, which need not be under that root at all. Both now apply only to a
create.

## Testing

- Four new tests in `tests/db/test_project_serializer.py` covering update,
  rename, the collision that must still be refused, and create. The first fails
  without the serializer change.
- `tsc --noEmit` clean; `npm run build:web` succeeds with the new route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
